### PR TITLE
Refactor: Backend controller cleanup and consistency

### DIFF
--- a/backend/src/ErrorResponse.h
+++ b/backend/src/ErrorResponse.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <drogon/HttpResponse.h>
+#include <json/json.h>
+#include <string>
+
+// Shared error JSON helper — returns {"error": code, "message": msg}
+inline Json::Value errorJson(const std::string& code, const std::string& msg) {
+    Json::Value v;
+    v["error"]   = code;
+    v["message"] = msg;
+    return v;
+}
+
+// Convenience: build an error HTTP response in one call
+inline drogon::HttpResponsePtr errorResponse(
+    drogon::HttpStatusCode status,
+    const std::string& code,
+    const std::string& msg) {
+    auto resp = drogon::HttpResponse::newHttpJsonResponse(errorJson(code, msg));
+    resp->setStatusCode(status);
+    return resp;
+}

--- a/backend/src/controllers/AnnotationController.cpp
+++ b/backend/src/controllers/AnnotationController.cpp
@@ -1,16 +1,10 @@
 #include "AnnotationController.h"
+#include "ErrorResponse.h"
 #include <drogon/drogon.h>
 
 static int callerUserId(const drogon::HttpRequestPtr& req) {
     try { return req->getAttributes()->get<int>("userId"); }
     catch (...) { return 0; }
-}
-
-static Json::Value errorJson(const std::string& code, const std::string& msg) {
-    Json::Value v;
-    v["error"]   = code;
-    v["message"] = msg;
-    return v;
 }
 
 // ─── GET /api/v1/tenants/{tenantId}/maps/{mapId}/annotations ──────────────────

--- a/backend/src/controllers/AuthController.cpp
+++ b/backend/src/controllers/AuthController.cpp
@@ -1,18 +1,12 @@
 #include "AuthController.h"
 #include "AuditLog.h"
