### PR TITLE
CI: Run fast test suite on PRs, block merge on failure (#14)

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,73 @@
+name: PR Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: docker-${{ runner.os }}-${{ hashFiles('backend/Dockerfile', 'frontend/Dockerfile.dev', 'backend/CMakeLists.txt') }}
+          restore-keys: |
+            docker-${{ runner.os }}-
+
+      - name: Build and start stack
+        run: |
+          docker compose build
+          docker compose up -d
+        env:
+          DOCKER_BUILDKIT: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
+
+      - name: Wait for MySQL to be healthy
+        run: |
+          echo "Waiting for MySQL..."
+          for i in $(seq 1 30); do
+            if docker compose exec -T mysql mysqladmin ping -uroot -prootpassword 2>/dev/null; then
+              echo "MySQL is ready"
+              break
+            fi
+            echo "  attempt $i..."
+            sleep 5
+          done
+
+      - name: Wait for backend
+        run: |
+          echo "Waiting for backend..."
+          for i in $(seq 1 12); do
+            if curl -s --max-time 5 -o /dev/null http://localhost:8080/api/v1/../ 2>/dev/null; then
+              echo "Backend is ready"
+              break
+            fi
+            echo "  attempt $i..."
+            sleep 5
+          done
+
+      - name: Run database tests
+        run: python3 database/tests/run-db-tests.py
+
+      - name: Run backend tests (fast tier)
+        run: python3 backend/tests/run-tests.py --tier fast
+        env:
+          CURL_TIMEOUT: "30"
+
+      - name: Show backend logs on failure
+        if: failure()
+        run: docker compose logs --tail 50 backend
+
+      - name: Stop stack
+        if: always()
+        run: docker compose down -v

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ annotated-maps/
 │   ├── run_migrations.py
 │   └── seed-local-dev.py
 ├── docs/                  Requirements, security audit, setup guides, test docs
-├── .github/workflows/     Nightly + weekend CI (GitHub Actions)
+├── .github/workflows/     PR gate, nightly + weekend CI (GitHub Actions)
 └── docker-compose.yml
 ```
 

--- a/docs/TESTING-BACKEND.md
+++ b/docs/TESTING-BACKEND.md
@@ -82,7 +82,18 @@ same database.
 4. End with `sys.exit(0 if report() else 1)`
 5. Add the filename to the `FAST_TESTS`, `NIGHTLY_EXTRA`, or `EXTENDED_EXTRA` list in `run-tests.py`
 
-## Scheduling
+## CI / GitHub Actions
+
+### Pull request gate
+
+Every pull request to `main` runs the fast test suite automatically via
+`.github/workflows/pr-tests.yml`. Both database tests and backend integration
+tests (fast tier) must pass before the PR can be merged.
+
+To enable merge blocking, configure branch protection on `main`:
+1. Go to Settings → Branches → Add rule for `main`
+2. Enable "Require status checks to pass before merging"
+3. Select the "test" check from the PR Tests workflow
 
 ### Nightly (e.g., 3am weekdays)
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-tests.yml` triggered on every pull request to `main`
- Runs database schema tests + backend integration tests (fast tier)
- Uses Docker layer caching for faster builds
- Shows backend logs automatically on test failure
- Cleans up containers/volumes after every run

## To enable merge blocking

After merging this PR, configure branch protection on `main`:
1. Go to Settings → Branches → Add rule for `main`
2. Enable "Require status checks to pass before merging"
3. Select the "test" check from the PR Tests workflow

## Test plan

- [ ] Open a PR to main — workflow triggers automatically
- [ ] If tests pass — green check appears on the PR
- [ ] If tests fail — red X with backend logs in the workflow output
- [ ] After branch protection is configured — merge button is blocked until tests pass

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)