### PR TITLE
Security: Fix H4-H5 (Argon2 env vars, SSO secret env var)

### DIFF
--- a/backend/src/controllers/AuthController.cpp
+++ b/backend/src/controllers/AuthController.cpp
@@ -5,17 +5,40 @@
 #include <jwt-cpp/jwt.h>
 #include <sodium.h>
 #include <chrono>
+#include <cstdlib>
+#include <cstring>
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+// Argon2id cost parameters. Configurable via environment:
+//   ARGON2_OPSLIMIT  — iteration count (default: MIN = 1)
+//   ARGON2_MEMLIMIT  — memory in bytes (default: MIN = 8 MiB)
+//
+// Defaults are MIN-safe for local dev on x86_64-on-ARM emulation, where
+// INTERACTIVE (4 iter, 64 MiB) hangs. Production deployments MUST set
+// these to at least INTERACTIVE: ARGON2_OPSLIMIT=4, ARGON2_MEMLIMIT=67108864.
+// See docs/DEVELOPER-GUIDE.md.
+static unsigned long long getArgon2OpsLimit() {
+    const char* env = std::getenv("ARGON2_OPSLIMIT");
+    if (env && std::strlen(env) > 0) {
+        try { return std::stoull(env); } catch (...) {}
+    }
+    return crypto_pwhash_OPSLIMIT_MIN;
+}
+
+static size_t getArgon2MemLimit() {
+    const char* env = std::getenv("ARGON2_MEMLIMIT");
+    if (env && std::strlen(env) > 0) {
+        try { return std::stoull(env); } catch (...) {}
+    }
+    return crypto_pwhash_MEMLIMIT_MIN;
+}
+
 static std::string hashPassword(const std::string& password) {
     char hashed[crypto_pwhash_STRBYTES];
-    // Use MODERATE params: 3 iterations, 256MB memory.
-    // INTERACTIVE (2 iter, 64MB) hangs under x86_64 emulation on Apple Silicon.
-    // For production on native hardware, consider OPSLIMIT_INTERACTIVE/MEMLIMIT_INTERACTIVE.
     if (crypto_pwhash_str(hashed, password.c_str(), password.size(),
-                          crypto_pwhash_OPSLIMIT_MIN,
-                          crypto_pwhash_MEMLIMIT_MIN) != 0) {
+                          getArgon2OpsLimit(),
+                          getArgon2MemLimit()) != 0) {
         throw std::runtime_error("Argon2id hashing failed (out of memory?)");
     }
     return std::string(hashed);

--- a/backend/src/controllers/SsoController.cpp
+++ b/backend/src/controllers/SsoController.cpp
@@ -180,8 +180,18 @@ void SsoController::callback(
             std::string tokenEndpoint    = ssoConfig["token_endpoint"].asString();
             std::string userinfoEndpoint = ssoConfig["userinfo_endpoint"].asString();
             std::string clientId         = ssoConfig["client_id"].asString();
-            std::string clientSecret     = ssoConfig["client_secret"].asString();
             std::string redirectUri      = ssoConfig["redirect_uri"].asString();
+
+            // H5: client_secret is read from SSO_CLIENT_SECRET_<ORG_ID> env var,
+            // never from the database. See docs/DEVELOPER-GUIDE.md.
+            std::string secretEnv = "SSO_CLIENT_SECRET_" + std::to_string(orgId);
+            const char* clientSecretPtr = std::getenv(secretEnv.c_str());
+            if (!clientSecretPtr || std::string(clientSecretPtr).empty()) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "server_error", "SSO is not available"));
+                return;
+            }
+            std::string clientSecret = clientSecretPtr;
 
             std::string tokenBody =
                 "grant_type=authorization_code"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,13 @@ services:
       # env var is set. Production deployments MUST NOT set this — they
       # must supply a real JWT_SECRET instead.
       - ALLOW_PLACEHOLDER_SECRETS=1
+      # Argon2id cost parameters (dev-safe defaults; production MUST set
+      # ARGON2_OPSLIMIT=4 ARGON2_MEMLIMIT=67108864 or higher). See
+      # docs/DEVELOPER-GUIDE.md.
+      #
+      # SSO client_secret is read from SSO_CLIENT_SECRET_<ORG_ID> env vars,
+      # e.g. SSO_CLIENT_SECRET_1=my-real-idp-secret. Not set by default
+      # because there's no dev IdP. See docs/DEVELOPER-GUIDE.md.
 
   # ── React Frontend (Vite dev server) ────────────────────────────────────────
   frontend:

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -191,3 +191,50 @@ environment. Local dev and CI override this by setting
 `ALLOW_PLACEHOLDER_SECRETS=1` in `docker-compose.yml` — this env var
 **must never** be set in production compose/env files. Production
 deployment must supply a real `JWT_SECRET` (min 32 chars).
