### PR TITLE
Frontend: Notes panel with group tabs (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ annotated-maps/
 │   ├── Dockerfile
 │   └── config.json
 ├── database/
-│   ├── migrations/        001–006 SQL migration scripts
+│   ├── migrations/        001–007 SQL migration scripts
 │   ├── tests/             Database schema tests (SQL + Python runner)
 │   ├── run_migrations.py
 │   └── seed-local-dev.py

--- a/backend/src/controllers/NoteController.cpp
+++ b/backend/src/controllers/NoteController.cpp
@@ -64,6 +64,7 @@ void NoteController::listNotes(
             n["title"]            = row["title"].isNull() ? "" : row["title"].as<std::string>();
             n["text"]             = row["text"].as<std::string>();
             n["pinned"]           = row["pinned"].as<bool>();
+            n["color"]            = row["color"].isNull() ? Json::Value() : Json::Value(row["color"].as<std::string>());
             n["groupId"]          = row["group_id"].isNull() ? Json::Value() : Json::Value(row["group_id"].as<int>());
             n["createdAt"]        = row["created_at"].as<std::string>();
             n["updatedAt"]        = row["updated_at"].as<std::string>();
@@ -112,6 +113,7 @@ void NoteController::createNote(
     double lng   = (*body)["lng"].asDouble();
     std::string title = (*body).get("title", "").asString();
     std::string text  = (*body)["text"].asString();
+    std::string color = (*body).get("color", "").asString();
     bool hasGroupId   = body->isMember("groupId") && !(*body)["groupId"].isNull();
     int groupId       = hasGroupId ? (*body)["groupId"].asInt() : 0;
 
@@ -126,7 +128,7 @@ void NoteController::createNote(
         "               AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
         "WHERE m.id = ? AND m.tenant_id = ? "
         "  AND (m.owner_id = ? OR mp.level IN ('view','comment','edit','moderate','admin') OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
-        [callback, mapId, userId, callerUsername, lat, lng, title, text, groupId]
+        [callback, mapId, userId, callerUsername, lat, lng, title, text, color, groupId]
         (const drogon::orm::Result& r) {
             if (r.empty()) {
                 auto resp = drogon::HttpResponse::newHttpJsonResponse(
@@ -140,7 +142,7 @@ void NoteController::createNote(
             auto db2 = drogon::app().getDbClient();
             db2->execSqlAsync(
                 "SELECT COUNT(*) AS cnt FROM notes WHERE map_id = ?",
-                [callback, mapId, userId, callerUsername, lat, lng, title, text, groupId]
+                [callback, mapId, userId, callerUsername, lat, lng, title, text, color, groupId]
                 (const drogon::orm::Result& rc) {
                     if (!rc.empty() && rc[0]["cnt"].as<int>() >= 10000) {
                         auto resp = drogon::HttpResponse::newHttpJsonResponse(
@@ -152,9 +154,9 @@ void NoteController::createNote(
 
                     auto db3 = drogon::app().getDbClient();
                     db3->execSqlAsync(
-                        "INSERT INTO notes (map_id, created_by, lat, lng, title, text, group_id) "
-                        "VALUES (?,?,?,?,?,?,NULLIF(?,0))",
-                        [callback, mapId, userId, callerUsername, lat, lng, title, text, groupId]
+                        "INSERT INTO notes (map_id, created_by, lat, lng, title, text, color, group_id) "
+                        "VALUES (?,?,?,?,?,?,NULLIF(?,''),NULLIF(?,0))",
+                        [callback, mapId, userId, callerUsername, lat, lng, title, text, color, groupId]
                         (const drogon::orm::Result& r2) {
                             int newId = static_cast<int>(r2.insertId());
                             Json::Value n;
@@ -167,6 +169,7 @@ void NoteController::createNote(
                             n["title"]     = title;
                             n["text"]      = text;
                             n["pinned"]    = false;
+                            n["color"]     = color.empty() ? Json::Value() : Json::Value(color);
                             n["groupId"]   = groupId > 0 ? Json::Value(groupId) : Json::Value();
                             n["canEdit"]   = true;
                             auto resp = drogon::HttpResponse::newHttpJsonResponse(n);
@@ -179,7 +182,7 @@ void NoteController::createNote(
                             resp->setStatusCode(drogon::k500InternalServerError);
                             callback(resp);
                         },
-                        mapId, userId, lat, lng, title, text, groupId);
+                        mapId, userId, lat, lng, title, text, color, groupId);
                 },
                 [callback](const drogon::orm::DrogonDbException&) {
                     auto resp = drogon::HttpResponse::newHttpJsonResponse(
@@ -239,6 +242,7 @@ void NoteController::getNote(
             n["title"]            = row["title"].isNull() ? "" : row["title"].as<std::string>();
             n["text"]             = row["text"].as<std::string>();
             n["pinned"]           = row["pinned"].as<bool>();
+            n["color"]            = row["color"].isNull() ? Json::Value() : Json::Value(row["color"].as<std::string>());
             n["groupId"]          = row["group_id"].isNull() ? Json::Value() : Json::Value(row["group_id"].as<int>());
             n["createdAt"]        = row["created_at"].as<std::string>();
             n["updatedAt"]        = row["updated_at"].as<std::string>();
@@ -273,14 +277,23 @@ void NoteController::updateNote(
 
     std::string newTitle = (*body).get("title", "").asString();
     std::string newText  = (*body).get("text", "").asString();
+    std::string newColor = (*body).get("color", "").asString();
+    bool hasGroupId      = body->isMember("groupId");
+    // groupId: null means ungroup, number means assign, absent means no change
+    bool ungrouping      = hasGroupId && (*body)["groupId"].isNull();
+    int newGroupId       = (hasGroupId && !ungrouping) ? (*body)["groupId"].asInt() : 0;
 
     auto db = drogon::app().getDbClient();
     db->execSqlAsync(
         "UPDATE notes n "
         "JOIN maps m ON m.id = n.map_id "
         "LEFT JOIN map_permissions mp ON mp.map_id = m.id AND mp.user_id = ? "
-        "SET n.title = IF(?='', n.title, ?), "
-        "    n.text  = IF(?='', n.text, ?) "
+        "SET n.title    = IF(?='', n.title, ?), "
+        "    n.text     = IF(?='', n.text, ?), "
+        "    n.color    = IF(?='', n.color, ?), "
+        "    n.group_id = CASE WHEN ?=0 THEN n.group_id "
+        "                      WHEN ?=-1 THEN NULL "
+        "                      ELSE ? END "
         "WHERE n.id = ? AND n.map_id = ? AND m.tenant_id = ? "
         "  AND (m.owner_id = ? OR mp.level IN ('edit','moderate','admin') OR n.created_by = ?)",
         [callback, id](const drogon::orm::Result& r) {
@@ -305,6 +318,10 @@ void NoteController::updateNote(
         userId,
         newTitle, newTitle,
         newText, newText,
+        newColor, newColor,
+        hasGroupId ? (ungrouping ? -1 : newGroupId) : 0,
+        hasGroupId ? (ungrouping ? -1 : newGroupId) : 0,
+        newGroupId,
         id, mapId, tenantId, userId, userId);
 }
 

--- a/backend/src/controllers/NoteController.cpp
+++ b/backend/src/controllers/NoteController.cpp
@@ -278,8 +278,11 @@ void NoteController::updateNote(
     std::string newTitle = (*body).get("title", "").asString();
     std::string newText  = (*body).get("text", "").asString();
     std::string newColor = (*body).get("color", "").asString();
+    bool hasLat          = body->isMember("lat");
+    bool hasLng          = body->isMember("lng");
+    double newLat        = hasLat ? (*body)["lat"].asDouble() : 0.0;
+    double newLng        = hasLng ? (*body)["lng"].asDouble() : 0.0;
     bool hasGroupId      = body->isMember("groupId");
-    // groupId: null means ungroup, number means assign, absent means no change
     bool ungrouping      = hasGroupId && (*body)["groupId"].isNull();
     int newGroupId       = (hasGroupId && !ungrouping) ? (*body)["groupId"].asInt() : 0;
 
@@ -291,6 +294,8 @@ void NoteController::updateNote(
         "SET n.title    = IF(?='', n.title, ?), "
         "    n.text     = IF(?='', n.text, ?), "
         "    n.color    = IF(?='', n.color, ?), "
+        "    n.lat      = IF(?, ?, n.lat), "
+        "    n.lng      = IF(?, ?, n.lng), "
         "    n.group_id = CASE WHEN ?=0 THEN n.group_id "
         "                      WHEN ?=-1 THEN NULL "
         "                      ELSE ? END "
@@ -319,6 +324,8 @@ void NoteController::updateNote(
         newTitle, newTitle,
         newText, newText,
         newColor, newColor,
+        hasLat, newLat,
+        hasLng, newLng,
         hasGroupId ? (ungrouping ? -1 : newGroupId) : 0,
         hasGroupId ? (ungrouping ? -1 : newGroupId) : 0,
         newGroupId,

--- a/backend/src/controllers/NoteController.cpp
+++ b/backend/src/controllers/NoteController.cpp
@@ -32,7 +32,7 @@ void NoteController::listNotes(
 
     std::string sql = R"(
         SELECT n.id, n.map_id, n.group_id, n.created_by, u.username AS creator_username,
-               n.lat, n.lng, n.title, n.text, n.pinned,
+               n.lat, n.lng, n.title, n.text, n.pinned, n.color,
                n.created_at, n.updated_at,
                CASE WHEN m.owner_id = ? OR n.created_by = ? OR mp.level IN ('edit','moderate','admin')
                     THEN 1 ELSE 0 END AS can_edit

--- a/backend/src/controllers/NoteController.cpp
+++ b/backend/src/controllers/NoteController.cpp
@@ -97,6 +97,8 @@ void NoteController::createNote(
     int tenantId, int mapId) {
 
     int userId = callerUserId(req);
+    std::string callerUsername;
+    try { callerUsername = req->getAttributes()->get<std::string>("username"); } catch (...) {}
     auto body  = req->getJsonObject();
     if (!body || !body->isMember("lat") || !body->isMember("lng") || !(*body)["text"]) {
         auto resp = drogon::HttpResponse::newHttpJsonResponse(
@@ -124,7 +126,7 @@ void NoteController::createNote(
         "               AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
         "WHERE m.id = ? AND m.tenant_id = ? "
         "  AND (m.owner_id = ? OR mp.level IN ('view','comment','edit','moderate','admin') OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
-        [callback, mapId, userId, lat, lng, title, text, groupId]
+        [callback, mapId, userId, callerUsername, lat, lng, title, text, groupId]
         (const drogon::orm::Result& r) {
             if (r.empty()) {
                 auto resp = drogon::HttpResponse::newHttpJsonResponse(
@@ -138,7 +140,7 @@ void NoteController::createNote(
             auto db2 = drogon::app().getDbClient();
             db2->execSqlAsync(
                 "SELECT COUNT(*) AS cnt FROM notes WHERE map_id = ?",
-                [callback, mapId, userId, lat, lng, title, text, groupId]
+                [callback, mapId, userId, callerUsername, lat, lng, title, text, groupId]
                 (const drogon::orm::Result& rc) {
                     if (!rc.empty() && rc[0]["cnt"].as<int>() >= 10000) {
                         auto resp = drogon::HttpResponse::newHttpJsonResponse(
@@ -152,13 +154,14 @@ void NoteController::createNote(
                     db3->execSqlAsync(
                         "INSERT INTO notes (map_id, created_by, lat, lng, title, text, group_id) "
                         "VALUES (?,?,?,?,?,?,NULLIF(?,0))",
-                        [callback, mapId, userId, lat, lng, title, text, groupId]
+                        [callback, mapId, userId, callerUsername, lat, lng, title, text, groupId]
                         (const drogon::orm::Result& r2) {
                             int newId = static_cast<int>(r2.insertId());
                             Json::Value n;
-                            n["id"]        = newId;
-                            n["mapId"]     = mapId;
-                            n["createdBy"] = userId;
+                            n["id"]                = newId;
+                            n["mapId"]             = mapId;
+                            n["createdBy"]         = userId;
+                            n["createdByUsername"] = callerUsername;
                             n["lat"]       = lat;
                             n["lng"]       = lng;
                             n["title"]     = title;

--- a/backend/tests/test_11_notes.py
+++ b/backend/tests/test_11_notes.py
@@ -107,6 +107,22 @@ assert_json_field("update: text changed", body, ["text"], "Updated location info
 status, _ = http_put(f"{BASE}/{NOTE_ID}", {"title": "New HQ"}, TOKEN)
 assert_status("update: title only returns 200", 200, status)
 
+# Move note (update lat/lng)
+status, _ = http_put(f"{BASE}/{NOTE_ID}", {"lat": 41.0, "lng": -73.5}, TOKEN)
+assert_status("update: move note returns 200", 200, status)
+
+status, body = http_get(f"{BASE}/{NOTE_ID}", TOKEN)
+coords = (json_field(body, ["lat"]), json_field(body, ["lng"]))
+assert_true("update: lat updated after move", coords[0] is not None and abs(coords[0] - 41.0) < 0.001)
+assert_true("update: lng updated after move", coords[1] is not None and abs(coords[1] - (-73.5)) < 0.001)
+
+# Update color
+status, _ = http_put(f"{BASE}/{NOTE_ID}", {"color": "#00ff00"}, TOKEN)
+assert_status("update: color returns 200", 200, status)
+
+status, body = http_get(f"{BASE}/{NOTE_ID}", TOKEN)
+assert_json_field("update: color changed", body, ["color"], "#00ff00")
+
 print("  All update tests passed.")
 
 # ─── Cross-org isolation ──────────────────────────────────────────────────────

--- a/backend/tests/test_11_notes.py
+++ b/backend/tests/test_11_notes.py
@@ -39,6 +39,7 @@ assert_json_field("create: text correct", body, ["text"], "Main office location"
 assert_json_field("create: title correct", body, ["title"], "HQ")
 assert_json_field("create: pinned defaults to false", body, ["pinned"], False)
 assert_json_field("create: canEdit is true for creator", body, ["canEdit"], True)
+assert_json_exists("create: has createdByUsername", body, ["createdByUsername"])
 
 # Without title (optional)
 status, body = http_post(BASE, {

--- a/backend/tests/test_11_notes.py
+++ b/backend/tests/test_11_notes.py
@@ -41,6 +41,14 @@ assert_json_field("create: pinned defaults to false", body, ["pinned"], False)
 assert_json_field("create: canEdit is true for creator", body, ["canEdit"], True)
 assert_json_exists("create: has createdByUsername", body, ["createdByUsername"])
 
+# With custom color
+status, body = http_post(BASE, {
+    "lat": 40.713, "lng": -74.007, "text": "Colored note", "color": "#ff5500"
+}, TOKEN)
+assert_status("create: note with color returns 201", 201, status)
+assert_json_field("create: color set", body, ["color"], "#ff5500")
+COLORED_NOTE_ID = json_field(body, ["id"])
+
 # Without title (optional)
 status, body = http_post(BASE, {
     "lat": 40.714, "lng": -74.002, "text": "No title note"
@@ -139,9 +147,12 @@ assert_status("delete: creator can delete", 204, status)
 status, _ = http_get(f"{BASE}/{NOTE_ID_2}", TOKEN)
 assert_status("delete: note is gone", 404, status)
 
-# Delete the other note too
+# Delete the other notes too
 status, _ = http_delete(f"{BASE}/{NOTE_ID}", TOKEN)
 assert_status("delete: second note deleted", 204, status)
+
+status, _ = http_delete(f"{BASE}/{COLORED_NOTE_ID}", TOKEN)
+assert_status("delete: colored note deleted", 204, status)
 
 print("  All delete tests passed.")
 

--- a/database/migrations/007_add_note_color.sql
+++ b/database/migrations/007_add_note_color.sql
@@ -1,0 +1,7 @@
+-- Migration 007: Add per-note color column.
+-- Optional hex color for individual note markers on the map.
+-- When set, overrides the group color and the default cyan.
+
+ALTER TABLE notes
+    ADD COLUMN color VARCHAR(9) DEFAULT NULL
+        AFTER pinned;

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -77,6 +77,8 @@ Annotated Maps is a multi-tenant, collaborative map annotation platform. Users c
 - Any user who can view a map can create notes on it.
 - Notes can be updated or deleted by the note creator, the map owner, or a user with edit permission.
 - Notes support a `pinned` flag (default false) for sorting important notes first.
+- Notes support an optional per-note `color` (hex format) for the map marker. Priority: per-note color > group color > default cyan (#00FFFF).
+- Notes can be moved between groups or ungrouped via the update endpoint (`groupId: null` to ungroup, `groupId: N` to assign).
 - A fulltext search index covers `title` and `text` columns.
 - Notes can optionally belong to a note group (see 2.10).
 - Resource limit: 10,000 notes per map.
@@ -307,6 +309,7 @@ Backend configuration uses Drogon's JSON config format. Custom application setti
 | 004 | Notes table (location-pinned text, fulltext index, group_id column) |
 | 005 | User roles (`status`, `platform_role`), `org_members` table, `map_permissions.level` enum |
 | 006 | Note groups table and FK constraint on `notes.group_id` |
+| 007 | Add per-note `color` column |
 
 ---
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -79,6 +79,8 @@ Annotated Maps is a multi-tenant, collaborative map annotation platform. Users c
 - Notes support a `pinned` flag (default false) for sorting important notes first.
 - Notes support an optional per-note `color` (hex format) for the map marker. Priority: per-note color > group color > default cyan (#00FFFF).
 - Notes can be moved between groups or ungrouped via the update endpoint (`groupId: null` to ungroup, `groupId: N` to assign).
+- Notes can be relocated on the map by updating `lat`/`lng` via the update endpoint.
+- Notes are rendered on the map as circle markers, visually distinct from annotation pin icons.
 - A fulltext search index covers `title` and `text` columns.
 - Notes can optionally belong to a note group (see 2.10).
 - Resource limit: 10,000 notes per map.
@@ -176,7 +178,7 @@ Annotated Maps is a multi-tenant, collaborative map annotation platform. Users c
 | `map_permissions` | Per-map, per-user permission grants. `user_id = NULL` = public access. Database triggers enforce at most one public row per map. |
 | `annotations` | GeoJSON annotations on maps (marker, polyline, polygon). |
 | `annotation_media` | Media attachments (image, link) on annotations. |
-| `notes` | Location-pinned text notes on maps. Separate from GeoJSON annotations. Fulltext indexed. Optional `group_id` FK to `note_groups`. |
+| `notes` | Location-pinned text notes on maps. Separate from GeoJSON annotations. Fulltext indexed. Optional `group_id` FK to `note_groups`. Optional `color` for per-note marker color. |
 | `note_groups` | Named categories for organizing notes on a map. Unique name per map. Optional color for display. |
 | `audit_log` | Security event log. FKs use `ON DELETE SET NULL` so records survive entity deletion. |
 
@@ -265,9 +267,9 @@ All routes require JWT + TenantFilter.
 | Method | Path | Description |
 |---|---|---|
 | GET | `.../maps/{mapId}/notes` | List notes (pinned first; `?groupId=N` to filter) |
-| POST | `.../maps/{mapId}/notes` | Create note (view perm required; optional `groupId`) |
+| POST | `.../maps/{mapId}/notes` | Create note (view perm required; optional `groupId`, `color`) |
 | GET | `.../maps/{mapId}/notes/{id}` | Get note |
-| PUT | `.../maps/{mapId}/notes/{id}` | Update note (creator, owner, or editor) |
+| PUT | `.../maps/{mapId}/notes/{id}` | Update note (title, text, color, lat/lng, groupId; creator, owner, or editor) |
 | DELETE | `.../maps/{mapId}/notes/{id}` | Delete note (creator, owner, or editor) |
 
 ### 5.6 Note Groups (tenant-scoped)

--- a/docs/SETUP-LOCAL-DEV.md
+++ b/docs/SETUP-LOCAL-DEV.md
@@ -32,7 +32,7 @@ Three containers are running:
 
 | Service | Port | Purpose |
 |---|---|---|
-| `mysql` | 3306 | MySQL 8. Migrations 001-006 run automatically on first boot. |
+| `mysql` | 3306 | MySQL 8. Migrations 001-007 run automatically on first boot. |
 | `backend` | 8080 | Drogon C++ REST API |
 | `frontend` | 5173 | Vite dev server with hot module replacement |
 

--- a/docs/TESTING-DATABASE.md
+++ b/docs/TESTING-DATABASE.md
@@ -14,7 +14,7 @@ python3 database/tests/run-db-tests.py
 
 The script will:
 1. Create a temporary database (`annotated_maps_test_<pid>`).
-2. Apply all migrations (001-006).
+2. Apply all migrations (001-007).
 3. Run each `test_*.sql` file and report PASS/FAIL per assertion.
 4. Drop the temporary database.
 

--- a/docs/TESTING-NOTES.md
+++ b/docs/TESTING-NOTES.md
@@ -25,7 +25,10 @@ This runs both layers in sequence:
    - Fulltext search index works
 
 2. **Backend integration tests** — restarts the backend (clears rate limiter), then runs `test_11_notes.py`. Verifies:
-   - Note CRUD (create with/without title, list, get, update, delete)
+   - Note CRUD (create with/without title, with custom color, list, get, update, delete)
+   - Note move (update lat/lng)
+   - Note color update
+   - `createdByUsername` in create response
    - Input validation (missing `text`, missing `lat`/`lng`)
    - Cross-org isolation (user from another org cannot list, create, read, update, or delete notes)
    - Permission model (note creator can edit/delete their own notes)

--- a/frontend/src/components/Map/MapView.tsx
+++ b/frontend/src/components/Map/MapView.tsx
@@ -126,6 +126,7 @@ function NotePlacement({ isActive, onPlace, onCancel }: NotePlacementProps) {
 
     const mapContainer = leafletMap.getContainer();
     mapContainer.style.cursor = 'crosshair';
+    let placementMarker: L.CircleMarker | null = null;
 
     const hint = document.createElement('div');
     hint.className = 'move-hint';
@@ -133,6 +134,25 @@ function NotePlacement({ isActive, onPlace, onCancel }: NotePlacementProps) {
     mapContainer.appendChild(hint);
 
     const handleClick = (e: L.LeafletMouseEvent) => {
+      // Leave a temporary marker showing where the note will be placed
+      placementMarker = L.circleMarker([e.latlng.lat, e.latlng.lng], {
+        radius: 10,
+        fillColor: '#00FFFF',
+        color: '#fff',
+        weight: 2,
+        opacity: 1,
+        fillOpacity: 0.85,
+      }).addTo(leafletMap);
+      placementMarker.bindPopup('Note will be placed here').openPopup();
+
+      // Remove marker after 5 seconds (note form is still open)
+      setTimeout(() => {
+        if (placementMarker) {
+          leafletMap.removeLayer(placementMarker);
+          placementMarker = null;
+        }
+      }, 5000);
+
       cleanup();
       onPlace(e.latlng.lat, e.latlng.lng);
     };

--- a/frontend/src/components/Map/MapView.tsx
+++ b/frontend/src/components/Map/MapView.tsx
@@ -109,11 +109,66 @@ function DrawControls({ mapId, canEdit }: DrawControlsProps) {
   return null;
 }
 
-interface MapViewProps {
-  map: MapRecord;
+// ─── Note placement mode ─────────────────────────────────────────────────────
+
+interface NotePlacementProps {
+  isActive: boolean;
+  onPlace: (lat: number, lng: number) => void;
+  onCancel: () => void;
 }
 
-export function MapView({ map }: MapViewProps) {
+function NotePlacement({ isActive, onPlace, onCancel }: NotePlacementProps) {
+  const leafletMap = useLeafletMap();
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    const mapContainer = leafletMap.getContainer();
+    mapContainer.style.cursor = 'crosshair';
+
+    const hint = document.createElement('div');
+    hint.className = 'move-hint';
+    hint.textContent = 'Click to place note (Esc to cancel)';
+    mapContainer.appendChild(hint);
+
+    const handleClick = (e: L.LeafletMouseEvent) => {
+      cleanup();
+      onPlace(e.latlng.lat, e.latlng.lng);
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        cleanup();
+        onCancel();
+      }
+    };
+
+    const cleanup = () => {
+      mapContainer.style.cursor = '';
+      hint.remove();
+      leafletMap.off('click', handleClick);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+
+    leafletMap.once('click', handleClick);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return cleanup;
+  }, [isActive, leafletMap, onPlace, onCancel]);
+
+  return null;
+}
+
+// ─── MapView ─────────────────────────────────────────────────────────────────
+
+interface MapViewProps {
+  map: MapRecord;
+  isPlacingNote?: boolean;
+  onMapClickForNote?: (lat: number, lng: number) => void;
+  onCancelPlace?: () => void;
+}
+
+export function MapView({ map, isPlacingNote, onMapClickForNote, onCancelPlace }: MapViewProps) {
   const canEdit = map.permission === 'edit' || map.permission === 'owner';
 
   return (
@@ -131,6 +186,13 @@ export function MapView({ map }: MapViewProps) {
         />
         <AnnotationLayer mapId={map.id} canEdit={canEdit} />
         <DrawControls mapId={map.id} canEdit={canEdit} />
+        {isPlacingNote && onMapClickForNote && onCancelPlace && (
+          <NotePlacement
+            isActive={isPlacingNote}
+            onPlace={onMapClickForNote}
+            onCancel={onCancelPlace}
+          />
+        )}
       </MapContainer>
     </div>
   );

--- a/frontend/src/components/Map/MapView.tsx
+++ b/frontend/src/components/Map/MapView.tsx
@@ -5,8 +5,9 @@ import 'leaflet-draw/dist/leaflet.draw.css';
 import L from 'leaflet';
 import 'leaflet-draw';
 import { AnnotationLayer } from './AnnotationLayer';
+import { NoteMarkers } from './NoteMarkers';
 import { useMap } from '@/hooks/useMap';
-import type { MapRecord, AnnotationType, GeoJsonGeometry } from '@/types';
+import type { MapRecord, AnnotationType, GeoJsonGeometry, Note, NoteGroup } from '@/types';
 
 // Fix default marker icon broken by webpack/vite bundling
 delete (L.Icon.Default.prototype as unknown as Record<string, unknown>)._getIconUrl;
@@ -163,12 +164,15 @@ function NotePlacement({ isActive, onPlace, onCancel }: NotePlacementProps) {
 
 interface MapViewProps {
   map: MapRecord;
+  notes?: Note[];
+  noteGroups?: NoteGroup[];
   isPlacingNote?: boolean;
   onMapClickForNote?: (lat: number, lng: number) => void;
   onCancelPlace?: () => void;
+  onNoteClick?: (note: Note) => void;
 }
 
-export function MapView({ map, isPlacingNote, onMapClickForNote, onCancelPlace }: MapViewProps) {
+export function MapView({ map, notes, noteGroups, isPlacingNote, onMapClickForNote, onCancelPlace, onNoteClick }: MapViewProps) {
   const canEdit = map.permission === 'edit' || map.permission === 'owner';
 
   return (
@@ -186,6 +190,9 @@ export function MapView({ map, isPlacingNote, onMapClickForNote, onCancelPlace }
         />
         <AnnotationLayer mapId={map.id} canEdit={canEdit} />
         <DrawControls mapId={map.id} canEdit={canEdit} />
+        {notes && noteGroups && (
+          <NoteMarkers notes={notes} groups={noteGroups} onNoteClick={onNoteClick} />
+        )}
         {isPlacingNote && onMapClickForNote && onCancelPlace && (
           <NotePlacement
             isActive={isPlacingNote}

--- a/frontend/src/components/Map/NoteMarkers.tsx
+++ b/frontend/src/components/Map/NoteMarkers.tsx
@@ -9,9 +9,11 @@ interface NoteMarkersProps {
   onNoteClick?: (note: Note) => void;
 }
 
-const DEFAULT_NOTE_COLOR = '#f59e0b'; // amber — distinct from blue annotations
+const DEFAULT_NOTE_COLOR = '#00FFFF'; // cyan — distinct from blue annotation pins
 
-function getGroupColor(note: Note, groups: NoteGroup[]): string {
+function getNoteColor(note: Note, groups: NoteGroup[]): string {
+  // Priority: per-note color > group color > default
+  if (note.color) return note.color;
   if (note.groupId) {
     const group = groups.find((g) => g.id === note.groupId);
     if (group?.color) return group.color;
@@ -32,7 +34,7 @@ export function NoteMarkers({ notes, groups, onNoteClick }: NoteMarkersProps) {
       // Skip notes at 0,0 (unplaced)
       if (note.lat === 0 && note.lng === 0) return;
 
-      const color = getGroupColor(note, groups);
+      const color = getNoteColor(note, groups);
 
       const marker = L.circleMarker([note.lat, note.lng], {
         radius: 8,

--- a/frontend/src/components/Map/NoteMarkers.tsx
+++ b/frontend/src/components/Map/NoteMarkers.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+import { useMap as useLeafletMap } from 'react-leaflet';
+import L from 'leaflet';
+import type { Note, NoteGroup } from '@/types';
+
+interface NoteMarkersProps {
+  notes: Note[];
+  groups: NoteGroup[];
+  onNoteClick?: (note: Note) => void;
+}
+
+const DEFAULT_NOTE_COLOR = '#f59e0b'; // amber — distinct from blue annotations
+
+function getGroupColor(note: Note, groups: NoteGroup[]): string {
+  if (note.groupId) {
+    const group = groups.find((g) => g.id === note.groupId);
+    if (group?.color) return group.color;
+  }
+  return DEFAULT_NOTE_COLOR;
+}
+
+export function NoteMarkers({ notes, groups, onNoteClick }: NoteMarkersProps) {
+  const leafletMap = useLeafletMap();
+  const layerGroupRef = useRef<L.LayerGroup>(new L.LayerGroup());
+
+  useEffect(() => {
+    const layerGroup = layerGroupRef.current;
+    leafletMap.addLayer(layerGroup);
+    layerGroup.clearLayers();
+
+    notes.forEach((note) => {
+      // Skip notes at 0,0 (unplaced)
+      if (note.lat === 0 && note.lng === 0) return;
+
+      const color = getGroupColor(note, groups);
+
+      const marker = L.circleMarker([note.lat, note.lng], {
+        radius: 8,
+        fillColor: color,
+        color: '#fff',
+        weight: 2,
+        opacity: 1,
+        fillOpacity: 0.85,
+      });
+
+      const popupContent = `
+        <div class="note-popup">
+          ${note.title ? `<h4>${note.title}</h4>` : ''}
+          <p>${note.text}</p>
+          <small>By ${note.createdByUsername || 'unknown'}</small>
+        </div>
+      `;
+      marker.bindPopup(popupContent);
+
+      marker.on('click', () => {
+        onNoteClick?.(note);
+      });
+
+      layerGroup.addLayer(marker);
+    });
+
+    return () => {
+      leafletMap.removeLayer(layerGroup);
+    };
+  }, [leafletMap, notes, groups, onNoteClick]);
+
+  return null;
+}

--- a/frontend/src/components/Notes/NotesPanel.tsx
+++ b/frontend/src/components/Notes/NotesPanel.tsx
@@ -8,14 +8,15 @@ interface NotesPanelProps {
   canEdit: boolean;
   isAdmin: boolean;
   onNoteClick?: (note: Note) => void;
+  onRequestMapClick?: (callback: (lat: number, lng: number) => void) => void;
 }
 
-export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick }: NotesPanelProps) {
+export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick, onRequestMapClick }: NotesPanelProps) {
   const tenantId = useAuthStore((s) => s.tenantId) ?? undefined;
 
   const [notes, setNotes] = useState<Note[]>([]);
   const [groups, setGroups] = useState<NoteGroup[]>([]);
-  const [activeGroupId, setActiveGroupId] = useState<number | null>(null); // null = "All"
+  const [activeGroupId, setActiveGroupId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
 
   // Note creation
@@ -23,6 +24,8 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick }: NotesPanelP
   const [newTitle, setNewTitle] = useState('');
   const [newText, setNewText] = useState('');
   const [newGroupId, setNewGroupId] = useState<number | undefined>(undefined);
+  const [newLat, setNewLat] = useState<number | null>(null);
+  const [newLng, setNewLng] = useState<number | null>(null);
 
   // Group management
   const [showGroupForm, setShowGroupForm] = useState(false);
@@ -45,7 +48,7 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick }: NotesPanelP
       setGroups(g);
       setNotes(n);
     } catch {
-      // silently fail — panel shows empty
+      // silently fail
     } finally {
       setLoading(false);
     }
@@ -58,11 +61,30 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick }: NotesPanelP
 
   // ─── Note CRUD ─────────────────────────────────────────────────────────────
 
+  const handlePlaceOnMap = () => {
+    if (!onRequestMapClick) return;
+    onRequestMapClick((lat, lng) => {
+      setNewLat(lat);
+      setNewLng(lng);
+    });
+  };
+
   const handleCreateNote = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!newText.trim()) return;
+
+    // If no location set, prompt to place on map
+    if (newLat === null || newLng === null) {
+      if (onRequestMapClick) {
+        alert('Please click "Place on map" to set the note location first.');
+        return;
+      }
+      // Fallback if no map click handler (shouldn't happen)
+    }
+
     const data: CreateNoteRequest = {
-      lat: 0, lng: 0, // default — user can move later
+      lat: newLat ?? 0,
+      lng: newLng ?? 0,
       text: newText,
       title: newTitle || undefined,
       groupId: newGroupId,
@@ -73,6 +95,8 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick }: NotesPanelP
       setNewTitle('');
       setNewText('');
       setNewGroupId(undefined);
+      setNewLat(null);
+      setNewLng(null);
       setShowCreate(false);
     } catch {
       alert('Failed to create note.');
@@ -141,7 +165,7 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick }: NotesPanelP
       if (editingGroup) {
         await noteGroupsService.updateGroup(mapId, editingGroup.id, data, tenantId);
         setGroups((prev) => prev.map((g) =>
-          g.id === editingGroup.id ? { ...g, ...data, name: groupName, color: groupColor, description: groupDesc } : g
+          g.id === editingGroup.id ? { ...g, name: groupName, color: groupColor, description: groupDesc } : g
         ));
       } else {
         const group = await noteGroupsService.createGroup(mapId, data, tenantId);
@@ -158,7 +182,6 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick }: NotesPanelP
     try {
       await noteGroupsService.deleteGroup(mapId, groupId, tenantId);
       setGroups((prev) => prev.filter((g) => g.id !== groupId));
-      // Notes in this group now have null groupId — reload
       if (activeGroupId === groupId) setActiveGroupId(null);
       loadData();
     } catch {
@@ -176,7 +199,11 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick }: NotesPanelP
         <h3>Notes</h3>
         <div className="notes-header-actions">
           {canEdit && (
-            <button className="btn btn-sm btn-primary" onClick={() => setShowCreate(true)}>
+            <button className="btn btn-sm btn-primary" onClick={() => {
+              setShowCreate(true);
+              setNewLat(null);
+              setNewLng(null);
+            }}>
               + Note
             </button>
           )}
@@ -241,6 +268,18 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick }: NotesPanelP
               ))}
             </select>
           )}
+          <div className="notes-location">
+            {newLat !== null && newLng !== null ? (
+              <span className="notes-location-set">
+                📍 {newLat.toFixed(4)}, {newLng.toFixed(4)}
+                <button type="button" className="btn-icon" onClick={() => { setNewLat(null); setNewLng(null); }}>×</button>
+              </span>
+            ) : (
+              <button type="button" className="btn btn-sm btn-ghost" onClick={handlePlaceOnMap}>
+                📍 Place on map
+              </button>
+            )}
+          </div>
           <div className="notes-form-actions">
             <button type="button" className="btn btn-sm btn-ghost" onClick={() => setShowCreate(false)}>Cancel</button>
             <button type="submit" className="btn btn-sm btn-primary">Save</button>
@@ -248,7 +287,7 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick }: NotesPanelP
         </form>
       )}
 
-      {/* Group form (create/edit) */}
+      {/* Group form */}
       {showGroupForm && (
         <form className="notes-form" onSubmit={handleSaveGroup}>
           <input
@@ -310,7 +349,7 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick }: NotesPanelP
                   {note.title && <h4 className="note-title">{note.title}</h4>}
                   <p className="note-text">{note.text}</p>
                   <div className="note-meta">
-                    <small>By {note.createdByUsername}</small>
+                    <small>By {note.createdByUsername || 'unknown'}</small>
                     {note.canEdit && (
                       <span className="note-actions">
                         <button className="btn-icon" onClick={(e) => { e.stopPropagation(); handleStartEdit(note); }} title="Edit">✎</button>

--- a/frontend/src/components/Notes/NotesPanel.tsx
+++ b/frontend/src/components/Notes/NotesPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useState } from 'react';
 import { notesService, noteGroupsService } from '@/services/maps';
 import type { Note, NoteGroup, CreateNoteRequest, CreateNoteGroupRequest } from '@/types';
 import { useAuthStore } from '@/store/authStore';
@@ -7,17 +7,20 @@ interface NotesPanelProps {
   mapId: number;
   canEdit: boolean;
   isAdmin: boolean;
+  notes: Note[];
+  groups: NoteGroup[];
+  onNotesChanged: (groupFilter?: number) => void;
   onNoteClick?: (note: Note) => void;
   onRequestMapClick?: (callback: (lat: number, lng: number) => void) => void;
 }
 
-export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick, onRequestMapClick }: NotesPanelProps) {
+export function NotesPanel({
+  mapId, canEdit, isAdmin, notes, groups,
+  onNotesChanged, onNoteClick, onRequestMapClick
+}: NotesPanelProps) {
   const tenantId = useAuthStore((s) => s.tenantId) ?? undefined;
 
-  const [notes, setNotes] = useState<Note[]>([]);
-  const [groups, setGroups] = useState<NoteGroup[]>([]);
   const [activeGroupId, setActiveGroupId] = useState<number | null>(null);
-  const [loading, setLoading] = useState(true);
 
   // Note creation
   const [showCreate, setShowCreate] = useState(false);
@@ -39,25 +42,10 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick, onRequestMapC
   const [editTitle, setEditTitle] = useState('');
   const [editText, setEditText] = useState('');
 
-  const loadData = useCallback(async () => {
-    try {
-      const [g, n] = await Promise.all([
-        noteGroupsService.listGroups(mapId, tenantId),
-        notesService.listNotes(mapId, activeGroupId ?? undefined, tenantId),
-      ]);
-      setGroups(g);
-      setNotes(n);
-    } catch {
-      // silently fail
-    } finally {
-      setLoading(false);
-    }
-  }, [mapId, tenantId, activeGroupId]);
-
-  useEffect(() => {
-    setLoading(true);
-    loadData();
-  }, [loadData]);
+  // Filter notes by active group tab
+  const filteredNotes = activeGroupId === null
+    ? notes
+    : notes.filter((n) => n.groupId === activeGroupId);
 
   // ─── Note CRUD ─────────────────────────────────────────────────────────────
 
@@ -73,13 +61,11 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick, onRequestMapC
     e.preventDefault();
     if (!newText.trim()) return;
 
-    // If no location set, prompt to place on map
     if (newLat === null || newLng === null) {
       if (onRequestMapClick) {
         alert('Please click "Place on map" to set the note location first.');
         return;
       }
-      // Fallback if no map click handler (shouldn't happen)
     }
 
     const data: CreateNoteRequest = {
@@ -90,14 +76,14 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick, onRequestMapC
       groupId: newGroupId,
     };
     try {
-      const note = await notesService.createNote(mapId, data, tenantId);
-      setNotes((prev) => [...prev, note]);
+      await notesService.createNote(mapId, data, tenantId);
       setNewTitle('');
       setNewText('');
       setNewGroupId(undefined);
       setNewLat(null);
       setNewLng(null);
       setShowCreate(false);
+      onNotesChanged(activeGroupId ?? undefined);
     } catch {
       alert('Failed to create note.');
     }
@@ -107,7 +93,7 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick, onRequestMapC
     if (!window.confirm('Delete this note?')) return;
     try {
       await notesService.deleteNote(mapId, noteId, tenantId);
-      setNotes((prev) => prev.filter((n) => n.id !== noteId));
+      onNotesChanged(activeGroupId ?? undefined);
     } catch {
       alert('Failed to delete note.');
     }
@@ -125,10 +111,8 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick, onRequestMapC
       await notesService.updateNote(mapId, editingNote.id, {
         title: editTitle, text: editText,
       }, tenantId);
-      setNotes((prev) => prev.map((n) =>
-        n.id === editingNote.id ? { ...n, title: editTitle, text: editText } : n
-      ));
       setEditingNote(null);
+      onNotesChanged(activeGroupId ?? undefined);
     } catch {
       alert('Failed to update note.');
     }
@@ -164,14 +148,11 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick, onRequestMapC
     try {
       if (editingGroup) {
         await noteGroupsService.updateGroup(mapId, editingGroup.id, data, tenantId);
-        setGroups((prev) => prev.map((g) =>
-          g.id === editingGroup.id ? { ...g, name: groupName, color: groupColor, description: groupDesc } : g
-        ));
       } else {
-        const group = await noteGroupsService.createGroup(mapId, data, tenantId);
-        setGroups((prev) => [...prev, group]);
+        await noteGroupsService.createGroup(mapId, data, tenantId);
       }
       setShowGroupForm(false);
+      onNotesChanged(activeGroupId ?? undefined);
     } catch {
       alert('Failed to save group.');
     }
@@ -181,17 +162,19 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick, onRequestMapC
     if (!window.confirm('Delete this group? Notes in this group will become ungrouped.')) return;
     try {
       await noteGroupsService.deleteGroup(mapId, groupId, tenantId);
-      setGroups((prev) => prev.filter((g) => g.id !== groupId));
       if (activeGroupId === groupId) setActiveGroupId(null);
-      loadData();
+      onNotesChanged();
     } catch {
       alert('Failed to delete group.');
     }
   };
 
-  // ─── Render ────────────────────────────────────────────────────────────────
+  const handleTabClick = (groupId: number | null) => {
+    setActiveGroupId(groupId);
+    onNotesChanged(groupId ?? undefined);
+  };
 
-  if (loading) return <div className="notes-panel"><p>Loading notes...</p></div>;
+  // ─── Render ────────────────────────────────────────────────────────────────
 
   return (
     <div className="notes-panel">
@@ -219,7 +202,7 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick, onRequestMapC
       <div className="notes-tabs">
         <button
           className={`notes-tab ${activeGroupId === null ? 'active' : ''}`}
-          onClick={() => setActiveGroupId(null)}
+          onClick={() => handleTabClick(null)}
         >
           All
         </button>
@@ -227,7 +210,7 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick, onRequestMapC
           <button
             key={g.id}
             className={`notes-tab ${activeGroupId === g.id ? 'active' : ''}`}
-            onClick={() => setActiveGroupId(g.id)}
+            onClick={() => handleTabClick(g.id)}
             style={g.color ? { borderBottomColor: g.color } : undefined}
           >
             {g.color && <span className="notes-tab-dot" style={{ backgroundColor: g.color }} />}
@@ -317,10 +300,10 @@ export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick, onRequestMapC
 
       {/* Note list */}
       <div className="notes-list">
-        {notes.length === 0 ? (
+        {filteredNotes.length === 0 ? (
           <p className="notes-empty">No notes yet.</p>
         ) : (
-          notes.map((note) => (
+          filteredNotes.map((note) => (
             <div
               key={note.id}
               className={`note-card ${note.pinned ? 'pinned' : ''}`}

--- a/frontend/src/components/Notes/NotesPanel.tsx
+++ b/frontend/src/components/Notes/NotesPanel.tsx
@@ -27,6 +27,7 @@ export function NotesPanel({
   const [newTitle, setNewTitle] = useState('');
   const [newText, setNewText] = useState('');
   const [newGroupId, setNewGroupId] = useState<number | undefined>(undefined);
+  const [newColor, setNewColor] = useState('');
   const [newLat, setNewLat] = useState<number | null>(null);
   const [newLng, setNewLng] = useState<number | null>(null);
 
@@ -41,6 +42,8 @@ export function NotesPanel({
   const [editingNote, setEditingNote] = useState<Note | null>(null);
   const [editTitle, setEditTitle] = useState('');
   const [editText, setEditText] = useState('');
+  const [editColor, setEditColor] = useState('');
+  const [editGroupId, setEditGroupId] = useState<number | null>(null);
 
   // Filter notes by active group tab
   const filteredNotes = activeGroupId === null
@@ -73,12 +76,14 @@ export function NotesPanel({
       lng: newLng ?? 0,
       text: newText,
       title: newTitle || undefined,
+      color: newColor || undefined,
       groupId: newGroupId,
     };
     try {
       await notesService.createNote(mapId, data, tenantId);
       setNewTitle('');
       setNewText('');
+      setNewColor('');
       setNewGroupId(undefined);
       setNewLat(null);
       setNewLng(null);
@@ -103,14 +108,23 @@ export function NotesPanel({
     setEditingNote(note);
     setEditTitle(note.title || '');
     setEditText(note.text);
+    setEditColor(note.color || '');
+    setEditGroupId(note.groupId);
   };
 
   const handleSaveEdit = async () => {
     if (!editingNote) return;
     try {
-      await notesService.updateNote(mapId, editingNote.id, {
-        title: editTitle, text: editText,
-      }, tenantId);
+      const updateData: Record<string, unknown> = {
+        title: editTitle,
+        text: editText,
+        color: editColor || undefined,
+      };
+      // Send groupId: null to ungroup, number to assign, omit for no change
+      if (editGroupId !== editingNote.groupId) {
+        updateData.groupId = editGroupId;
+      }
+      await notesService.updateNote(mapId, editingNote.id, updateData as any, tenantId);
       setEditingNote(null);
       onNotesChanged(activeGroupId ?? undefined);
     } catch {
@@ -251,6 +265,11 @@ export function NotesPanel({
               ))}
             </select>
           )}
+          <input
+            placeholder="Pin color (e.g. #ff0000, optional)"
+            value={newColor}
+            onChange={(e) => setNewColor(e.target.value)}
+          />
           <div className="notes-location">
             {newLat !== null && newLng !== null ? (
               <span className="notes-location-set">
@@ -321,6 +340,22 @@ export function NotesPanel({
                     onChange={(e) => setEditText(e.target.value)}
                     rows={3}
                   />
+                  <input
+                    value={editColor}
+                    onChange={(e) => setEditColor(e.target.value)}
+                    placeholder="Pin color (e.g. #ff0000)"
+                  />
+                  {groups.length > 0 && (
+                    <select
+                      value={editGroupId ?? ''}
+                      onChange={(e) => setEditGroupId(e.target.value ? Number(e.target.value) : null)}
+                    >
+                      <option value="">No group</option>
+                      {groups.map((g) => (
+                        <option key={g.id} value={g.id}>{g.name}</option>
+                      ))}
+                    </select>
+                  )}
                   <div className="notes-form-actions">
                     <button className="btn btn-sm btn-ghost" onClick={() => setEditingNote(null)}>Cancel</button>
                     <button className="btn btn-sm btn-primary" onClick={handleSaveEdit}>Save</button>

--- a/frontend/src/components/Notes/NotesPanel.tsx
+++ b/frontend/src/components/Notes/NotesPanel.tsx
@@ -1,0 +1,329 @@
+import { useEffect, useState, useCallback } from 'react';
+import { notesService, noteGroupsService } from '@/services/maps';
+import type { Note, NoteGroup, CreateNoteRequest, CreateNoteGroupRequest } from '@/types';
+import { useAuthStore } from '@/store/authStore';
+
+interface NotesPanelProps {
+  mapId: number;
+  canEdit: boolean;
+  isAdmin: boolean;
+  onNoteClick?: (note: Note) => void;
+}
+
+export function NotesPanel({ mapId, canEdit, isAdmin, onNoteClick }: NotesPanelProps) {
+  const tenantId = useAuthStore((s) => s.tenantId) ?? undefined;
+
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [groups, setGroups] = useState<NoteGroup[]>([]);
+  const [activeGroupId, setActiveGroupId] = useState<number | null>(null); // null = "All"
+  const [loading, setLoading] = useState(true);
+
+  // Note creation
+  const [showCreate, setShowCreate] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+  const [newText, setNewText] = useState('');
+  const [newGroupId, setNewGroupId] = useState<number | undefined>(undefined);
+
+  // Group management
+  const [showGroupForm, setShowGroupForm] = useState(false);
+  const [editingGroup, setEditingGroup] = useState<NoteGroup | null>(null);
+  const [groupName, setGroupName] = useState('');
+  const [groupColor, setGroupColor] = useState('');
+  const [groupDesc, setGroupDesc] = useState('');
+
+  // Edit note
+  const [editingNote, setEditingNote] = useState<Note | null>(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [editText, setEditText] = useState('');
+
+  const loadData = useCallback(async () => {
+    try {
+      const [g, n] = await Promise.all([
+        noteGroupsService.listGroups(mapId, tenantId),
+        notesService.listNotes(mapId, activeGroupId ?? undefined, tenantId),
+      ]);
+      setGroups(g);
+      setNotes(n);
+    } catch {
+      // silently fail — panel shows empty
+    } finally {
+      setLoading(false);
+    }
+  }, [mapId, tenantId, activeGroupId]);
+
+  useEffect(() => {
+    setLoading(true);
+    loadData();
+  }, [loadData]);
+
+  // ─── Note CRUD ─────────────────────────────────────────────────────────────
+
+  const handleCreateNote = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newText.trim()) return;
+    const data: CreateNoteRequest = {
+      lat: 0, lng: 0, // default — user can move later
+      text: newText,
+      title: newTitle || undefined,
+      groupId: newGroupId,
+    };
+    try {
+      const note = await notesService.createNote(mapId, data, tenantId);
+      setNotes((prev) => [...prev, note]);
+      setNewTitle('');
+      setNewText('');
+      setNewGroupId(undefined);
+      setShowCreate(false);
+    } catch {
+      alert('Failed to create note.');
+    }
+  };
+
+  const handleDeleteNote = async (noteId: number) => {
+    if (!window.confirm('Delete this note?')) return;
+    try {
+      await notesService.deleteNote(mapId, noteId, tenantId);
+      setNotes((prev) => prev.filter((n) => n.id !== noteId));
+    } catch {
+      alert('Failed to delete note.');
+    }
+  };
+
+  const handleStartEdit = (note: Note) => {
+    setEditingNote(note);
+    setEditTitle(note.title || '');
+    setEditText(note.text);
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editingNote) return;
+    try {
+      await notesService.updateNote(mapId, editingNote.id, {
+        title: editTitle, text: editText,
+      }, tenantId);
+      setNotes((prev) => prev.map((n) =>
+        n.id === editingNote.id ? { ...n, title: editTitle, text: editText } : n
+      ));
+      setEditingNote(null);
+    } catch {
+      alert('Failed to update note.');
+    }
+  };
+
+  // ─── Group CRUD ────────────────────────────────────────────────────────────
+
+  const handleOpenGroupForm = (group?: NoteGroup) => {
+    if (group) {
+      setEditingGroup(group);
+      setGroupName(group.name);
+      setGroupColor(group.color || '');
+      setGroupDesc(group.description || '');
+    } else {
+      setEditingGroup(null);
+      setGroupName('');
+      setGroupColor('');
+      setGroupDesc('');
+    }
+    setShowGroupForm(true);
+  };
+
+  const handleSaveGroup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!groupName.trim()) return;
+
+    const data: CreateNoteGroupRequest = {
+      name: groupName,
+      color: groupColor || undefined,
+      description: groupDesc || undefined,
+    };
+
+    try {
+      if (editingGroup) {
+        await noteGroupsService.updateGroup(mapId, editingGroup.id, data, tenantId);
+        setGroups((prev) => prev.map((g) =>
+          g.id === editingGroup.id ? { ...g, ...data, name: groupName, color: groupColor, description: groupDesc } : g
+        ));
+      } else {
+        const group = await noteGroupsService.createGroup(mapId, data, tenantId);
+        setGroups((prev) => [...prev, group]);
+      }
+      setShowGroupForm(false);
+    } catch {
+      alert('Failed to save group.');
+    }
+  };
+
+  const handleDeleteGroup = async (groupId: number) => {
+    if (!window.confirm('Delete this group? Notes in this group will become ungrouped.')) return;
+    try {
+      await noteGroupsService.deleteGroup(mapId, groupId, tenantId);
+      setGroups((prev) => prev.filter((g) => g.id !== groupId));
+      // Notes in this group now have null groupId — reload
+      if (activeGroupId === groupId) setActiveGroupId(null);
+      loadData();
+    } catch {
+      alert('Failed to delete group.');
+    }
+  };
+
+  // ─── Render ────────────────────────────────────────────────────────────────
+
+  if (loading) return <div className="notes-panel"><p>Loading notes...</p></div>;
+
+  return (
+    <div className="notes-panel">
+      <div className="notes-header">
+        <h3>Notes</h3>
+        <div className="notes-header-actions">
+          {canEdit && (
+            <button className="btn btn-sm btn-primary" onClick={() => setShowCreate(true)}>
+              + Note
+            </button>
+          )}
+          {isAdmin && (
+            <button className="btn btn-sm btn-ghost" onClick={() => handleOpenGroupForm()}>
+              + Group
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Group tabs */}
+      <div className="notes-tabs">
+        <button
+          className={`notes-tab ${activeGroupId === null ? 'active' : ''}`}
+          onClick={() => setActiveGroupId(null)}
+        >
+          All
+        </button>
+        {groups.map((g) => (
+          <button
+            key={g.id}
+            className={`notes-tab ${activeGroupId === g.id ? 'active' : ''}`}
+            onClick={() => setActiveGroupId(g.id)}
+            style={g.color ? { borderBottomColor: g.color } : undefined}
+          >
+            {g.color && <span className="notes-tab-dot" style={{ backgroundColor: g.color }} />}
+            {g.name}
+            {isAdmin && (
+              <span className="notes-tab-actions">
+                <button className="btn-icon" onClick={(e) => { e.stopPropagation(); handleOpenGroupForm(g); }} title="Edit group">✎</button>
+                <button className="btn-icon" onClick={(e) => { e.stopPropagation(); handleDeleteGroup(g.id); }} title="Delete group">×</button>
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Note creation form */}
+      {showCreate && (
+        <form className="notes-form" onSubmit={handleCreateNote}>
+          <input
+            placeholder="Title (optional)"
+            value={newTitle}
+            onChange={(e) => setNewTitle(e.target.value)}
+          />
+          <textarea
+            placeholder="Note text (required)"
+            value={newText}
+            onChange={(e) => setNewText(e.target.value)}
+            required
+            rows={3}
+          />
+          {groups.length > 0 && (
+            <select
+              value={newGroupId ?? ''}
+              onChange={(e) => setNewGroupId(e.target.value ? Number(e.target.value) : undefined)}
+            >
+              <option value="">No group</option>
+              {groups.map((g) => (
+                <option key={g.id} value={g.id}>{g.name}</option>
+              ))}
+            </select>
+          )}
+          <div className="notes-form-actions">
+            <button type="button" className="btn btn-sm btn-ghost" onClick={() => setShowCreate(false)}>Cancel</button>
+            <button type="submit" className="btn btn-sm btn-primary">Save</button>
+          </div>
+        </form>
+      )}
+
+      {/* Group form (create/edit) */}
+      {showGroupForm && (
+        <form className="notes-form" onSubmit={handleSaveGroup}>
+          <input
+            placeholder="Group name"
+            value={groupName}
+            onChange={(e) => setGroupName(e.target.value)}
+            required
+          />
+          <input
+            placeholder="Color (e.g. #dc2626)"
+            value={groupColor}
+            onChange={(e) => setGroupColor(e.target.value)}
+          />
+          <input
+            placeholder="Description (optional)"
+            value={groupDesc}
+            onChange={(e) => setGroupDesc(e.target.value)}
+          />
+          <div className="notes-form-actions">
+            <button type="button" className="btn btn-sm btn-ghost" onClick={() => setShowGroupForm(false)}>Cancel</button>
+            <button type="submit" className="btn btn-sm btn-primary">
+              {editingGroup ? 'Update' : 'Create'} Group
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Note list */}
+      <div className="notes-list">
+        {notes.length === 0 ? (
+          <p className="notes-empty">No notes yet.</p>
+        ) : (
+          notes.map((note) => (
+            <div
+              key={note.id}
+              className={`note-card ${note.pinned ? 'pinned' : ''}`}
+              onClick={() => onNoteClick?.(note)}
+            >
+              {editingNote?.id === note.id ? (
+                <div className="note-edit-form" onClick={(e) => e.stopPropagation()}>
+                  <input
+                    value={editTitle}
+                    onChange={(e) => setEditTitle(e.target.value)}
+                    placeholder="Title"
+                  />
+                  <textarea
+                    value={editText}
+                    onChange={(e) => setEditText(e.target.value)}
+                    rows={3}
+                  />
+                  <div className="notes-form-actions">
+                    <button className="btn btn-sm btn-ghost" onClick={() => setEditingNote(null)}>Cancel</button>
+                    <button className="btn btn-sm btn-primary" onClick={handleSaveEdit}>Save</button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  {note.pinned && <span className="note-pin-badge">📌</span>}
+                  {note.title && <h4 className="note-title">{note.title}</h4>}
+                  <p className="note-text">{note.text}</p>
+                  <div className="note-meta">
+                    <small>By {note.createdByUsername}</small>
+                    {note.canEdit && (
+                      <span className="note-actions">
+                        <button className="btn-icon" onClick={(e) => { e.stopPropagation(); handleStartEdit(note); }} title="Edit">✎</button>
+                        <button className="btn-icon" onClick={(e) => { e.stopPropagation(); handleDeleteNote(note.id); }} title="Delete">×</button>
+                      </span>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Notes/NotesPanel.tsx
+++ b/frontend/src/components/Notes/NotesPanel.tsx
@@ -80,8 +80,7 @@ export function NotesPanel({
       groupId: newGroupId,
     };
     try {
-      const created = await notesService.createNote(mapId, data, tenantId);
-      console.log('Note created:', created);
+      await notesService.createNote(mapId, data, tenantId);
       setNewTitle('');
       setNewText('');
       setNewColor('');
@@ -89,7 +88,8 @@ export function NotesPanel({
       setNewLat(null);
       setNewLng(null);
       setShowCreate(false);
-      onNotesChanged(activeGroupId ?? undefined);
+      // Reload notes from server — use setTimeout to ensure state updates have flushed
+      setTimeout(() => onNotesChanged(activeGroupId ?? undefined), 100);
     } catch (err) {
       console.error('Failed to create note:', err);
       alert('Failed to create note.');

--- a/frontend/src/components/Notes/NotesPanel.tsx
+++ b/frontend/src/components/Notes/NotesPanel.tsx
@@ -80,7 +80,8 @@ export function NotesPanel({
       groupId: newGroupId,
     };
     try {
-      await notesService.createNote(mapId, data, tenantId);
+      const created = await notesService.createNote(mapId, data, tenantId);
+      console.log('Note created:', created);
       setNewTitle('');
       setNewText('');
       setNewColor('');
@@ -89,7 +90,8 @@ export function NotesPanel({
       setNewLng(null);
       setShowCreate(false);
       onNotesChanged(activeGroupId ?? undefined);
-    } catch {
+    } catch (err) {
+      console.error('Failed to create note:', err);
       alert('Failed to create note.');
     }
   };
@@ -130,6 +132,18 @@ export function NotesPanel({
     } catch {
       alert('Failed to update note.');
     }
+  };
+
+  const handleMoveNote = (note: Note) => {
+    if (!onRequestMapClick) return;
+    onRequestMapClick(async (lat, lng) => {
+      try {
+        await notesService.updateNote(mapId, note.id, { lat, lng } as any, tenantId);
+        onNotesChanged(activeGroupId ?? undefined);
+      } catch {
+        alert('Failed to move note.');
+      }
+    });
   };
 
   // ─── Group CRUD ────────────────────────────────────────────────────────────
@@ -371,6 +385,7 @@ export function NotesPanel({
                     {note.canEdit && (
                       <span className="note-actions">
                         <button className="btn-icon" onClick={(e) => { e.stopPropagation(); handleStartEdit(note); }} title="Edit">✎</button>
+                        <button className="btn-icon" onClick={(e) => { e.stopPropagation(); handleMoveNote(note); }} title="Move">⤢</button>
                         <button className="btn-icon" onClick={(e) => { e.stopPropagation(); handleDeleteNote(note.id); }} title="Delete">×</button>
                       </span>
                     )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -106,6 +106,12 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
 
 /* ─── Mobile ─────────────────────────────────────────────────────────────────── */
 /* ─── Annotation popup ─────────────────────────────────────────────────────── */
+/* ─── Note popup (map circle markers) ──────────────────────────────────────── */
+.note-popup h4 { margin: 0 0 0.25rem; font-size: 0.9rem; }
+.note-popup p { margin: 0 0 0.5rem; font-size: 0.85rem; color: var(--color-text); }
+.note-popup small { color: var(--color-text-muted); font-size: 0.75rem; }
+
+/* ─── Annotation popup ─────────────────────────────────────────────────────── */
 .annotation-popup h3 { margin: 0 0 0.25rem; font-size: 1rem; }
 .annotation-popup p { margin: 0 0 0.5rem; color: var(--color-text-muted); font-size: 0.875rem; }
 .annotation-popup small { color: var(--color-text-muted); font-size: 0.75rem; }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -224,6 +224,12 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
 }
 .notes-form textarea { resize: vertical; }
 .notes-form-actions { display: flex; gap: 0.5rem; justify-content: flex-end; }
+.notes-location { font-size: 0.85rem; }
+.notes-location-set {
+  display: inline-flex; align-items: center; gap: 0.25rem;
+  color: var(--color-primary); font-size: 0.85rem;
+}
+.notes-location-set .btn-icon { font-size: 0.75rem; }
 
 /* Note list */
 .notes-list {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -138,8 +138,145 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
   pointer-events: none;
 }
 
+/* ─── Map page layout with notes panel ──────────────────────────────────────── */
+.map-page-content {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+.map-page-content .map-wrapper {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ─── Notes panel ──────────────────────────────────────────────────────────── */
+.notes-panel {
+  width: 320px;
+  border-left: 1px solid var(--color-border);
+  background: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.notes-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+.notes-header h3 { margin: 0; font-size: 1rem; }
+.notes-header-actions { display: flex; gap: 0.25rem; }
+
+/* Tabs */
+.notes-tabs {
+  display: flex;
+  gap: 0;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+.notes-tab {
+  padding: 0.5rem 0.75rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  border-bottom: 2px solid transparent;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.notes-tab.active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+  font-weight: 600;
+}
+.notes-tab:hover { color: var(--color-text); }
+.notes-tab-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.notes-tab-actions { margin-left: 0.25rem; }
+.notes-tab-actions .btn-icon {
+  background: none; border: none; cursor: pointer;
+  font-size: 0.75rem; color: var(--color-text-muted);
+  padding: 0 2px;
+}
+.notes-tab-actions .btn-icon:hover { color: var(--color-danger); }
+
+/* Forms */
+.notes-form {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.notes-form input, .notes-form textarea, .notes-form select {
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+}
+.notes-form textarea { resize: vertical; }
+.notes-form-actions { display: flex; gap: 0.5rem; justify-content: flex-end; }
+
+/* Note list */
+.notes-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+.notes-empty {
+  text-align: center;
+  color: var(--color-text-muted);
+  padding: 2rem 1rem;
+  font-size: 0.875rem;
+}
+.note-card {
+  padding: 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.note-card:hover { border-color: var(--color-primary); }
+.note-card.pinned { border-left: 3px solid var(--color-primary); }
+.note-pin-badge { font-size: 0.75rem; }
+.note-title { margin: 0 0 0.25rem; font-size: 0.9rem; }
+.note-text { margin: 0 0 0.5rem; font-size: 0.85rem; color: var(--color-text); }
+.note-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.note-meta small { color: var(--color-text-muted); font-size: 0.75rem; }
+.note-actions { display: flex; gap: 0.25rem; }
+.note-actions .btn-icon {
+  background: none; border: none; cursor: pointer;
+  font-size: 0.85rem; color: var(--color-text-muted); padding: 0 2px;
+}
+.note-actions .btn-icon:hover { color: var(--color-primary); }
+.note-edit-form { display: flex; flex-direction: column; gap: 0.5rem; }
+.note-edit-form input, .note-edit-form textarea {
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+}
+
+/* Small button variants */
+.btn-sm { padding: 0.25rem 0.5rem; font-size: 0.8rem; }
+
 @media (max-width: 600px) {
   .navbar-menu a:not(.btn) { display: none; }
   .map-grid { grid-template-columns: 1fr; }
   .auth-card { padding: 1.5rem; }
+  .map-page-content { flex-direction: column; }
+  .notes-panel { width: 100%; max-height: 300px; border-left: none; border-top: 1px solid var(--color-border); }
 }

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -1,13 +1,21 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { MapView } from '@/components/Map/MapView';
+import { NotesPanel } from '@/components/Notes/NotesPanel';
 import { useMap } from '@/hooks/useMap';
+import { useAuthStore } from '@/store/authStore';
+import type { Note } from '@/types';
 
 export function MapDetailPage() {
-  const { mapId } = useParams<{ mapId: string }>();
+  const { mapId, tenantId } = useParams<{ mapId: string; tenantId: string }>();
   const { activeMap, loadMap } = useMap();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const tenants = useAuthStore((s) => s.tenants);
+
+  // Determine if user is tenant admin (for group management)
+  const currentTenant = tenants.find((t) => String(t.id) === tenantId);
+  const isAdmin = currentTenant?.role === 'admin';
 
   useEffect(() => {
     if (!mapId) return;
@@ -16,9 +24,17 @@ export function MapDetailPage() {
       .finally(() => setLoading(false));
   }, [mapId, loadMap]);
 
+  const handleNoteClick = (note: Note) => {
+    // Future: pan map to note location
+    // For now, just select it visually
+    console.log('Note clicked:', note.id, note.lat, note.lng);
+  };
+
   if (loading) return <div className="page-loading">Loading map…</div>;
   if (error) return <div className="page-error">{error}</div>;
   if (!activeMap) return null;
+
+  const canEdit = activeMap.permission === 'edit' || activeMap.permission === 'owner';
 
   return (
     <div className="map-page">
@@ -26,10 +42,18 @@ export function MapDetailPage() {
         <h2>{activeMap.title}</h2>
         {activeMap.description && <p>{activeMap.description}</p>}
         {(activeMap.permission === 'none') && (
-          <p className="permission-notice">👁 View only — sign in for more access</p>
+          <p className="permission-notice">View only — sign in for more access</p>
         )}
       </div>
-      <MapView map={activeMap} />
+      <div className="map-page-content">
+        <MapView map={activeMap} />
+        <NotesPanel
+          mapId={activeMap.id}
+          canEdit={canEdit}
+          isAdmin={isAdmin}
+          onNoteClick={handleNoteClick}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -41,10 +41,11 @@ export function MapDetailPage() {
         noteGroupsService.listGroups(Number(mapId), storedTenantId),
         notesService.listNotes(Number(mapId), groupFilter, storedTenantId),
       ]);
+      console.log('Notes loaded:', n.length, 'Groups loaded:', g.length);
       setGroups(g);
       setNotes(n);
-    } catch {
-      // silently fail
+    } catch (err) {
+      console.error('Failed to load notes/groups:', err);
     }
   }, [mapId, storedTenantId]);
 

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -35,15 +35,12 @@ export function MapDetailPage() {
 
   // Load notes and groups
   const loadNotesAndGroups = useCallback(async (groupFilter?: number) => {
-    console.log('loadNotesAndGroups called, mapId:', mapId, 'groupFilter:', groupFilter, 'tenantId:', storedTenantId);
     if (!mapId) return;
     try {
-      console.log('Fetching notes and groups...');
-      const gPromise = noteGroupsService.listGroups(Number(mapId), storedTenantId);
-      const nPromise = notesService.listNotes(Number(mapId), groupFilter, storedTenantId);
-      console.log('Promises created, awaiting...');
-      const [g, n] = await Promise.all([gPromise, nPromise]);
-      console.log('Notes loaded:', n.length, 'Groups loaded:', g.length);
+      const [g, n] = await Promise.all([
+        noteGroupsService.listGroups(Number(mapId), storedTenantId),
+        notesService.listNotes(Number(mapId), groupFilter, storedTenantId),
+      ]);
       setGroups(g);
       setNotes(n);
     } catch (err) {
@@ -58,7 +55,7 @@ export function MapDetailPage() {
   }, [loading, activeMap, loadNotesAndGroups]);
 
   const handleNoteClick = (note: Note) => {
-    console.log('Note clicked:', note.id, note.lat, note.lng);
+    // Future: pan map to note location
   };
 
   const handleRequestMapClick = useCallback((callback: (lat: number, lng: number) => void) => {

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -4,7 +4,8 @@ import { MapView } from '@/components/Map/MapView';
 import { NotesPanel } from '@/components/Notes/NotesPanel';
 import { useMap } from '@/hooks/useMap';
 import { useAuthStore } from '@/store/authStore';
-import type { Note } from '@/types';
+import { notesService, noteGroupsService } from '@/services/maps';
+import type { Note, NoteGroup } from '@/types';
 
 export function MapDetailPage() {
   const { mapId, tenantId } = useParams<{ mapId: string; tenantId: string }>();
@@ -12,9 +13,14 @@ export function MapDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const tenants = useAuthStore((s) => s.tenants);
+  const storedTenantId = useAuthStore((s) => s.tenantId) ?? undefined;
 
   const currentTenant = tenants.find((t) => String(t.id) === tenantId);
   const isAdmin = currentTenant?.role === 'admin';
+
+  // Shared notes/groups state (used by both MapView markers and NotesPanel list)
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [groups, setGroups] = useState<NoteGroup[]>([]);
 
   // Map click handler for "Place on map" feature
   const mapClickCallbackRef = useRef<((lat: number, lng: number) => void) | null>(null);
@@ -26,6 +32,27 @@ export function MapDetailPage() {
       .catch(() => setError('Map not found or you do not have permission to view it.'))
       .finally(() => setLoading(false));
   }, [mapId, loadMap]);
+
+  // Load notes and groups
+  const loadNotesAndGroups = useCallback(async (groupFilter?: number) => {
+    if (!mapId) return;
+    try {
+      const [g, n] = await Promise.all([
+        noteGroupsService.listGroups(Number(mapId), storedTenantId),
+        notesService.listNotes(Number(mapId), groupFilter, storedTenantId),
+      ]);
+      setGroups(g);
+      setNotes(n);
+    } catch {
+      // silently fail
+    }
+  }, [mapId, storedTenantId]);
+
+  useEffect(() => {
+    if (!loading && activeMap) {
+      loadNotesAndGroups();
+    }
+  }, [loading, activeMap, loadNotesAndGroups]);
 
   const handleNoteClick = (note: Note) => {
     console.log('Note clicked:', note.id, note.lat, note.lng);
@@ -67,14 +94,20 @@ export function MapDetailPage() {
       <div className="map-page-content">
         <MapView
           map={activeMap}
+          notes={notes}
+          noteGroups={groups}
           isPlacingNote={isPlacingNote}
           onMapClickForNote={handleMapClickForNote}
           onCancelPlace={handleCancelPlace}
+          onNoteClick={handleNoteClick}
         />
         <NotesPanel
           mapId={activeMap.id}
           canEdit={canEdit}
           isAdmin={isAdmin}
+          notes={notes}
+          groups={groups}
+          onNotesChanged={loadNotesAndGroups}
           onNoteClick={handleNoteClick}
           onRequestMapClick={handleRequestMapClick}
         />

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -35,6 +35,7 @@ export function MapDetailPage() {
 
   // Load notes and groups
   const loadNotesAndGroups = useCallback(async (groupFilter?: number) => {
+    console.log('loadNotesAndGroups called, mapId:', mapId, 'groupFilter:', groupFilter);
     if (!mapId) return;
     try {
       const [g, n] = await Promise.all([

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { MapView } from '@/components/Map/MapView';
 import { NotesPanel } from '@/components/Notes/NotesPanel';
@@ -13,9 +13,12 @@ export function MapDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const tenants = useAuthStore((s) => s.tenants);
 
-  // Determine if user is tenant admin (for group management)
   const currentTenant = tenants.find((t) => String(t.id) === tenantId);
   const isAdmin = currentTenant?.role === 'admin';
+
+  // Map click handler for "Place on map" feature
+  const mapClickCallbackRef = useRef<((lat: number, lng: number) => void) | null>(null);
+  const [isPlacingNote, setIsPlacingNote] = useState(false);
 
   useEffect(() => {
     if (!mapId) return;
@@ -25,10 +28,26 @@ export function MapDetailPage() {
   }, [mapId, loadMap]);
 
   const handleNoteClick = (note: Note) => {
-    // Future: pan map to note location
-    // For now, just select it visually
     console.log('Note clicked:', note.id, note.lat, note.lng);
   };
+
+  const handleRequestMapClick = useCallback((callback: (lat: number, lng: number) => void) => {
+    mapClickCallbackRef.current = callback;
+    setIsPlacingNote(true);
+  }, []);
+
+  const handleMapClickForNote = useCallback((lat: number, lng: number) => {
+    if (mapClickCallbackRef.current) {
+      mapClickCallbackRef.current(lat, lng);
+      mapClickCallbackRef.current = null;
+      setIsPlacingNote(false);
+    }
+  }, []);
+
+  const handleCancelPlace = useCallback(() => {
+    mapClickCallbackRef.current = null;
+    setIsPlacingNote(false);
+  }, []);
 
   if (loading) return <div className="page-loading">Loading map…</div>;
   if (error) return <div className="page-error">{error}</div>;
@@ -46,12 +65,18 @@ export function MapDetailPage() {
         )}
       </div>
       <div className="map-page-content">
-        <MapView map={activeMap} />
+        <MapView
+          map={activeMap}
+          isPlacingNote={isPlacingNote}
+          onMapClickForNote={handleMapClickForNote}
+          onCancelPlace={handleCancelPlace}
+        />
         <NotesPanel
           mapId={activeMap.id}
           canEdit={canEdit}
           isAdmin={isAdmin}
           onNoteClick={handleNoteClick}
+          onRequestMapClick={handleRequestMapClick}
         />
       </div>
     </div>

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -35,13 +35,14 @@ export function MapDetailPage() {
 
   // Load notes and groups
   const loadNotesAndGroups = useCallback(async (groupFilter?: number) => {
-    console.log('loadNotesAndGroups called, mapId:', mapId, 'groupFilter:', groupFilter);
+    console.log('loadNotesAndGroups called, mapId:', mapId, 'groupFilter:', groupFilter, 'tenantId:', storedTenantId);
     if (!mapId) return;
     try {
-      const [g, n] = await Promise.all([
-        noteGroupsService.listGroups(Number(mapId), storedTenantId),
-        notesService.listNotes(Number(mapId), groupFilter, storedTenantId),
-      ]);
+      console.log('Fetching notes and groups...');
+      const gPromise = noteGroupsService.listGroups(Number(mapId), storedTenantId);
+      const nPromise = notesService.listNotes(Number(mapId), groupFilter, storedTenantId);
+      console.log('Promises created, awaiting...');
+      const [g, n] = await Promise.all([gPromise, nPromise]);
       console.log('Notes loaded:', n.length, 'Groups loaded:', g.length);
       setGroups(g);
       setNotes(n);

--- a/frontend/src/services/maps.ts
+++ b/frontend/src/services/maps.ts
@@ -12,6 +12,10 @@ import type {
   PaginatedResponse,
   Tenant,
   TenantMember,
+  Note,
+  CreateNoteRequest,
+  NoteGroup,
+  CreateNoteGroupRequest,
 } from '@/types';
 
 // Helper: resolve tenantId from store if not explicitly provided
@@ -168,5 +172,71 @@ export const permissionsService = {
   async removePermission(mapId: number, userId: number | null, tenantId?: number): Promise<void> {
     const target = userId === null ? 'public' : String(userId);
     await apiClient.delete(`${tenantBase(tenantId)}/maps/${mapId}/permissions/${target}`);
+  },
+};
+
+// ─── Notes ────────────────────────────────────────────────────────────────────
+
+export const notesService = {
+  async listNotes(mapId: number, groupId?: number, tenantId?: number): Promise<Note[]> {
+    const params = groupId ? { groupId } : {};
+    const res = await apiClient.get<Note[]>(
+      `${tenantBase(tenantId)}/maps/${mapId}/notes`, { params }
+    );
+    return res.data;
+  },
+
+  async createNote(mapId: number, data: CreateNoteRequest, tenantId?: number): Promise<Note> {
+    const res = await apiClient.post<Note>(
+      `${tenantBase(tenantId)}/maps/${mapId}/notes`, data
+    );
+    return res.data;
+  },
+
+  async getNote(mapId: number, noteId: number, tenantId?: number): Promise<Note> {
+    const res = await apiClient.get<Note>(
+      `${tenantBase(tenantId)}/maps/${mapId}/notes/${noteId}`
+    );
+    return res.data;
+  },
+
+  async updateNote(
+    mapId: number, noteId: number,
+    data: Partial<CreateNoteRequest>, tenantId?: number
+  ): Promise<void> {
+    await apiClient.put(`${tenantBase(tenantId)}/maps/${mapId}/notes/${noteId}`, data);
+  },
+
+  async deleteNote(mapId: number, noteId: number, tenantId?: number): Promise<void> {
+    await apiClient.delete(`${tenantBase(tenantId)}/maps/${mapId}/notes/${noteId}`);
+  },
+};
+
+// ─── Note Groups ──────────────────────────────────────────────────────────────
+
+export const noteGroupsService = {
+  async listGroups(mapId: number, tenantId?: number): Promise<NoteGroup[]> {
+    const res = await apiClient.get<NoteGroup[]>(
+      `${tenantBase(tenantId)}/maps/${mapId}/note-groups`
+    );
+    return res.data;
+  },
+
+  async createGroup(mapId: number, data: CreateNoteGroupRequest, tenantId?: number): Promise<NoteGroup> {
+    const res = await apiClient.post<NoteGroup>(
+      `${tenantBase(tenantId)}/maps/${mapId}/note-groups`, data
+    );
+    return res.data;
+  },
+
+  async updateGroup(
+    mapId: number, groupId: number,
+    data: Partial<CreateNoteGroupRequest>, tenantId?: number
+  ): Promise<void> {
+    await apiClient.put(`${tenantBase(tenantId)}/maps/${mapId}/note-groups/${groupId}`, data);
+  },
+
+  async deleteGroup(mapId: number, groupId: number, tenantId?: number): Promise<void> {
+    await apiClient.delete(`${tenantBase(tenantId)}/maps/${mapId}/note-groups/${groupId}`);
   },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -178,6 +178,7 @@ export interface Note {
   title: string | null;
   text: string;
   pinned: boolean;
+  color: string | null;
   canEdit: boolean;
   createdAt: string;
   updatedAt: string;
@@ -188,6 +189,7 @@ export interface CreateNoteRequest {
   lng: number;
   title?: string;
   text: string;
+  color?: string;
   groupId?: number;
 }
 


### PR DESCRIPTION
## Summary

Complete implementation of issue #2 (Note Groups) — backend, frontend, database, tests, and docs.

### Notes Panel
- Side-by-side layout: Leaflet map + Notes panel
- Note CRUD: create, inline edit, delete
- "Place on map" button: crosshair mode, click to set lat/lng, temporary cyan marker shows placement
- "Move" button (⤢): relocate a note by clicking a new map location
- Per-note custom color (hex) for map markers
- `createdByUsername` in all responses

### Note Groups
- Group CRUD: create, rename, delete (admin only)
- Tab UI with color dots, "All" tab for unfiltered view
- Assign notes to groups at creation or via edit
- Move notes between groups or ungroup (`groupId: null`)
- Filter notes by group tab (client-side filtering)
- Deleting a group preserves notes (sets `group_id` to NULL)

### Map Markers
- Notes rendered as circle markers (visually distinct from annotation pin icons)
- Color priority: per-note color > group color > default cyan (#00FFFF)
- Popups show title, text, and author

### Database
- Migration 006: `note_groups` table + FK on `notes.group_id`
- Migration 007: `color` column on `notes`

### Backend
- `NoteGroupController`: list, create, update, delete (admin-only mutations)
- `NoteController` updates: `groupId`, `color`, `lat`/`lng` in create and update
- `createdByUsername` in create response

### Tests
- `test_13_note_groups.py`: group CRUD, assignment, filtering, permissions, cross-org isolation
- `test_11_notes.py`: added color, move, createdByUsername assertions

### Docs updated
- REQUIREMENTS.md: sections 2.9, 2.10, 4.1, 5.5, 5.6, migration table
- TESTING-BACKEND.md, TESTING-DATABASE.md, TESTING-NOTES.md, SETUP-LOCAL-DEV.md, README.md

## Test plan

- [ ] Create a note with "Place on map" → cyan circle appears on map and in list
- [ ] Create a note with custom color → circle uses that color
- [ ] Edit a note's text, color, group → changes reflected
- [ ] Move a note (⤢) → circle relocates on map
- [ ] Delete a note → removed from list and map
- [ ] Create a group (admin) → tab appears with color dot
- [ ] Filter by group tab → only grouped notes shown
- [ ] Delete a group → notes become ungrouped
- [ ] Cross-org user cannot access notes or groups
- [ ] `python3 backend/tests/run-tests.py --only 11` passes
- [ ] `python3 backend/tests/run-tests.py --only 13` passes
- [ ] `python3 database/tests/run-db-tests.py` passes

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)