### PR TITLE
CI: Only post PR test summary comment on failure

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -250,6 +250,10 @@ jobs:
               c.body?.startsWith(marker) || c.body?.startsWith(markerFail)
             );
 
+            // On success with no existing comment: skip posting so the PR
+            // author doesn't get a PR-comment email for every green run.
+            // On failure OR when updating an existing comment (edits don't
+            // trigger email notifications), post/update as usual.
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
@@ -257,7 +261,7 @@ jobs:
                 comment_id: existing.id,
                 body,
               });
-            } else {
+            } else if (total.failed > 0) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/docs/TESTING-BACKEND.md
+++ b/docs/TESTING-BACKEND.md
@@ -109,10 +109,17 @@ pre-built image tags to the services so `docker compose up` skips rebuilding.
 If either lint or compile fails, the test job is skipped entirely, giving
 faster feedback than waiting for the full stack build.
 
-After tests run, the test job posts a summary comment on the PR with
-pass/fail counts per suite (database, backend), a table of totals, and
-a link to full logs. On failure, the specific `FAIL:` lines are included.
-The comment is updated in place on re-runs to avoid clutter.
+After tests run, the test job posts a summary comment on the PR only
+when at least one suite failed. The comment shows pass/fail counts per
+suite (database, backend), a table of totals, the specific `FAIL:`
+lines, and a link to full logs.
+
+On re-runs, the comment is updated in place (comment edits don't
+trigger email notifications, so the PR author isn't re-notified once
+they've seen the initial failure). A successful re-run after a prior
+failure still updates the existing comment to ✅ so the PR doesn't
+carry a stale failure indicator. Successful first runs post nothing —
+that's why you no longer get an email for every green build.
 
 To enable merge blocking, configure branch protection on `main`:
 1. Go to Settings → Branches → Add rule for `main`


### PR DESCRIPTION
## Summary
- Successful runs no longer create a new PR comment (which was sending email notifications for every green build).
- When a prior failing run has already posted a comment, a subsequent run still **updates** it in place — including updating ❌ to ✅ on a successful fix — so the PR doesn't carry a stale failure indicator.
- Comment edits don't trigger email notifications, so you only get emailed on the initial failure, not on subsequent updates.

## Files changed
- `.github/workflows/pr-tests.yml` — Wrap `createComment` in a `total.failed > 0` check so new comments are only posted on failure; update inside `if (existing)` branch remains unchanged
- `docs/TESTING-BACKEND.md` — Document the new posting behavior

## Test plan
- [ ] Open this PR — tests should pass, and no comment should be posted (verifying no-comment-on-success)
- [ ] If a follow-up PR fails, a comment should be posted and email sent once
- [ ] If that PR is fixed and re-run succeeds, the comment should be updated to ✅ without a new email

🤖 Generated with [Claude Code](https://claude.com/claude-code)