### PR TITLE
Docs: Add DEVELOPER-GUIDE.md documenting refactor conventions

### DIFF
--- a/backend/src/ErrorResponse.h
+++ b/backend/src/ErrorResponse.h
@@ -1,5 +1,9 @@
 #pragma once
 
+// All controllers should include this header and use errorJson() /
+// errorResponse() instead of defining their own local helpers or
+// constructing error JSON inline. See docs/DEVELOPER-GUIDE.md.
+
 #include <drogon/HttpResponse.h>
 #include <json/json.h>
 #include <string>

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -48,6 +48,28 @@ All auditable events use `AuditLog::record(...)` and are fire-and-forget
 (no callback chain). See [`backend/src/AuditLog.h`](../backend/src/AuditLog.h)
 for the signature.
 
+## CI / Docker
+
+### `docker-compose.ci.yml`
+
+The [`docker-compose.ci.yml`](../docker-compose.ci.yml) override is used by
+the PR and nightly workflows. It maps pre-built image tags
+(`annotated-maps-backend:latest`, `annotated-maps-frontend:latest`) onto the
+backend and frontend services so that `docker compose up` uses images the
+workflow just built via `docker/build-push-action` (with GHA cache) instead
+of rebuilding from scratch. Local development uses `docker-compose.yml`
+alone — the override is CI-only.
+
+### Soak test duration vs. runner timeout
+
+`backend/tests/test_10_soak.py` has `DURATION = 300` (5 minutes of
+continuous load). The test runner in `run-tests.py` gives each test a
+900-second subprocess timeout. These are set independently: 300s is the
+minimum window to catch rate-limiter over-admission under sustained load,
+and 900s gives headroom for stack-up and teardown without masking real
+soak failures. Don't change one without considering the other — see #21
+for the history.
+
 ## Frontend (React / TypeScript)
 
 ### Handling API errors in components
@@ -99,5 +121,24 @@ for the pattern: `NotesPanel.tsx` coordinates, while `NoteCard.tsx`,
 - Errors must be displayed to the user (inline banner, toast, etc.).
 - Don't use `alert()` — use the component's error state instead.
 - Don't `catch` and only `console.error()` — that's a silent failure.
-  For Leaflet popup handlers where React state isn't available, use the
-  `showMapError()` helper in [`AnnotationLayer.tsx`](../frontend/src/components/Map/AnnotationLayer.tsx).
+
+This is a convention, not a lint rule, so review PRs for it.
+
+### Errors from Leaflet popup handlers
+
+Leaflet popup button handlers run outside React, so you can't call
+`setState` from them. Use the `showMapError(map, message)` helper in
+[`AnnotationLayer.tsx`](../frontend/src/components/Map/AnnotationLayer.tsx):
+
+```ts
+try {
+  await annotationsService.updateAnnotation(...);
+} catch {
+  showMapError(leafletMap, 'Failed to update annotation.');
+}
+```
+
+It appends a `.map-error-banner` div to the map container and auto-removes
+it after 5 seconds. The CSS lives in [`frontend/src/index.css`](../frontend/src/index.css).
+Only use this pattern for Leaflet event handlers — React components
+should use component-local error state with inline banner display.

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -1,0 +1,103 @@
+# Developer Guide
+
+Conventions and shared utilities used across the codebase. Follow these
+patterns when adding new controllers, components, or services so the
+codebase stays internally consistent.
+
+## Backend (C++)
+
+### Error responses
+
+All controllers emit errors as JSON via the shared helpers in
+[`backend/src/ErrorResponse.h`](../backend/src/ErrorResponse.h):
+
+```cpp
+#include "ErrorResponse.h"
+
+// In a controller, for a one-liner:
+callback(errorResponse(drogon::k404NotFound, "not_found", "Map not found"));
+
+// Or build the JSON first (useful if you need to attach extra fields):
+auto body = errorJson("bad_request", "Invalid input");
+body["field"] = "title";
+auto resp = drogon::HttpResponse::newHttpJsonResponse(body);
+resp->setStatusCode(drogon::k400BadRequest);
+callback(resp);
+```
+
+Every error response has the shape `{"error": "<code>", "message": "<text>"}`.
+The frontend relies on this — don't construct error JSON inline with other
+keys.
+
+**Do not** define local `static Json::Value errorJson(...)` helpers in new
+controllers. Always include the shared header.
+
+### Filter failure callbacks
+
+Filters (`JwtFilter`, `TenantFilter`, etc.) that use `execSqlAsync` must
+wrap `failCb` in a `shared_ptr<FilterCallback>` before capturing it into
+both the success and error lambdas. A plain `std::move` into two captures
+causes a `std::bad_function_call` crash because the second lambda moves
+from a moved-from object.
+
+See the pattern in [`backend/src/filters/JwtFilter.cpp`](../backend/src/filters/JwtFilter.cpp).
+
+### Audit logging
+
+All auditable events use `AuditLog::record(...)` and are fire-and-forget
+(no callback chain). See [`backend/src/AuditLog.h`](../backend/src/AuditLog.h)
+for the signature.
+
+## Frontend (React / TypeScript)
+
+### Handling API errors in components
+
+Use the helpers in [`frontend/src/utils/errors.ts`](../frontend/src/utils/errors.ts)
+instead of inline axios/AxiosError handling:
+
+```tsx
+import { extractApiError, getApiErrorCode } from '@/utils/errors';
+
+try {
+  await mapsService.createMap(data);
+} catch (err) {
+  setError(extractApiError(err, 'Failed to create map.'));
+}
+```
+
+When you need custom UX for specific backend error codes (e.g.,
+`email_taken`, `username_taken`), use `getApiErrorCode(err)` to get the
+machine-readable code and fall back to `extractApiError` for unknown cases.
+
+**Do not** reach into `(err as AxiosError<ApiError>).response?.data` directly
+in component code — keep that knowledge in the `utils/errors.ts` helpers.
+
+### Service layer request types
+
+The service layer uses dedicated TypeScript types for each request:
+
+- `CreateMapRequest` / `UpdateMapRequest`
+- `CreateAnnotationRequest` / `UpdateAnnotationRequest`
+- `CreateNoteRequest` / `UpdateNoteRequest`
+- `CreateNoteGroupRequest` / `UpdateNoteGroupRequest`
+
+**Do not** use `Partial<CreateXRequest>` as an update type. The `Update*`
+variant exists to express fields that are genuinely optional on update
+(e.g., `color: string | null` for "clear this field") versus fields that
+are simply unset (`undefined`).
+
+### Component decomposition
+
+Feature panels that grow past ~300 lines should be decomposed into
+focused subcomponents that sit alongside the parent in the same folder.
+See [`frontend/src/components/Notes/`](../frontend/src/components/Notes/)
+for the pattern: `NotesPanel.tsx` coordinates, while `NoteCard.tsx`,
+`NoteForm.tsx`, and `GroupForm.tsx` handle the leaf UI.
+
+### No `alert()` or silent catches
+
+- Errors must be displayed to the user (inline banner, toast, etc.).
+- Don't use `alert()` — use the component's error state instead.
+- Don't `catch` and only `console.error()` — that's a silent failure.
+  For Leaflet popup handlers where React state isn't available, use the
+  `showMapError()` helper in [`AnnotationLayer.tsx`](../frontend/src/components/Map/AnnotationLayer.tsx).