+
+### Argon2id cost parameters
+
+Password hashing cost is configurable via environment variables read
+at hash time (not startup) in `AuthController.cpp`:
+
+- `ARGON2_OPSLIMIT` — iteration count. Default: `crypto_pwhash_OPSLIMIT_MIN` (1).
+- `ARGON2_MEMLIMIT` — memory in bytes. Default: `crypto_pwhash_MEMLIMIT_MIN` (8 MiB).
+
+Dev/CI uses the MIN defaults because `OPSLIMIT_INTERACTIVE`
+(4 iterations, 64 MiB) hangs under x86_64 emulation on Apple Silicon.
+
+**Production MUST set at least INTERACTIVE:**
+
+```
+ARGON2_OPSLIMIT=4
+ARGON2_MEMLIMIT=67108864   # 64 MiB
+```
+
+Higher values (`SENSITIVE`: 8 ops, 256 MiB) are appropriate if you
+have the CPU budget. Measure login latency at whatever value you
+choose — you want it to be a couple hundred ms, not many seconds.
+
+### SSO `client_secret` storage
+
+`sso_providers.config` in the database holds SSO provider metadata
+(endpoints, `client_id`, `redirect_uri`) but **NEVER** the client
+secret. The backend reads `client_secret` from the environment variable
+`SSO_CLIENT_SECRET_<ORG_ID>` (e.g. `SSO_CLIENT_SECRET_1`) at request
+time. If the env var is missing or empty, the SSO flow returns a
+generic `500 SSO is not available`.
+
+This moves the highest-value secret out of the DB. Production
+deployments typically wire these env vars up via the platform's secret
+manager (Kubernetes Secrets, AWS Secrets Manager + External Secrets,
+Docker Secrets, etc.). Never commit real client secrets to `.env`
+files that are tracked by git.
+
+For local dev against a test IdP, add a `docker-compose.override.yml`
+(gitignored) with entries like:
+
+```yaml
+services:
+  backend:
+    environment:
+      - SSO_CLIENT_SECRET_1=your-real-test-idp-secret
+```

--- a/docs/SECURITY-AUDIT.md
+++ b/docs/SECURITY-AUDIT.md
@@ -11,11 +11,11 @@
 
 | Severity | Total open | Fixed since audit |
 |---|---:|---:|
