### PR TITLE
CI: Add compile-check job to fail fast on C++ errors

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -4,8 +4,34 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
+  compile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compile backend (builder stage only)
+        uses: docker/build-push-action@v6
+        with:
+          context: backend
+          file: backend/Dockerfile
+          target: builder
+          push: false
+          load: false
+          cache-from: type=gha,scope=backend-compile
+          cache-to: type=gha,scope=backend-compile,mode=max
+
   test:
+    needs: compile
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/docs/TESTING-BACKEND.md
+++ b/docs/TESTING-BACKEND.md
@@ -86,14 +86,22 @@ same database.
 
 ### Pull request gate
 
-Every pull request to `main` runs the fast test suite automatically via
-`.github/workflows/pr-tests.yml`. Both database tests and backend integration
-tests (fast tier) must pass before the PR can be merged.
+Every pull request to `main` runs two jobs via `.github/workflows/pr-tests.yml`:
+
+1. **compile** — Builds only the backend builder stage (C++ compile + link).
+   Uses the GitHub Actions cache so Drogon/jwt-cpp layers are cached and only
+   the application code is recompiled (~30s on cache hit).
+2. **test** — Runs after compile succeeds (`needs: compile`). Builds the full
+   Docker Compose stack and runs database tests + backend integration tests
+   (fast tier).
+
+If the C++ code doesn't compile, the test job is skipped entirely, giving
+faster feedback than waiting for the full stack build.
 
 To enable merge blocking, configure branch protection on `main`:
 1. Go to Settings → Branches → Add rule for `main`
 2. Enable "Require status checks to pass before merging"
-3. Select the "test" check from the PR Tests workflow
+3. Select both the "compile" and "test" checks from the PR Tests workflow
 
 ### Nightly (e.g., 3am weekdays)
 


### PR DESCRIPTION
## Summary
- Split PR workflow into two jobs: **compile** (builder stage only, ~30s on cache hit) and **test** (full stack + integration tests)
- Test job uses `needs: compile` so it's skipped entirely if C++ doesn't compile
- Uses GHA cache for Drogon/jwt-cpp layers so only application code is recompiled
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var (was missing from this workflow)
- Updated TESTING-BACKEND.md to document the two-job structure

Closes #19

## Files changed
- `.github/workflows/pr-tests.yml` — Split single `test` job into `compile` + `test` jobs with `needs:` dependency
- `docs/TESTING-BACKEND.md` — Updated "Pull request gate" section to document two-job structure

## Test plan
- [ ] Open a PR with valid C++ — both compile and test jobs should pass
- [ ] Open a PR with a syntax error in a .cpp file — compile job should fail, test job should be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)