+#include "ErrorResponse.h"
 #include <drogon/drogon.h>
 #include <jwt-cpp/jwt.h>
 #include <sodium.h>
 #include <chrono>
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-static Json::Value errorJson(const std::string& code, const std::string& msg) {
-    Json::Value v;
-    v["error"]   = code;
-    v["message"] = msg;
-    return v;
-}
 
 static std::string hashPassword(const std::string& password) {
     char hashed[crypto_pwhash_STRBYTES];

--- a/backend/src/controllers/MapController.cpp
+++ b/backend/src/controllers/MapController.cpp
@@ -1,5 +1,6 @@
 #include "MapController.h"
 #include "AuditLog.h"
+#include "ErrorResponse.h"
 #include <drogon/drogon.h>
 
 static int callerUserId(const drogon::HttpRequestPtr& req) {
@@ -10,13 +11,6 @@ static int callerUserId(const drogon::HttpRequestPtr& req) {
 static int callerOrgId(const drogon::HttpRequestPtr& req) {
     try { return req->getAttributes()->get<int>("orgId"); }
     catch (...) { return 0; }
-}
-
-static Json::Value errorJson(const std::string& code, const std::string& msg) {
-    Json::Value v;
-    v["error"]   = code;
-    v["message"] = msg;
-    return v;
 }
 
 // ─── GET /api/v1/tenants/{tenantId}/maps ──────────────────────────────────────

--- a/backend/src/controllers/NoteController.cpp
+++ b/backend/src/controllers/NoteController.cpp
@@ -1,16 +1,10 @@
 #include "NoteController.h"
+#include "ErrorResponse.h"
 #include <drogon/drogon.h>
 
 static int callerUserId(const drogon::HttpRequestPtr& req) {
     try { return req->getAttributes()->get<int>("userId"); }
     catch (...) { return 0; }
-}
-
-static Json::Value errorJson(const std::string& code, const std::string& msg) {
-    Json::Value v;
-    v["error"]   = code;
-    v["message"] = msg;
-    return v;
 }
 
 // ─── GET /api/v1/tenants/{tenantId}/maps/{mapId}/notes ────────────────────────

--- a/backend/src/controllers/NoteGroupController.cpp
+++ b/backend/src/controllers/NoteGroupController.cpp
@@ -1,4 +1,5 @@
 #include "NoteGroupController.h"
+#include "ErrorResponse.h"
 #include <drogon/drogon.h>
 
 static int callerUserId(const drogon::HttpRequestPtr& req) {
@@ -9,13 +10,6 @@ static int callerUserId(const drogon::HttpRequestPtr& req) {
 static std::string callerTenantRole(const drogon::HttpRequestPtr& req) {
     try { return req->getAttributes()->get<std::string>("tenantRole"); }
     catch (...) { return ""; }
-}
-
-static Json::Value errorJson(const std::string& code, const std::string& msg) {
-    Json::Value v;
-    v["error"]   = code;
-    v["message"] = msg;
-    return v;
 }
 
 // ─── GET .../note-groups ──────────────────────────────────────────────────────

--- a/backend/src/controllers/SsoController.cpp
+++ b/backend/src/controllers/SsoController.cpp
@@ -1,5 +1,6 @@
 #include "SsoController.h"
 #include "AuditLog.h"
+#include "ErrorResponse.h"
 #include <drogon/drogon.h>
 #include <jwt-cpp/jwt.h>
 #include <openssl/rand.h>
@@ -62,12 +63,8 @@ void SsoController::initiate(
         "WHERE o.slug = ? LIMIT 1",
         [this, callback, orgSlug](const drogon::orm::Result& r) {
             if (r.empty()) {
-                Json::Value body;
-                body["error"]   = "bad_request";
-                body["message"] = "SSO is not available";
-                auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
-                resp->setStatusCode(drogon::k400BadRequest);
-                callback(resp);
+                callback(errorResponse(drogon::k400BadRequest,
+                    "bad_request", "SSO is not available"));
                 return;
             }
 
@@ -107,12 +104,8 @@ void SsoController::initiate(
             callback(resp);
         },
         [callback](const drogon::orm::DrogonDbException&) {
-            Json::Value body;
-            body["error"]   = "db_error";
-            body["message"] = "Database error during SSO initiation";
-            auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
-            resp->setStatusCode(drogon::k500InternalServerError);
-            callback(resp);
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error during SSO initiation"));
         },
         orgSlug);
 }
@@ -130,22 +123,14 @@ void SsoController::callback(
     std::string error = req->getParameter("error");
 
     if (!error.empty()) {
-        Json::Value body;
-        body["error"]   = "sso_error";
-        body["message"] = "IdP returned error: " + error;
-        auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
-        resp->setStatusCode(drogon::k400BadRequest);
-        callback(resp);
+        callback(errorResponse(drogon::k400BadRequest,
+            "sso_error", "IdP returned error: " + error));
         return;
     }
 
     if (code.empty() || state.empty()) {
-        Json::Value body;
-        body["error"]   = "bad_request";
-        body["message"] = "code and state are required";
-        auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
-        resp->setStatusCode(drogon::k400BadRequest);
-        callback(resp);
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "code and state are required"));
         return;
     }
 
@@ -155,12 +140,8 @@ void SsoController::callback(
         auto it = pendingStates_.find(state);
         if (it == pendingStates_.end() ||
             it->second.expiry < std::chrono::steady_clock::now()) {
-            Json::Value body;
-            body["error"]   = "invalid_state";
-            body["message"] = "SSO state is invalid or expired";
-            auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
-            resp->setStatusCode(drogon::k400BadRequest);
-            callback(resp);
+            callback(errorResponse(drogon::k400BadRequest,
+                "invalid_state", "SSO state is invalid or expired"));
             return;
         }
         savedState = it->second;
@@ -174,12 +155,8 @@ void SsoController::callback(
         "SELECT s.config FROM sso_providers s WHERE s.org_id = ? LIMIT 1",
         [this, callback, req, code, orgId](const drogon::orm::Result& r) {
             if (r.empty()) {
-                Json::Value body;
-                body["error"]   = "not_found";
-                body["message"] = "SSO provider config not found";
-                auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
-                resp->setStatusCode(drogon::k404NotFound);
-                callback(resp);
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "SSO provider config not found"));
                 return;
             }
 
@@ -223,12 +200,8 @@ void SsoController::callback(
                 [this, callback, req, orgId, userinfoEndpoint]
                 (drogon::ReqResult result, const drogon::HttpResponsePtr& tokenResp) {
                     if (result != drogon::ReqResult::Ok) {
-                        Json::Value body;
-                        body["error"]   = "sso_error";
-                        body["message"] = "Failed to contact IdP token endpoint";
-                        auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
-                        resp->setStatusCode(drogon::k502BadGateway);
-                        callback(resp);
+                        callback(errorResponse(drogon::k502BadGateway,
+                            "sso_error", "Failed to contact IdP token endpoint"));
                         return;
                     }
 
@@ -237,12 +210,8 @@ void SsoController::callback(
                     reader.parse(std::string(tokenResp->getBody()), tokenData);
 
                     if (!tokenData.isMember("access_token")) {
-                        Json::Value body;
-                        body["error"]   = "sso_error";
-                        body["message"] = "No access_token in IdP response";
-                        auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
-                        resp->setStatusCode(drogon::k502BadGateway);
-                        callback(resp);
+                        callback(errorResponse(drogon::k502BadGateway,
+                            "sso_error", "No access_token in IdP response"));
                         return;
                     }
 
@@ -270,12 +239,8 @@ void SsoController::callback(
                         [this, callback, req, orgId]
                         (drogon::ReqResult result2, const drogon::HttpResponsePtr& uiResp) {
                             if (result2 != drogon::ReqResult::Ok) {
-                                Json::Value body;
-                                body["error"]   = "sso_error";
-                                body["message"] = "Failed to contact IdP userinfo endpoint";
-                                auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
-                                resp->setStatusCode(drogon::k502BadGateway);
-                                callback(resp);
+                                callback(errorResponse(drogon::k502BadGateway,
+                                    "sso_error", "Failed to contact IdP userinfo endpoint"));
                                 return;
                             }
 
@@ -289,12 +254,8 @@ void SsoController::callback(
                                 uiData.get("name", email).asString()).asString();
 
                             if (externalId.empty()) {
-                                Json::Value body;
-                                body["error"]   = "sso_error";
-                                body["message"] = "IdP did not return a subject claim";
-                                auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
-                                resp->setStatusCode(drogon::k502BadGateway);
-                                callback(resp);
+                                callback(errorResponse(drogon::k502BadGateway,
+                                    "sso_error", "IdP did not return a subject claim"));
                                 return;
                             }
 
@@ -336,34 +297,22 @@ void SsoController::callback(
                                             callback(resp);
                                         },
                                         [callback](const drogon::orm::DrogonDbException&) {
-                                            Json::Value body;
-                                            body["error"]   = "db_error";
-                                            body["message"] = "Failed to load tenant info";
-                                            auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
-                                            resp->setStatusCode(drogon::k500InternalServerError);
-                                            callback(resp);
+                                            callback(errorResponse(drogon::k500InternalServerError,
+                                                "db_error", "Failed to load tenant info"));
                                         },
                                         userId, orgId);
                                 },
                                 [callback](const drogon::orm::DrogonDbException&) {
-                                    Json::Value body;
-                                    body["error"]   = "db_error";
-                                    body["message"] = "Failed to upsert SSO user";
-                                    auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
-                                    resp->setStatusCode(drogon::k500InternalServerError);
-                                    callback(resp);
+                                    callback(errorResponse(drogon::k500InternalServerError,
+                                        "db_error", "Failed to upsert SSO user"));
                                 },
                                 username, email, orgId, externalId);
                         });
                 });
         },
         [callback](const drogon::orm::DrogonDbException&) {
-            Json::Value body;
-            body["error"]   = "db_error";
-            body["message"] = "Failed to load SSO provider config";
-            auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
-            resp->setStatusCode(drogon::k500InternalServerError);
-            callback(resp);
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to load SSO provider config"));
         },
         orgId);
 }

