### PR TITLE
Test: broken C++ compile-check (expect FAIL)

### DIFF
--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -1,4 +1,6 @@
+// Test: broken C++ for CI compile-check verification
 #include <drogon/drogon.h>
+THIS_IS_NOT_VALID_CPP;
 #include <sodium.h>
 #include <iostream>
 #include <set>


### PR DESCRIPTION
## Summary
- Introduces a deliberate syntax error in `main.cpp` to verify the compile job catches it
- **Expected:** `compile` job fails, `test` job is skipped

## Files changed
- `backend/src/main.cpp` — Added invalid C++ statement to trigger compile failure

## Test plan
- [ ] Compile job fails
- [ ] Test job is skipped (not failed, skipped)

🧪 Throwaway PR — close and delete branch after verification