--- a/docs/SETUP-LOCAL-DEV.md
+++ b/docs/SETUP-LOCAL-DEV.md
@@ -169,7 +169,29 @@ docker compose exec mysql mysql -uroot -prootpassword annotated_maps \
 
 ---
 
-## 5. Day-to-day development
+## 5. Running frontend checks locally
+
+Before opening a PR, run the same checks CI runs so you don't eat a slow
+round-trip. These run in the local npm install, not in Docker:
+
+```bash
+cd frontend
+
+# TypeScript type check (no output on success)
+npx tsc --noEmit
+
+# ESLint (fails on any warning — max-warnings 0)
+npm run lint
+
+# npm audit (PR CI fails only on critical; lower severities are noted in #31)
+npm audit --audit-level=critical
+```
+
+The ESLint config lives at [`frontend/.eslintrc.cjs`](../frontend/.eslintrc.cjs).
+If you need to disable a rule on a specific line, use
+`// eslint-disable-next-line <rule-name>` with a comment explaining why.
+
+## 6. Day-to-day development
 
 ```bash
 # Rebuild after code changes
@@ -192,7 +214,7 @@ docker compose exec mysql mysql -uroot -prootpassword annotated_maps
 
 ---
 
-## 6. Resource usage
+## 7. Resource usage
 
 | Resource | Approximate usage |
 |---|---|

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -1,3 +1,7 @@
+// All components catching API errors should import from this file.
+// Do not reach into AxiosError.response.data directly in component code.
+// See docs/DEVELOPER-GUIDE.md.
+
 import { AxiosError } from 'axios';
 import type { ApiError } from '@/types';
 


### PR DESCRIPTION
## Summary

Follow-up to recent CI / refactor work (#19, #16, #17, #20, #18, #21, #33, #42, #43). Those PRs introduced new conventions and shared helpers but didn't all document them, so future code could drift back to older patterns.

This PR adds a canonical conventions doc and fills targeted gaps uncovered by an audit across all seven issues.

## Files changed

- \`backend/src/ErrorResponse.h\` — Header comment pointing to DEVELOPER-GUIDE.md
- \`docs/DEVELOPER-GUIDE.md\` — New: conventions doc covering backend error responses, filter callbacks, audit logging, CI compose override, soak test timeout context, frontend API error handling, service request types, component decomposition, no-alert rule, and the Leaflet \`showMapError()\` / \`.map-error-banner\` pattern
- \`docs/SETUP-LOCAL-DEV.md\` — New "Running frontend checks locally" section with lint, tsc, and npm audit commands
- \`frontend/src/utils/errors.ts\` — Header comment pointing to DEVELOPER-GUIDE.md

## Gaps deliberately deferred

- **Explicit test coverage for \`{error, message}\` response shape** — filed as #52. Legitimate gap but out of scope for a docs PR.
- **Dedicated \`ERROR-CODES.md\`** — rejected. Codes are visible in controller source; the frontend only switches on a small set (\`email_taken\`, \`username_taken\`). A separate doc would become another source of drift.
- **\"Must pass lint before test\" statement** — already visible in \`needs: [lint, compile]\` in \`pr-tests.yml\`. Redundant to repeat in docs.
- **Claims of an ESLint no-alert rule** — we don't have one; it's a convention. DEVELOPER-GUIDE.md now says this explicitly so reviewers know to check for it.

## Test plan

- [ ] All file links in DEVELOPER-GUIDE.md resolve (verified locally)
- [x] Markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)