--- a/backend/src/controllers/TenantController.cpp
+++ b/backend/src/controllers/TenantController.cpp
@@ -1,13 +1,7 @@
 #include "TenantController.h"
 #include "AuditLog.h"
+#include "ErrorResponse.h"
 #include <drogon/drogon.h>
-
-static Json::Value errorJson(const std::string& code, const std::string& msg) {
-    Json::Value v;
-    v["error"]   = code;
-    v["message"] = msg;
-    return v;
-}
 
 // ─── GET /api/v1/tenants ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Extract `errorJson()` and `errorResponse()` into shared `ErrorResponse.h`, removing 6 identical static copies across controllers
- Standardize SsoController to use the shared helpers instead of inline `Json::Value` construction (~50 lines removed)
- Audit confirmed: `shared_ptr<FilterCallback>` pattern is correct in both filters, config access is appropriately scattered, audit log calls are consistent, no dead code or TODO/FIXME comments found

Closes #42

## Files changed
- `backend/src/ErrorResponse.h` — New shared header with `errorJson()` and `errorResponse()` helpers
- `backend/src/controllers/AnnotationController.cpp` — Replace local `errorJson()` with shared header
- `backend/src/controllers/AuthController.cpp` — Replace local `errorJson()` with shared header
- `backend/src/controllers/MapController.cpp` — Replace local `errorJson()` with shared header
- `backend/src/controllers/NoteController.cpp` — Replace local `errorJson()` with shared header
- `backend/src/controllers/NoteGroupController.cpp` — Replace local `errorJson()` with shared header
- `backend/src/controllers/SsoController.cpp` — Replace 10+ inline JSON error constructions with `errorResponse()` calls
- `backend/src/controllers/TenantController.cpp` — Replace local `errorJson()` with shared header

## Audit results (no changes needed)
- **shared_ptr<FilterCallback>**: Correct in both JwtFilter and TenantFilter
- **Config access**: 9 calls, contextually appropriate, no centralization needed
- **Audit log**: All 9 calls consistent with AuditLog::record() signature
- **Dead code**: None found (no commented-out blocks, no TODO/FIXME, no unused includes)
- **Callback nesting**: AuthController::registerUser has 5 levels — acceptable for Drogon's async pattern without introducing a coroutine/promise library

## Test plan
- [ ] Backend compiles successfully (compile job)
- [ ] All existing integration tests pass (no behavior changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)