-| High | 2 | 3 (H1, H2, H3 — see #55) |
+| High | 0 | 5 (H1, H2, H3 in #55; H4, H5 in #56) |
 | Medium | 12 | 1 (M13 — fixed with H1) |
 | Low | 5 | 0 |
 
-No critical findings. Remaining High items are production-deployment concerns (Argon2id parameters, SSO `client_secret` storage — tracked in #56).
+All High findings are closed. Remaining open items are Mediums (SSO hardening, rate limiter scope, JWT storage, and the Medium grab-bag tracked in #57, #58) and Lows.
 
 Deliberate design trade-offs are listed separately below.
 
@@ -29,7 +29,7 @@ The application implements the following security controls (verified in this aud
 
 ### Backend
 - **Parameterized queries:** All SQL uses Drogon's `execSqlAsync` bind arguments. No string concatenation, no dynamic column names.
-- **Argon2id password hashing:** libsodium's `crypto_pwhash_str`. Legacy SHA-256 hashes rejected at login.
+- **Argon2id password hashing:** libsodium's `crypto_pwhash_str`. Cost parameters (`OPSLIMIT`/`MEMLIMIT`) are configurable via `ARGON2_OPSLIMIT`/`ARGON2_MEMLIMIT` env vars; defaults are dev-safe MIN values. Production must set at least INTERACTIVE (4 ops, 64 MiB). Legacy SHA-256 hashes rejected at login.
 - **Per-request user verification:** `JwtFilter` checks `users.status` against the database on every authenticated request. Status changes take effect immediately.
 - **JWT scoping:** HS256, `issuer` + `audience` (`annotated-maps`) + `orgId` claims all validated.
 - **Shared error helpers:** `ErrorResponse.h` provides `errorJson()`/`errorResponse()` — removes duplication and ensures consistent `{error, message}` shape.
@@ -40,7 +40,7 @@ The application implements the following security controls (verified in this aud
 - **Audit logging:** `audit_log` records security events (login success/failure, registration, SSO login, member add/remove, permission changes) with atomic success/failure counters.
 - **Security headers:** `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`.
 - **CORS allowlist:** Origins listed in `allowed_origins` config; unknown origins receive no CORS headers.
-- **Secrets management:** `JWT_SECRET` env var overrides config, minimum 32 characters enforced. Config placeholders (`CHANGE_ME...`) cause fatal startup exit unless `ALLOW_PLACEHOLDER_SECRETS=1` is explicitly set (dev-only).
+- **Secrets management:** `JWT_SECRET` env var overrides config, minimum 32 characters enforced. Config placeholders (`CHANGE_ME...`) cause fatal startup exit unless `ALLOW_PLACEHOLDER_SECRETS=1` is explicitly set (dev-only). SSO `client_secret` is read from `SSO_CLIENT_SECRET_<ORG_ID>` env vars and never stored in the database.
 - **Registration privacy at the login endpoint:** Login returns identical error for wrong password and nonexistent email.
 - **SSO enumeration resistance:** SSO initiate returns generic "SSO is not available" for all error cases.
 
@@ -59,32 +59,6 @@ The application implements the following security controls (verified in this aud
 ---
 
 ## Open findings
-
-### High
-
-#### H4 (NEW): Argon2id parameters set to `*_MIN` values
-
-**File:** `backend/src/controllers/AuthController.cpp:17-27`
-
-Current settings (`OPSLIMIT_MIN`, `MEMLIMIT_MIN`) were chosen to work around x86_64-on-ARM emulation slowness during development. The in-code comment notes this is not appropriate for production. `OPSLIMIT_MIN = 1` and `MEMLIMIT_MIN = 8 MB` are meaningfully weaker than `OPSLIMIT_INTERACTIVE = 4` and `MEMLIMIT_INTERACTIVE = 64 MB`.
-
-**Fix:** Make the parameters configurable via env var (`ARGON2_OPSLIMIT`, `ARGON2_MEMLIMIT`) and document recommended production values.
-
-**Effort:** Small (~20 lines).
-
----
-
-#### H5 (NEW): SSO provider `client_secret` stored in plaintext in the database
-
-**File:** `database/migrations/001_schema.sql:92-99`, `backend/src/controllers/SsoController.cpp:170`
-
-The `sso_providers.config` JSON column contains `client_secret` as plaintext. Any actor with database read access (DBAs, backup systems, replicas, compromised application) can retrieve every tenant's IdP credential.
-
-**Fix:** Two options — (a) application-layer encryption of the secret field before insert and on read, with key in a secret manager/env var, or (b) move `client_secret` out of the database entirely and into a secret manager keyed by `org_id`. Option (b) is cleaner operationally.
-
-**Effort:** Moderate (~100 lines + deployment runbook change).
-
----
 
 ### Medium
 
@@ -354,3 +328,36 @@ unless `ALLOW_PLACEHOLDER_SECRETS=1` is explicitly set. The dev
 must never appear in production compose/env files. An env var
 `JWT_SECRET` shorter than 32 characters also now exits fatally instead
 of silently falling back to the config value.
+
+### H4 — Argon2id parameters at `*_MIN` values
+
+**Closed by PR #56 (2026-04-21).**
+
+Password hashing used `crypto_pwhash_OPSLIMIT_MIN` / `crypto_pwhash_MEMLIMIT_MIN`
+(1 iteration, 8 MiB) hardcoded. The MIN values were chosen to work
+around x86_64-on-ARM emulation slowness during local dev but are far
+weaker than the recommended INTERACTIVE values (4 iterations, 64 MiB)
+for online authentication.
+
+**Fix applied:** `hashPassword()` now reads `ARGON2_OPSLIMIT` and
+`ARGON2_MEMLIMIT` from the environment and falls back to MIN if unset.
+`docker-compose.yml` comments document the expected production values
+(`ARGON2_OPSLIMIT=4`, `ARGON2_MEMLIMIT=67108864`). Dev/CI defaults
+remain MIN for performance.
+
+### H5 — SSO `client_secret` stored in plaintext in the database
+
+**Closed by PR #56 (2026-04-21).**
+
+The `sso_providers.config` JSON column held `client_secret` in
+plaintext. Any actor with database read access (DBAs, backups, replicas,
+compromised backend) could retrieve every tenant's IdP credential.
+
+**Fix applied:** `SsoController::callback` now reads the client secret
+from the `SSO_CLIENT_SECRET_<ORG_ID>` environment variable (e.g.
+`SSO_CLIENT_SECRET_1`) instead of the DB. If the env var is missing or
+empty, the controller returns a generic 500 "SSO is not available",
+consistent with the SSO enumeration-resistance posture. The
+`sso_providers.config` JSON is no longer expected to contain
+`client_secret` — any legacy value is ignored. No DB migration is
+required for v0.1 because no production SSO data exists yet.

--- a/docs/SETUP-LOCAL-DEV.md
+++ b/docs/SETUP-LOCAL-DEV.md
@@ -254,3 +254,15 @@ env var, either add it back or set a real `JWT_SECRET` (min 32 chars).
 **Do not set `ALLOW_PLACEHOLDER_SECRETS` in any production
 deployment** — it's a safety gate specifically to prevent silent
 placeholder deployments.
+
+**SSO flow returns "SSO is not available" in callback**
+The backend reads SSO client secrets from the environment, not the
+database. Set `SSO_CLIENT_SECRET_<ORG_ID>=...` in a
+`docker-compose.override.yml` (gitignored) for your test IdP. See
+`docs/DEVELOPER-GUIDE.md` → "SSO client_secret storage".
+
+**Login/registration feels fast — is Argon2id OK?**
+By default the backend uses `ARGON2_OPSLIMIT_MIN` / `ARGON2_MEMLIMIT_MIN`
+(1 iteration, 8 MiB), which is dev-safe but weak for production.
+See `docs/DEVELOPER-GUIDE.md` → "Argon2id cost parameters" for the
+production settings.


### PR DESCRIPTION
## Summary

Closes #56. Both Highs are production-deployment concerns: neither is exploitable in current dev state, but both must land before a production rollout.

- **H4 — Argon2id cost parameters configurable via env.** `hashPassword()` reads \`ARGON2_OPSLIMIT\` and \`ARGON2_MEMLIMIT\` from the environment. Falls back to \`crypto_pwhash_OPSLIMIT_MIN\` / \`crypto_pwhash_MEMLIMIT_MIN\` if unset (preserves dev defaults for x86_64-on-ARM emulation). \`docker-compose.yml\` comments document the production values (\`ARGON2_OPSLIMIT=4\`, \`ARGON2_MEMLIMIT=67108864\`). Verified env vars take effect — SENSITIVE settings registration is ~7x slower than INTERACTIVE.
- **H5 — SSO \`client_secret\` out of the DB, into env vars.** \`SsoController::callback\` reads the secret from \`SSO_CLIENT_SECRET_<ORG_ID>\` (e.g. \`SSO_CLIENT_SECRET_1\`) rather than the \`sso_providers.config\` JSON. Missing or empty env var → generic \`500 SSO is not available\`. Legacy \`client_secret\` values in the DB are now silently ignored. No schema migration needed for v0.1 since no production SSO data exists.

## Files changed

- \`backend/src/controllers/AuthController.cpp\` — H4: add \`getArgon2OpsLimit()\` / \`getArgon2MemLimit()\` helpers reading env; \`hashPassword()\` uses them
- \`backend/src/controllers/SsoController.cpp\` — H5: read \`SSO_CLIENT_SECRET_<ORG_ID>\` instead of parsing \`client_secret\` from \`sso_providers.config\`
- \`docker-compose.yml\` — Comment block documenting both env-var patterns and the SSO override approach for dev
- \`docs/DEVELOPER-GUIDE.md\` — New sections: "Argon2id cost parameters" and "SSO \`client_secret\` storage"
- \`docs/SECURITY-AUDIT.md\` — Move H4/H5 to closed findings, update summary counts (now 0 open Highs), refresh posture bullets for Argon2 and SSO secret storage
- \`docs/SETUP-LOCAL-DEV.md\` — Add troubleshooting entries pointing to the new DEVELOPER-GUIDE sections

## Test plan

- [x] \`python3 database/tests/run-db-tests.py\` → 110 passed
- [x] \`python3 backend/tests/run-tests.py --tier fast\` → all suites passed
- [x] Argon2 env vars verified: registration at INTERACTIVE (4,64MB) is ~156ms, at SENSITIVE (8,256MB) is ~1042ms — ~7x scaling matches the cost ratio, confirming the env vars are honored
- [x] Docker stack boots cleanly with new env-var comments
- [ ] Manual: production-like run with \`ARGON2_OPSLIMIT=4 ARGON2_MEMLIMIT=67108864\` — already tested via the docker run above
- [ ] Manual: SSO flow against a real test IdP — deferred; no dev IdP configured. Will be verifiable when SSO hardening lands in #58 and a test IdP harness is set up

## Public-repo diff scan

- Live credentials: **none** (only env-var *names* and \`CHANGE_ME\` placeholders)
- Real PII: **none** (the \`argon_test@test.com\` / \`argon_sens@test.com\` addresses were ephemeral test data during local verification, not committed)
- Internal refs / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)