### PR TITLE
Fix critical npm audit vulnerability in axios

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3277,9 +3277,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -4392,9 +4392,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
## Summary
- Upgrade axios to resolve two critical SSRF vulnerabilities that were blocking all PR security checks
- Non-breaking change (minor version bump via `npm audit fix`)
- Remaining moderate/high findings are build-tool only (tracked in #31)

## Files changed
- `frontend/package-lock.json` — Upgraded axios to patched version

## Test plan
- [ ] Security job `npm audit --audit-level=critical` passes
- [ ] Frontend typecheck and lint pass
- [ ] Login, register, and API calls still work (axios is the HTTP client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)