### PR TITLE
Security: Fix M6-M12 + L4 (medium-severity grab-bag)

### DIFF
--- a/backend/src/ErrorResponse.h
+++ b/backend/src/ErrorResponse.h
@@ -25,3 +25,31 @@ inline drogon::HttpResponsePtr errorResponse(
     resp->setStatusCode(status);
     return resp;
 }
+
+// ─── Input length limits ─────────────────────────────────────────────────────
+// Server-side caps on user-supplied string fields. These are the ceiling the
+// application enforces; the database columns are VARCHAR(255) for name-like
+// fields and TEXT (64 KiB) for long-form content. Keeping app limits below
+// DB limits avoids silent truncation.
+
+inline constexpr size_t MAX_TITLE_LEN       = 255;
+inline constexpr size_t MAX_NAME_LEN        = 255;
+inline constexpr size_t MAX_DESCRIPTION_LEN = 10000;
+inline constexpr size_t MAX_TEXT_LEN        = 10000;
+
+// Returns true if `value.size() <= max`. If too long, sends a 400 response
+// via `callback` (caller should `return` immediately on false). Use this at
+// controller entry so oversized input is rejected before any DB work.
+inline bool checkMaxLen(
+    const std::string& fieldName,
+    const std::string& value,
+    size_t max,
+    const std::function<void(const drogon::HttpResponsePtr&)>& callback) {
+    if (value.size() > max) {
+        callback(errorResponse(drogon::k400BadRequest, "bad_request",
+            "Field '" + fieldName + "' exceeds maximum length (" +
+            std::to_string(max) + " characters)"));
+        return false;
+    }
+    return true;
+}

--- a/backend/src/controllers/AnnotationController.cpp
+++ b/backend/src/controllers/AnnotationController.cpp
@@ -1,4 +1,5 @@
 #include "AnnotationController.h"
+#include "AuditLog.h"
 #include "ErrorResponse.h"
 #include <drogon/drogon.h>
 
@@ -98,6 +99,10 @@ void AnnotationController::createAnnotation(
     std::string title       = (*body)["title"].asString();
     std::string description = (*body).get("description", "").asString();
 
+    // M8: length limits
+    if (!checkMaxLen("title", title, MAX_TITLE_LEN, callback)) return;
+    if (!checkMaxLen("description", description, MAX_DESCRIPTION_LEN, callback)) return;
+
     // Validate GeoJSON structure
     const auto& geoObj = (*body)["geoJson"];
     if (!geoObj.isObject() || !geoObj.isMember("type") || !geoObj.isMember("coordinates")) {
@@ -142,26 +147,19 @@ void AnnotationController::createAnnotation(
                 callback(resp);
                 return;
             }
-            // L4 fix: enforce per-map annotation limit
+            // M9 + L4: atomic INSERT-with-limit-check (see MapController for rationale)
             auto db2 = drogon::app().getDbClient();
             db2->execSqlAsync(
-                "SELECT COUNT(*) AS cnt FROM annotations WHERE map_id=?",
-                [callback, mapId, userId, callerUsername, type, title, description, geoJsonStr]
-                (const drogon::orm::Result& rc) {
-                    static const int MAX_ANNOTATIONS_PER_MAP = 5000;
-                    if (!rc.empty() && rc[0]["cnt"].as<int>() >= MAX_ANNOTATIONS_PER_MAP) {
-                        auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                            errorJson("limit_exceeded", "Annotation limit reached for this map"));
-                        resp->setStatusCode(drogon::k400BadRequest);
-                        callback(resp);
-                        return;
-                    }
-                    auto db3 = drogon::app().getDbClient();
-                    db3->execSqlAsync(
                 "INSERT INTO annotations (map_id, created_by, type, title, description, geo_json) "
-                "VALUES (?,?,?,?,?,?)",
+                "SELECT ?,?,?,?,?,? FROM dual "
+                "WHERE (SELECT COUNT(*) FROM annotations WHERE map_id=?) < 5000",
                 [callback, mapId, userId, callerUsername, type, title, description, geoJsonStr]
                 (const drogon::orm::Result& r2) {
+                    if (r2.affectedRows() == 0) {
+                        callback(errorResponse(drogon::k400BadRequest,
+                            "limit_exceeded", "Annotation limit reached for this map"));
+                        return;
+                    }
                     int newId = static_cast<int>(r2.insertId());
                     Json::Value a;
                     a["id"]                = newId;
@@ -183,20 +181,10 @@ void AnnotationController::createAnnotation(
                     callback(resp);
                 },
                 [callback](const drogon::orm::DrogonDbException&) {
-                    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                        errorJson("db_error", "Failed to create annotation"));
-                    resp->setStatusCode(drogon::k500InternalServerError);
-                    callback(resp);
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to create annotation"));
                 },
-                mapId, userId, type, title, description, geoJsonStr);
-                },
-                [callback](const drogon::orm::DrogonDbException&) {
-                    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                        errorJson("db_error", "Failed to check annotation count"));
-                    resp->setStatusCode(drogon::k500InternalServerError);
-                    callback(resp);
-                },
-                mapId);
+                mapId, userId, type, title, description, geoJsonStr, mapId);
         },
         [callback](const drogon::orm::DrogonDbException&) {
             auto resp = drogon::HttpResponse::newHttpJsonResponse(
@@ -284,6 +272,10 @@ void AnnotationController::updateAnnotation(
     std::string newTitle = (*body).get("title", "").asString();
     std::string newDesc  = (*body).get("description", "").asString();
 
+    // M8: length limits
+    if (!checkMaxLen("title", newTitle, MAX_TITLE_LEN, callback)) return;
+    if (!checkMaxLen("description", newDesc, MAX_DESCRIPTION_LEN, callback)) return;
+
     // Serialize geoJson if provided
     std::string newGeoJson;
     bool hasGeoJson = body->isMember("geoJson") && !(*body)["geoJson"].isNull();
@@ -302,24 +294,25 @@ void AnnotationController::updateAnnotation(
         "    a.geo_json    = IF(?=0, a.geo_json, ?) "
         "WHERE a.id=? AND a.map_id=? AND m.tenant_id=? "
         "  AND (m.owner_id=? OR mp.level IN ('edit','moderate','admin') OR a.created_by=?)",
-        [callback, id](const drogon::orm::Result& r) {
+        [callback, req, userId, tenantId, mapId, id](const drogon::orm::Result& r) {
             if (r.affectedRows() == 0) {
-                auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                    errorJson("forbidden", "Cannot update annotation"));
-                resp->setStatusCode(drogon::k403Forbidden);
-                callback(resp);
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Cannot update annotation"));
                 return;
             }
+            // M12: audit the update
+            Json::Value detail;
+            detail["mapId"] = mapId;
+            detail["annotationId"] = id;
+            AuditLog::record("annotation_update", req, userId, 0, tenantId, detail);
             Json::Value v;
             v["id"]      = id;
             v["updated"] = true;
             callback(drogon::HttpResponse::newHttpJsonResponse(v));
         },
         [callback](const drogon::orm::DrogonDbException&) {
-            auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                errorJson("db_error", "Failed to update annotation"));
-            resp->setStatusCode(drogon::k500InternalServerError);
-            callback(resp);
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to update annotation"));
         },
         userId,
         newTitle, newTitle,
@@ -343,23 +336,24 @@ void AnnotationController::deleteAnnotation(
         "LEFT JOIN map_permissions mp ON mp.map_id=m.id AND mp.user_id=? "
         "WHERE a.id=? AND a.map_id=? AND m.tenant_id=? "
         "  AND (m.owner_id=? OR mp.level IN ('edit','moderate','admin') OR a.created_by=?)",
-        [callback](const drogon::orm::Result& r) {
+        [callback, req, userId, tenantId, mapId, id](const drogon::orm::Result& r) {
             if (r.affectedRows() == 0) {
-                auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                    errorJson("forbidden", "Cannot delete annotation"));
-                resp->setStatusCode(drogon::k403Forbidden);
-                callback(resp);
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Cannot delete annotation"));
                 return;
             }
+            // M12: audit the deletion
+            Json::Value detail;
+            detail["mapId"] = mapId;
+            detail["annotationId"] = id;
+            AuditLog::record("annotation_delete", req, userId, 0, tenantId, detail);
             auto resp = drogon::HttpResponse::newHttpResponse();
             resp->setStatusCode(drogon::k204NoContent);
             callback(resp);
         },
         [callback](const drogon::orm::DrogonDbException&) {
-            auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                errorJson("db_error", "Failed to delete annotation"));
-            resp->setStatusCode(drogon::k500InternalServerError);
-            callback(resp);
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to delete annotation"));
         },
         userId, id, mapId, tenantId, userId, userId);
 }

--- a/backend/src/controllers/AnnotationController.h
+++ b/backend/src/controllers/AnnotationController.h
@@ -20,22 +20,22 @@ public:
                       drogon::Get, "JwtFilter", "TenantFilter");
         ADD_METHOD_TO(AnnotationController::createAnnotation,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/annotations",
-                      drogon::Post, "JwtFilter", "TenantFilter");
+                      drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
         ADD_METHOD_TO(AnnotationController::getAnnotation,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/annotations/{id}",
                       drogon::Get, "JwtFilter", "TenantFilter");
         ADD_METHOD_TO(AnnotationController::updateAnnotation,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/annotations/{id}",
-                      drogon::Put, "JwtFilter", "TenantFilter");
+                      drogon::Put, "JwtFilter", "TenantFilter", "RateLimitFilter");
         ADD_METHOD_TO(AnnotationController::deleteAnnotation,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/annotations/{id}",
-                      drogon::Delete, "JwtFilter", "TenantFilter");
+                      drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
         ADD_METHOD_TO(AnnotationController::addMedia,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/annotations/{id}/media",
-                      drogon::Post, "JwtFilter", "TenantFilter");
+                      drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
         ADD_METHOD_TO(AnnotationController::deleteMedia,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/annotations/{id}/media/{mediaId}",
-                      drogon::Delete, "JwtFilter", "TenantFilter");
+                      drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
     METHOD_LIST_END
 
     void listAnnotations(const drogon::HttpRequestPtr&,

--- a/backend/src/controllers/MapController.cpp
+++ b/backend/src/controllers/MapController.cpp
@@ -115,27 +115,28 @@ void MapController::createMap(
     double      centerLng   = (*body).get("centerLng", 0.0).asDouble();
     int         zoom        = (*body).get("zoom", 3).asInt();
 
-    // L4 fix: enforce per-tenant map limit
+    // M8: enforce input length limits before any DB work
+    if (!checkMaxLen("title", title, MAX_TITLE_LEN, callback)) return;
+    if (!checkMaxLen("description", description, MAX_DESCRIPTION_LEN, callback)) return;
+
+    // M9 + L4: enforce per-tenant map limit atomically. The previous pattern
+    // (SELECT COUNT then INSERT in separate queries) raced — two concurrent
+    // creates could both pass the count check. INSERT ... SELECT ... WHERE
+    // (subquery) evaluates the count and inserts in a single statement; the
+    // affectedRows() == 0 case means the limit was hit.
     auto db = drogon::app().getDbClient();
     db->execSqlAsync(
-        "SELECT COUNT(*) AS cnt FROM maps WHERE tenant_id=?",
-        [callback, userId, tenantId, title, description, centerLat, centerLng, zoom]
-        (const drogon::orm::Result& r) {
-            static const int MAX_MAPS_PER_TENANT = 1000;
-            if (!r.empty() && r[0]["cnt"].as<int>() >= MAX_MAPS_PER_TENANT) {
-                auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                    errorJson("limit_exceeded", "Tenant map limit reached"));
-                resp->setStatusCode(drogon::k400BadRequest);
-                callback(resp);
-                return;
-            }
-            auto db2 = drogon::app().getDbClient();
-            db2->execSqlAsync(
         "INSERT INTO maps (owner_id, tenant_id, title, description, "
         "                  center_lat, center_lng, zoom) "
-        "VALUES (?,?,?,?,?,?,?)",
+        "SELECT ?,?,?,?,?,?,? FROM dual "
+        "WHERE (SELECT COUNT(*) FROM maps WHERE tenant_id=?) < 1000",
         [callback, userId, tenantId, title, description, centerLat, centerLng, zoom]
         (const drogon::orm::Result& r) {
+            if (r.affectedRows() == 0) {
+                callback(errorResponse(drogon::k400BadRequest,
+                    "limit_exceeded", "Tenant map limit reached"));
+                return;
+            }
             int newId = static_cast<int>(r.insertId());
             Json::Value m;
             m["id"]          = newId;
@@ -152,20 +153,10 @@ void MapController::createMap(
             callback(resp);
         },
         [callback](const drogon::orm::DrogonDbException&) {
-            auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                errorJson("db_error", "Failed to create map"));
-            resp->setStatusCode(drogon::k500InternalServerError);
-            callback(resp);
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to create map"));
         },
-        userId, tenantId, title, description, centerLat, centerLng, zoom);
-        },
-        [callback](const drogon::orm::DrogonDbException&) {
-            auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                errorJson("db_error", "Failed to check map count"));
-            resp->setStatusCode(drogon::k500InternalServerError);
-            callback(resp);
-        },
-        tenantId);
+        userId, tenantId, title, description, centerLat, centerLng, zoom, tenantId);
 }
 
 // ─── GET /api/v1/tenants/{tenantId}/maps/{id} ─────────────────────────────────
@@ -261,6 +252,11 @@ void MapController::updateMap(
     // passing pointers to temporaries (which don't compile).
     std::string title       = (*body).get("title", "").asString();
     std::string description = (*body).get("description", "").asString();
+
+    // M8: length limits apply on update too
+    if (!checkMaxLen("title", title, MAX_TITLE_LEN, callback)) return;
+    if (!checkMaxLen("description", description, MAX_DESCRIPTION_LEN, callback)) return;
+
     bool hasLat  = body->isMember("centerLat");
     bool hasLng  = body->isMember("centerLng");
     bool hasZoom = body->isMember("zoom");
@@ -277,24 +273,24 @@ void MapController::updateMap(
         "center_lng  = IF(?, ?, center_lng), "
         "zoom        = IF(?, ?, zoom) "
         "WHERE id=? AND tenant_id=? AND owner_id=?",
-        [callback, id](const drogon::orm::Result& r) {
+        [callback, req, userId, tenantId, id](const drogon::orm::Result& r) {
             if (r.affectedRows() == 0) {
-                auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                    errorJson("forbidden", "Map not found or insufficient permissions"));
-                resp->setStatusCode(drogon::k403Forbidden);
-                callback(resp);
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
                 return;
             }
+            // M12: audit the update
+            Json::Value detail;
+            detail["mapId"] = id;
+            AuditLog::record("map_update", req, userId, 0, tenantId, detail);
             Json::Value v;
             v["id"]      = id;
             v["updated"] = true;
             callback(drogon::HttpResponse::newHttpJsonResponse(v));
         },
         [callback](const drogon::orm::DrogonDbException&) {
-            auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                errorJson("db_error", "Failed to update map"));
-            resp->setStatusCode(drogon::k500InternalServerError);
-            callback(resp);
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to update map"));
         },
         title, title,
         description, description,
@@ -315,23 +311,23 @@ void MapController::deleteMap(
     auto db    = drogon::app().getDbClient();
     db->execSqlAsync(
         "DELETE FROM maps WHERE id=? AND tenant_id=? AND owner_id=?",
-        [callback](const drogon::orm::Result& r) {
+        [callback, req, userId, tenantId, id](const drogon::orm::Result& r) {
             if (r.affectedRows() == 0) {
-                auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                    errorJson("forbidden", "Map not found or insufficient permissions"));
-                resp->setStatusCode(drogon::k403Forbidden);
-                callback(resp);
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
                 return;
             }
+            // M12: audit the deletion
+            Json::Value detail;
+            detail["mapId"] = id;
+            AuditLog::record("map_delete", req, userId, 0, tenantId, detail);
             auto resp = drogon::HttpResponse::newHttpResponse();
             resp->setStatusCode(drogon::k204NoContent);
             callback(resp);
         },
         [callback](const drogon::orm::DrogonDbException&) {
-            auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                errorJson("db_error", "Failed to delete map"));
-            resp->setStatusCode(drogon::k500InternalServerError);
-            callback(resp);
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to delete map"));
         },
         id, tenantId, userId);
 }

--- a/backend/src/controllers/MapController.h
+++ b/backend/src/controllers/MapController.h
@@ -16,25 +16,25 @@ public:
                       drogon::Get, "JwtFilter", "TenantFilter");
         ADD_METHOD_TO(MapController::createMap,
                       "/api/v1/tenants/{tenantId}/maps",
-                      drogon::Post, "JwtFilter", "TenantFilter");
+                      drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
         ADD_METHOD_TO(MapController::getMap,
                       "/api/v1/tenants/{tenantId}/maps/{id}",
                       drogon::Get, "JwtFilter", "TenantFilter");
         ADD_METHOD_TO(MapController::updateMap,
                       "/api/v1/tenants/{tenantId}/maps/{id}",
-                      drogon::Put, "JwtFilter", "TenantFilter");
+                      drogon::Put, "JwtFilter", "TenantFilter", "RateLimitFilter");
         ADD_METHOD_TO(MapController::deleteMap,
                       "/api/v1/tenants/{tenantId}/maps/{id}",
-                      drogon::Delete, "JwtFilter", "TenantFilter");
+                      drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
         ADD_METHOD_TO(MapController::listPermissions,
                       "/api/v1/tenants/{tenantId}/maps/{id}/permissions",
                       drogon::Get, "JwtFilter", "TenantFilter");
         ADD_METHOD_TO(MapController::setPermission,
                       "/api/v1/tenants/{tenantId}/maps/{id}/permissions",
-                      drogon::Put, "JwtFilter", "TenantFilter");
+                      drogon::Put, "JwtFilter", "TenantFilter", "RateLimitFilter");
         ADD_METHOD_TO(MapController::removePermission,
                       "/api/v1/tenants/{tenantId}/maps/{id}/permissions/{target}",
-                      drogon::Delete, "JwtFilter", "TenantFilter");
+                      drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
     METHOD_LIST_END
 
     void listMaps(const drogon::HttpRequestPtr&,

--- a/backend/src/controllers/NoteController.cpp
+++ b/backend/src/controllers/NoteController.cpp
@@ -1,4 +1,5 @@
 #include "NoteController.h"
+#include "AuditLog.h"
 #include "ErrorResponse.h"
 #include <drogon/drogon.h>
 
@@ -111,6 +112,10 @@ void NoteController::createNote(
     bool hasGroupId   = body->isMember("groupId") && !(*body)["groupId"].isNull();
     int groupId       = hasGroupId ? (*body)["groupId"].asInt() : 0;
 
+    // M8: length limits
+    if (!checkMaxLen("title", title, MAX_TITLE_LEN, callback)) return;
+    if (!checkMaxLen("text", text, MAX_TEXT_LEN, callback)) return;
+
     // Verify map exists in this tenant and user has at least view access
     // (any member who can see the map can leave a note)
     auto db = drogon::app().getDbClient();
@@ -132,59 +137,43 @@ void NoteController::createNote(
                 return;
             }
 
-            // Resource limit: 10,000 notes per map
+            // M9: atomic INSERT-with-limit-check (10,000 notes per map; see
+            // MapController for rationale).
             auto db2 = drogon::app().getDbClient();
             db2->execSqlAsync(
-                "SELECT COUNT(*) AS cnt FROM notes WHERE map_id = ?",
+                "INSERT INTO notes (map_id, created_by, lat, lng, title, text, color, group_id) "
+                "SELECT ?,?,?,?,?,?,NULLIF(?,''),NULLIF(?,0) FROM dual "
+                "WHERE (SELECT COUNT(*) FROM notes WHERE map_id=?) < 10000",
                 [callback, mapId, userId, callerUsername, lat, lng, title, text, color, groupId]
-                (const drogon::orm::Result& rc) {
-                    if (!rc.empty() && rc[0]["cnt"].as<int>() >= 10000) {
-                        auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                            errorJson("limit_exceeded", "Note limit reached for this map"));
-                        resp->setStatusCode(drogon::k400BadRequest);
-                        callback(resp);
+                (const drogon::orm::Result& r2) {
+                    if (r2.affectedRows() == 0) {
+                        callback(errorResponse(drogon::k400BadRequest,
+                            "limit_exceeded", "Note limit reached for this map"));
                         return;
                     }
-
-                    auto db3 = drogon::app().getDbClient();
-                    db3->execSqlAsync(
-                        "INSERT INTO notes (map_id, created_by, lat, lng, title, text, color, group_id) "
-                        "VALUES (?,?,?,?,?,?,NULLIF(?,''),NULLIF(?,0))",
-                        [callback, mapId, userId, callerUsername, lat, lng, title, text, color, groupId]
-                        (const drogon::orm::Result& r2) {
-                            int newId = static_cast<int>(r2.insertId());
-                            Json::Value n;
-                            n["id"]                = newId;
-                            n["mapId"]             = mapId;
-                            n["createdBy"]         = userId;
-                            n["createdByUsername"] = callerUsername;
-                            n["lat"]       = lat;
-                            n["lng"]       = lng;
-                            n["title"]     = title;
-                            n["text"]      = text;
-                            n["pinned"]    = false;
-                            n["color"]     = color.empty() ? Json::Value() : Json::Value(color);
-                            n["groupId"]   = groupId > 0 ? Json::Value(groupId) : Json::Value();
-                            n["canEdit"]   = true;
-                            auto resp = drogon::HttpResponse::newHttpJsonResponse(n);
-                            resp->setStatusCode(drogon::k201Created);
-                            callback(resp);
-                        },
-                        [callback](const drogon::orm::DrogonDbException&) {
-                            auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                                errorJson("db_error", "Failed to create note"));
-                            resp->setStatusCode(drogon::k500InternalServerError);
-                            callback(resp);
-                        },
-                        mapId, userId, lat, lng, title, text, color, groupId);
-                },
-                [callback](const drogon::orm::DrogonDbException&) {
-                    auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                        errorJson("db_error", "Failed to check note count"));
-                    resp->setStatusCode(drogon::k500InternalServerError);
+                    int newId = static_cast<int>(r2.insertId());
+                    Json::Value n;
+                    n["id"]                = newId;
+                    n["mapId"]             = mapId;
+                    n["createdBy"]         = userId;
+                    n["createdByUsername"] = callerUsername;
+                    n["lat"]       = lat;
+                    n["lng"]       = lng;
+                    n["title"]     = title;
+                    n["text"]      = text;
+                    n["pinned"]    = false;
+                    n["color"]     = color.empty() ? Json::Value() : Json::Value(color);
+                    n["groupId"]   = groupId > 0 ? Json::Value(groupId) : Json::Value();
+                    n["canEdit"]   = true;
+                    auto resp = drogon::HttpResponse::newHttpJsonResponse(n);
+                    resp->setStatusCode(drogon::k201Created);
                     callback(resp);
                 },
-                mapId);
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to create note"));
+                },
+                mapId, userId, lat, lng, title, text, color, groupId, mapId);
         },
         [callback](const drogon::orm::DrogonDbException&) {
             auto resp = drogon::HttpResponse::newHttpJsonResponse(
@@ -272,6 +261,11 @@ void NoteController::updateNote(
     std::string newTitle = (*body).get("title", "").asString();
     std::string newText  = (*body).get("text", "").asString();
     std::string newColor = (*body).get("color", "").asString();
+
+    // M8: length limits
+    if (!checkMaxLen("title", newTitle, MAX_TITLE_LEN, callback)) return;
+    if (!checkMaxLen("text", newText, MAX_TEXT_LEN, callback)) return;
+
     bool hasLat          = body->isMember("lat");
     bool hasLng          = body->isMember("lng");
     double newLat        = hasLat ? (*body)["lat"].asDouble() : 0.0;
@@ -295,24 +289,25 @@ void NoteController::updateNote(
         "                      ELSE ? END "
         "WHERE n.id = ? AND n.map_id = ? AND m.tenant_id = ? "
         "  AND (m.owner_id = ? OR mp.level IN ('edit','moderate','admin') OR n.created_by = ?)",
-        [callback, id](const drogon::orm::Result& r) {
+        [callback, req, userId, tenantId, mapId, id](const drogon::orm::Result& r) {
             if (r.affectedRows() == 0) {
-                auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                    errorJson("forbidden", "Cannot update note"));
-                resp->setStatusCode(drogon::k403Forbidden);
-                callback(resp);
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Cannot update note"));
                 return;
             }
+            // M12: audit the update
+            Json::Value detail;
+            detail["mapId"] = mapId;
+            detail["noteId"] = id;
+            AuditLog::record("note_update", req, userId, 0, tenantId, detail);
             Json::Value v;
             v["id"]      = id;
             v["updated"] = true;
             callback(drogon::HttpResponse::newHttpJsonResponse(v));
         },
         [callback](const drogon::orm::DrogonDbException&) {
-            auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                errorJson("db_error", "Failed to update note"));
-            resp->setStatusCode(drogon::k500InternalServerError);
-            callback(resp);
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to update note"));
         },
         userId,
         newTitle, newTitle,
@@ -341,14 +336,17 @@ void NoteController::deleteNote(
         "LEFT JOIN map_permissions mp ON mp.map_id = m.id AND mp.user_id = ? "
         "WHERE n.id = ? AND n.map_id = ? AND m.tenant_id = ? "
         "  AND (m.owner_id = ? OR mp.level IN ('edit','moderate','admin') OR n.created_by = ?)",
-        [callback](const drogon::orm::Result& r) {
+        [callback, req, userId, tenantId, mapId, id](const drogon::orm::Result& r) {
             if (r.affectedRows() == 0) {
-                auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                    errorJson("forbidden", "Cannot delete note"));
-                resp->setStatusCode(drogon::k403Forbidden);
-                callback(resp);
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Cannot delete note"));
                 return;
             }
+            // M12: audit the deletion
+            Json::Value detail;
+            detail["mapId"] = mapId;
+            detail["noteId"] = id;
+            AuditLog::record("note_delete", req, userId, 0, tenantId, detail);
             auto resp = drogon::HttpResponse::newHttpResponse();
             resp->setStatusCode(drogon::k204NoContent);
             callback(resp);

--- a/backend/src/controllers/NoteController.h
+++ b/backend/src/controllers/NoteController.h
@@ -18,16 +18,16 @@ public:
                       drogon::Get, "JwtFilter", "TenantFilter");
         ADD_METHOD_TO(NoteController::createNote,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/notes",
-                      drogon::Post, "JwtFilter", "TenantFilter");
+                      drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
         ADD_METHOD_TO(NoteController::getNote,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}",
                       drogon::Get, "JwtFilter", "TenantFilter");
         ADD_METHOD_TO(NoteController::updateNote,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}",
-                      drogon::Put, "JwtFilter", "TenantFilter");
+                      drogon::Put, "JwtFilter", "TenantFilter", "RateLimitFilter");
         ADD_METHOD_TO(NoteController::deleteNote,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}",
-                      drogon::Delete, "JwtFilter", "TenantFilter");
+                      drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
     METHOD_LIST_END
 
     void listNotes(const drogon::HttpRequestPtr&,

--- a/backend/src/controllers/NoteGroupController.cpp
+++ b/backend/src/controllers/NoteGroupController.cpp
@@ -1,4 +1,5 @@
 #include "NoteGroupController.h"
+#include "AuditLog.h"
 #include "ErrorResponse.h"
 #include <drogon/drogon.h>
 
@@ -89,6 +90,10 @@ void NoteGroupController::createGroup(
     std::string color = (*body).get("color", "").asString();
     int sortOrder     = (*body).get("sortOrder", 0).asInt();
 
+    // M8: length limits
+    if (!checkMaxLen("name", name, MAX_NAME_LEN, callback)) return;
+    if (!checkMaxLen("description", desc, MAX_DESCRIPTION_LEN, callback)) return;
+
     // Validate color if provided
     if (!color.empty()) {
         bool validColor = color[0] == '#' &&
@@ -174,6 +179,7 @@ void NoteGroupController::updateGroup(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId, int mapId, int id) {
 
+    int userId = callerUserId(req);
     std::string role = callerTenantRole(req);
     if (role != "admin") {
         auto resp = drogon::HttpResponse::newHttpJsonResponse(
@@ -194,6 +200,10 @@ void NoteGroupController::updateGroup(
 
     std::string newName  = (*body).get("name", "").asString();
     std::string newDesc  = (*body).get("description", "").asString();
+
+    // M8: length limits
+    if (!checkMaxLen("name", newName, MAX_NAME_LEN, callback)) return;
+    if (!checkMaxLen("description", newDesc, MAX_DESCRIPTION_LEN, callback)) return;
     std::string newColor = (*body).get("color", "").asString();
     bool hasSortOrder    = body->isMember("sortOrder");
     int newSortOrder     = (*body).get("sortOrder", 0).asInt();
@@ -230,14 +240,17 @@ void NoteGroupController::updateGroup(
         "    ng.color       = IF(?='', ng.color, ?), "
         "    ng.sort_order  = IF(?=0, ng.sort_order, ?) "
         "WHERE ng.id = ? AND ng.map_id = ? AND m.tenant_id = ?",
-        [callback, id](const drogon::orm::Result& r) {
+        [callback, req, userId, tenantId, mapId, id](const drogon::orm::Result& r) {
             if (r.affectedRows() == 0) {
-                auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                    errorJson("not_found", "Note group not found"));
-                resp->setStatusCode(drogon::k404NotFound);
-                callback(resp);
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "Note group not found"));
                 return;
             }
+            // M12: audit the update
+            Json::Value detail;
+            detail["mapId"] = mapId;
+            detail["noteGroupId"] = id;
+            AuditLog::record("notegroup_update", req, userId, 0, tenantId, detail);
             Json::Value v;
             v["id"]      = id;
             v["updated"] = true;
@@ -268,12 +281,11 @@ void NoteGroupController::deleteGroup(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId, int mapId, int id) {
 
+    int userId = callerUserId(req);
     std::string role = callerTenantRole(req);
     if (role != "admin") {
-        auto resp = drogon::HttpResponse::newHttpJsonResponse(
-            errorJson("forbidden", "Only tenant admins can delete note groups"));
-        resp->setStatusCode(drogon::k403Forbidden);
-        callback(resp);
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Only tenant admins can delete note groups"));
         return;
     }
 
@@ -282,23 +294,24 @@ void NoteGroupController::deleteGroup(
         "DELETE ng FROM note_groups ng "
         "JOIN maps m ON m.id = ng.map_id "
         "WHERE ng.id = ? AND ng.map_id = ? AND m.tenant_id = ?",
-        [callback](const drogon::orm::Result& r) {
+        [callback, req, userId, tenantId, mapId, id](const drogon::orm::Result& r) {
             if (r.affectedRows() == 0) {
-                auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                    errorJson("not_found", "Note group not found"));
-                resp->setStatusCode(drogon::k404NotFound);
-                callback(resp);
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "Note group not found"));
                 return;
             }
+            // M12: audit the deletion
+            Json::Value detail;
+            detail["mapId"] = mapId;
+            detail["noteGroupId"] = id;
+            AuditLog::record("notegroup_delete", req, userId, 0, tenantId, detail);
             auto resp = drogon::HttpResponse::newHttpResponse();
             resp->setStatusCode(drogon::k204NoContent);
             callback(resp);
         },
         [callback](const drogon::orm::DrogonDbException&) {
-            auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                errorJson("db_error", "Failed to delete note group"));
-            resp->setStatusCode(drogon::k500InternalServerError);
-            callback(resp);
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to delete note group"));
         },
         id, mapId, tenantId);
 }

--- a/backend/src/controllers/NoteGroupController.h
+++ b/backend/src/controllers/NoteGroupController.h
@@ -17,13 +17,13 @@ public:
                       drogon::Get, "JwtFilter", "TenantFilter");
         ADD_METHOD_TO(NoteGroupController::createGroup,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/note-groups",
-                      drogon::Post, "JwtFilter", "TenantFilter");
+                      drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
         ADD_METHOD_TO(NoteGroupController::updateGroup,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/note-groups/{id}",
-                      drogon::Put, "JwtFilter", "TenantFilter");
+                      drogon::Put, "JwtFilter", "TenantFilter", "RateLimitFilter");
         ADD_METHOD_TO(NoteGroupController::deleteGroup,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/note-groups/{id}",
-                      drogon::Delete, "JwtFilter", "TenantFilter");
+                      drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
     METHOD_LIST_END
 
     void listGroups(const drogon::HttpRequestPtr&,

--- a/backend/src/controllers/TenantController.cpp
+++ b/backend/src/controllers/TenantController.cpp
@@ -169,10 +169,15 @@ void TenantController::updateBranding(
     Json::StreamWriterBuilder wb;
     std::string brandingStr = Json::writeString(wb, branding);
 
+    int userId = 0;
+    try { userId = req->getAttributes()->get<int>("userId"); } catch (...) {}
+
     auto db = drogon::app().getDbClient();
     db->execSqlAsync(
         "UPDATE tenants SET branding=? WHERE id=?",
-        [callback, branding](const drogon::orm::Result&) {
+        [callback, req, userId, tenantId, branding](const drogon::orm::Result&) {
+            // M12: audit the update
+            AuditLog::record("branding_update", req, userId, 0, tenantId, branding);
             callback(drogon::HttpResponse::newHttpJsonResponse(branding));
         },
         [callback](const drogon::orm::DrogonDbException&) {

--- a/backend/src/filters/RateLimitFilter.cpp
+++ b/backend/src/filters/RateLimitFilter.cpp
@@ -12,12 +12,27 @@ static std::unordered_map<std::string,
 static uint64_t sCallCount = 0;
 
 static std::string clientIp(const drogon::HttpRequestPtr& req) {
+    // X-Forwarded-For is honored, but only trust it if the deployment
+    // sits behind a reverse proxy that strips client-supplied XFF.
+    // See docs/DEVELOPER-GUIDE.md "Proxy trust".
     const std::string& xff = req->getHeader("X-Forwarded-For");
     if (!xff.empty()) {
         auto comma = xff.find(',');
         return comma != std::string::npos ? xff.substr(0, comma) : xff;
     }
     return req->getPeerAddr().toIp();
+}
+
+// M10: when JwtFilter has run upstream, key the rate window by user ID.
+// Authenticated abuse from a single account is what we're guarding against
+// on content endpoints; IP-keying would let one user wedge other users
+// behind the same NAT.
+static std::string rateKey(const drogon::HttpRequestPtr& req) {
+    try {
+        int userId = req->getAttributes()->get<int>("userId");
+        if (userId > 0) return "user:" + std::to_string(userId);
+    } catch (...) {}
+    return "ip:" + clientIp(req);
 }
 
 void RateLimitFilter::doFilter(const drogon::HttpRequestPtr& req,
@@ -27,13 +42,13 @@ void RateLimitFilter::doFilter(const drogon::HttpRequestPtr& req,
     int maxReqs     = cfg.get("max_requests",   10).asInt();
     int windowSecs  = cfg.get("window_seconds",  60).asInt();
 
-    std::string ip = clientIp(req);
-    auto now       = std::chrono::steady_clock::now();
-    auto cutoff    = now - std::chrono::seconds(windowSecs);
+    std::string key = rateKey(req);
+    auto now        = std::chrono::steady_clock::now();
+    auto cutoff     = now - std::chrono::seconds(windowSecs);
 
     std::lock_guard<std::mutex> lock(sMutex);
 
-    auto& dq = sWindows[ip];
+    auto& dq = sWindows[key];
 
     // Trim timestamps outside the window
     while (!dq.empty() && dq.front() < cutoff)

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -80,14 +80,45 @@ int main(int argc, char* argv[]) {
         allowedOrigins.insert("http://localhost:8080");
     }
 
-    // ── H2 fix: Security headers + CORS ──────────────────────────────────────
+    // ── Production flag (controls HSTS emission) ─────────────────────────────
+    // Set PRODUCTION=1 in production deployments. Also triggers HSTS when the
+    // request is served over HTTPS (detected via X-Forwarded-Proto from the
+    // trusted reverse proxy — see docs/DEVELOPER-GUIDE.md "Proxy trust").
+    const char* prodEnv = std::getenv("PRODUCTION");
+    const bool isProduction = prodEnv && std::string(prodEnv) == "1";
+
+    // ── H2 + M6 + M7 + L4: Security headers + CORS ───────────────────────────
     drogon::app().registerPreSendingAdvice(
-        [allowedOrigins](const drogon::HttpRequestPtr& req,
-                         const drogon::HttpResponsePtr& resp) {
-            // Security headers
+        [allowedOrigins, isProduction](const drogon::HttpRequestPtr& req,
+                                       const drogon::HttpResponsePtr& resp) {
+            // Baseline security headers on every response
             resp->addHeader("X-Content-Type-Options", "nosniff");
             resp->addHeader("X-Frame-Options", "DENY");
             resp->addHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+
+            // M6: Content-Security-Policy. This backend serves a JSON API;
+            // `default-src 'none'` is the tightest default. The frontend
+            // static files are served by Vite/nginx in a separate origin;
+            // their CSP is configured there.
+            resp->addHeader("Content-Security-Policy",
+                            "default-src 'none'; frame-ancestors 'none'");
+
+            // L4: Permissions-Policy — disable browser features we don't use.
+            resp->addHeader("Permissions-Policy",
+                            "geolocation=(), microphone=(), camera=(), usb=()");
+
+            // M7: HSTS only when both (a) running in production, and (b) the
+            // request arrived via HTTPS at the trusted proxy. Emitting HSTS
+            // on HTTP responses is harmless but misleading; emitting it in
+            // dev would cache the requirement on localhost and break http
+            // dev access for a year.
+            if (isProduction) {
+                const auto& proto = req->getHeader("X-Forwarded-Proto");
+                if (proto == "https") {
+                    resp->addHeader("Strict-Transport-Security",
+                                    "max-age=31536000; includeSubDomains");
+                }
+            }
 
             // CORS — only allow whitelisted origins
             const auto& origin = req->getHeader("Origin");

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -48,6 +48,47 @@ All auditable events use `AuditLog::record(...)` and are fire-and-forget
 (no callback chain). See [`backend/src/AuditLog.h`](../backend/src/AuditLog.h)
 for the signature.
 
+Currently audited:
+
+- Auth: `register`, `login_success`, `login_failure`, `sso_login`
+- Membership: `member_add`, `member_remove`, `permission_change`
+- Content (added in #57): `map_update`, `map_delete`, `annotation_update`,
+  `annotation_delete`, `note_update`, `note_delete`, `notegroup_update`,
+  `notegroup_delete`, `branding_update`
+
+Add a new event when introducing any destructive or privilege-changing
+operation. Read paths (GET) are not audited.
+
+### Proxy trust and `X-Forwarded-For`
+
+Several controls (rate limiting in [`RateLimitFilter`](../backend/src/filters/RateLimitFilter.cpp),
+HSTS conditional emission, future client-IP-based audit) read the
+`X-Forwarded-For` and `X-Forwarded-Proto` headers. **These headers are
+client-supplied unless a trusted reverse proxy strips and rewrites them.**
+
+Deployment requirements:
+
+- The backend must only accept traffic via a trusted reverse proxy
+  (nginx, Caddy, ALB, etc.) on the production host. Direct connections
+  to the backend port from outside the host should be blocked at the
+  network layer.
+- The proxy must:
+  - Strip any client-supplied `X-Forwarded-For` and `X-Forwarded-Proto`
+    headers before forwarding.
+  - Set `X-Forwarded-For` to the real client IP it observed.
+  - Set `X-Forwarded-Proto` to `https` when the client connected via TLS.
+- For `nginx`, the standard recipe is `proxy_set_header X-Forwarded-For
+  $remote_addr;` (note: `$proxy_add_x_forwarded_for` would *append* and
+  preserve any client-supplied value — don't use it here).
+
+`RateLimitFilter` uses only the leftmost entry of `X-Forwarded-For`,
+which is the IP injected by the trusted proxy. Without the proxy
+discipline above, an attacker can spoof IPs by setting the header
+themselves and rotate around per-IP rate limits.
+
+For local dev (no proxy), `X-Forwarded-For` is empty and the filter
+falls back to `req->getPeerAddr()`, so dev workflow is unaffected.
+
 ## CI / Docker
 
 ### `docker-compose.ci.yml`

--- a/docs/SECURITY-AUDIT.md
+++ b/docs/SECURITY-AUDIT.md
@@ -12,10 +12,10 @@
 | Severity | Total open | Fixed since audit |
 |---|---:|---:|
 | High | 0 | 5 (H1, H2, H3 in #55; H4, H5 in #56) |
-| Medium | 12 | 1 (M13 — fixed with H1) |
-| Low | 5 | 0 |
+| Medium | 5 | 8 (M6, M7, M8, M9, M10, M11, M12, M13 — see #55, #57) |
+| Low | 4 | 1 (L4 — fixed with M6/M7 in #57) |
 
-All High findings are closed. Remaining open items are Mediums (SSO hardening, rate limiter scope, JWT storage, and the Medium grab-bag tracked in #57, #58) and Lows.
+Remaining open items are the 4 SSO-hardening Mediums carried from the previous audit (M1, M3, M4 tracked in #58; M2 deferred), the in-process rate-limiter Medium (M5, also #58/deferred), and four Lows.
 
 Deliberate design trade-offs are listed separately below.
 
@@ -34,12 +34,13 @@ The application implements the following security controls (verified in this aud
 - **JWT scoping:** HS256, `issuer` + `audience` (`annotated-maps`) + `orgId` claims all validated.
 - **Shared error helpers:** `ErrorResponse.h` provides `errorJson()`/`errorResponse()` — removes duplication and ensures consistent `{error, message}` shape.
 - **Tenant isolation:** `TenantFilter` runs before every tenant-scoped endpoint and verifies `tenant_members` membership before any controller code runs. Superuser bypass is explicit.
-- **Rate limiting:** `RateLimitFilter` applies a sliding-window limit to login, registration, and SSO endpoints. Returns 429 with `Retry-After`. Configurable via `custom_config.rate_limit`.
-- **Input validation:** GeoJSON structure, media URL schemes (`http`/`https`), branding colors (hex), branding URLs (HTTPS-only), display-name length, and pagination bounds all validated.
-- **Resource limits:** 1,000 maps/tenant, 5,000 annotations/map, 10,000 notes/map.
-- **Audit logging:** `audit_log` records security events (login success/failure, registration, SSO login, member add/remove, permission changes) with atomic success/failure counters.
-- **Security headers:** `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`.
+- **Rate limiting:** `RateLimitFilter` applies a sliding-window limit to auth/SSO endpoints (IP-keyed) and to all content POST/PUT/DELETE endpoints (user-keyed when JWT is present, IP-keyed otherwise). Returns 429 with `Retry-After`. Configurable via `custom_config.rate_limit`.
+- **Input validation:** GeoJSON structure, media URL schemes (`http`/`https`), branding colors (hex), branding URLs (HTTPS-only), display-name length, pagination bounds, and per-field length limits (title/name ≤ 255, description/text ≤ 10 KB) all validated server-side via `checkMaxLen()` and field-specific checks.
+- **Resource limits:** 1,000 maps/tenant, 5,000 annotations/map, 10,000 notes/map. Enforced by atomic `INSERT ... SELECT WHERE COUNT < limit` so concurrent creates can't race past the cap.
+- **Audit logging:** `audit_log` records auth events (login success/failure, registration, SSO login), membership/permission changes (member add/remove, permission_change), and content mutations (map/annotation/note/notegroup update + delete, branding update). Atomic success/failure counters for monitoring.
+- **Security headers:** `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'`, `Permissions-Policy: geolocation=(), microphone=(), camera=(), usb=()`. HSTS (`Strict-Transport-Security: max-age=31536000; includeSubDomains`) is emitted only when `PRODUCTION=1` and `X-Forwarded-Proto: https`.
 - **CORS allowlist:** Origins listed in `allowed_origins` config; unknown origins receive no CORS headers.
+- **Proxy trust:** `RateLimitFilter` and HSTS read `X-Forwarded-For`/`X-Forwarded-Proto` from a trusted reverse proxy. Production deployments must put a proxy in front that strips client-supplied values; documented in `docs/DEVELOPER-GUIDE.md` "Proxy trust".
 - **Secrets management:** `JWT_SECRET` env var overrides config, minimum 32 characters enforced. Config placeholders (`CHANGE_ME...`) cause fatal startup exit unless `ALLOW_PLACEHOLDER_SECRETS=1` is explicitly set (dev-only). SSO `client_secret` is read from `SSO_CLIENT_SECRET_<ORG_ID>` env vars and never stored in the database.
 - **Registration privacy at the login endpoint:** Login returns identical error for wrong password and nonexistent email.
 - **SSO enumeration resistance:** SSO initiate returns generic "SSO is not available" for all error cases.
@@ -114,90 +115,6 @@ Multi-instance deployments each keep independent counters; attacker multiplies e
 
 ---
 
-#### M6 (NEW): No Content-Security-Policy header
-
-**Files:** `backend/src/main.cpp:68-87`, `frontend/index.html`
-
-No CSP is set by the backend or via meta tag. A CSP is the main defense-in-depth when XSS protections fail.
-
-**Fix:** Add `Content-Security-Policy: default-src 'self'; img-src 'self' https: data:; connect-src 'self' https://tile.openstreetmap.org; frame-ancestors 'none'` (plus `style-src 'self' 'unsafe-inline'` for Leaflet). Set from the backend's pre-send advice.
-
-**Effort:** Small. Test carefully — CSP breakage is subtle.
-
----
-
-#### M7 (NEW): No HSTS header
-
-**File:** `backend/src/main.cpp:68-87`
-
-Without `Strict-Transport-Security`, a user connecting over HTTP once (before the app forces HTTPS) is vulnerable to a MITM downgrade.
-
-**Fix:** Add `Strict-Transport-Security: max-age=31536000; includeSubDomains` in production only (detect via `X-Forwarded-Proto` or a production flag).
-
-**Effort:** Trivial.
-
----
-
-#### M8 (NEW): No length limits on title/description/text fields
-
-**Files:** `backend/src/controllers/MapController.cpp` (`title`, `description`), `AnnotationController.cpp` (`title`, `description`), `NoteController.cpp` (`text`, `title`), `NoteGroupController.cpp` (`name`, `description`)
-
-Fields are inserted into `VARCHAR(255)` or `TEXT` columns without server-side length checks; the database truncates silently on VARCHAR and accepts up to 64KB on TEXT. An unauthenticated-after-register user could flood the DB with max-size TEXT payloads.
-
-**Fix:** Validate lengths at controller entry (e.g., 255 for titles, 10KB for descriptions, 64KB for notes) and return 400 if exceeded.
-
-**Effort:** Small.
-
----
-
-#### M9 (NEW): Race conditions in resource-limit enforcement
-
-**Files:** `MapController.cpp:119-131`, `AnnotationController.cpp:145-158`, `NoteController.cpp:135-147`
-
-Pattern: `SELECT COUNT(*)` → compare to limit → `INSERT`. Two concurrent requests can both pass the check and both insert, exceeding the limit.
-
-**Fix:** Either combine into atomic `INSERT ... SELECT ... WHERE (SELECT COUNT(*) ...) < limit` or enforce at the database level via a trigger.
-
-**Effort:** Small-moderate (three controllers, plus a test).
-
----
-
-#### M10 (NEW): No rate limit on content-creation endpoints
-
-**Files:** `backend/src/main.cpp` filter registration
-
-`RateLimitFilter` applies only to auth endpoints. An authenticated attacker can spam map/annotation/note creation up to the resource cap and fill `audit_log`.
-
-**Fix:** Apply a per-user or per-tenant rate limit to POST/PUT/DELETE content endpoints. Requires a user-scoped key instead of IP-scoped in `RateLimitFilter`.
-
-**Effort:** Moderate.
-
----
-
-#### M11 (NEW): X-Forwarded-For trust is implicit
-
-**File:** `backend/src/filters/RateLimitFilter.cpp:14-21`
-
-`RateLimitFilter` uses `X-Forwarded-For` without verifying that the request came from a trusted reverse proxy. Direct requests to the Drogon process (or requests through a proxy that forwards client headers) can spoof IPs.
-
-**Fix:** Document that the app must only accept traffic via a trusted proxy that strips client `X-Forwarded-For`, OR only trust the rightmost entry when a fixed number of trusted proxies is configured.
-
-**Effort:** Small (config + doc).
-
----
-
-#### M12 (NEW): Missing audit logs for delete/update operations
-
-**Files:** `MapController.cpp`, `AnnotationController.cpp`, `NoteController.cpp`, `NoteGroupController.cpp`, `TenantController.cpp` (branding update)
-
-Audit log currently captures: register, login success/failure, SSO login, member add/remove, permission change. It does not capture: map/annotation/note/group deletions, map/annotation/note updates, branding changes. These are the destructive/mutative operations most important for incident investigation.
-
-**Fix:** Add `AuditLog::record(...)` calls to each delete and update path, with enough detail to identify the affected resource.
-
-**Effort:** Small-moderate.
-
----
-
 ### Low
 
 #### L1 (NEW): GeoJSON coordinate ranges not validated
@@ -211,12 +128,6 @@ Same as L1 for notes. `DECIMAL(10,7)` field prevents worse outcomes.
 #### L3 (NEW): Missing composite index on `audit_log(event_type, created_at)`
 
 Separate indexes exist on each column. Time-range queries filtered by event type will use one index and filter with the other in memory. Performance concern, not security, but matters for incident-investigation workflows.
-
-#### L4 (NEW): No `Permissions-Policy` header
-
-Standard hardening header; disables unused browser features (camera, mic, geolocation, etc.).
-
-**Fix:** `Permissions-Policy: geolocation=(), microphone=(), camera=(), usb=()`. One-liner in `main.cpp`.
 
 #### L5 (NEW): `leaflet-draw` is effectively unmaintained
 
@@ -361,3 +272,90 @@ consistent with the SSO enumeration-resistance posture. The
 `sso_providers.config` JSON is no longer expected to contain
 `client_secret` — any legacy value is ignored. No DB migration is
 required for v0.1 because no production SSO data exists yet.
+
+### M6 — Content-Security-Policy header
+
+**Closed by PR #57 (2026-04-22).**
+
+**Fix applied:** Backend pre-send advice now emits
+`Content-Security-Policy: default-src 'none'; frame-ancestors 'none'`.
+The backend serves a JSON API; `default-src 'none'` is the tightest
+possible default. The frontend bundle is served by Vite/nginx in a
+separate origin and configures its own CSP there.
+
+### M7 — HSTS header
+
+**Closed by PR #57 (2026-04-22).**
+
+**Fix applied:** Backend emits `Strict-Transport-Security: max-age=31536000;
+includeSubDomains` only when `PRODUCTION=1` env var is set AND the
+request arrived with `X-Forwarded-Proto: https`. Avoids caching the
+requirement on localhost during dev.
+
+### M8 — Server-side length limits
+
+**Closed by PR #57 (2026-04-22).**
+
+**Fix applied:** New `checkMaxLen()` helper in `ErrorResponse.h`
+(constants `MAX_TITLE_LEN=255`, `MAX_NAME_LEN=255`,
+`MAX_DESCRIPTION_LEN=10000`, `MAX_TEXT_LEN=10000`). Applied at the
+entry of every create and update path in MapController,
+AnnotationController, NoteController, NoteGroupController. Returns
+400 with field name and limit.
+
+### M9 — Resource-limit race conditions
+
+**Closed by PR #57 (2026-04-22).**
+
+**Fix applied:** Replaced separate `SELECT COUNT(*)` + `INSERT` with
+atomic `INSERT ... SELECT ... FROM dual WHERE (SELECT COUNT(*) ...) <
+limit` in MapController, AnnotationController, NoteController. The
+INSERT either succeeds (and `affectedRows() > 0`) or is rejected
+(`affectedRows() == 0` triggers the limit-exceeded response). Eliminates
+the COUNT-then-INSERT window.
+
+### M10 — Per-user rate limit on content endpoints
+
+**Closed by PR #57 (2026-04-22).**
+
+**Fix applied:** `RateLimitFilter` now keys by `user:<id>` when the
+upstream JwtFilter has set a `userId` request attribute, falling back
+to `ip:<ip>` otherwise. `RateLimitFilter` added to POST/PUT/DELETE
+routes on Map, Annotation, Note, and NoteGroup controllers (after
+JwtFilter+TenantFilter so the user attribute is available). Same
+config knob (`custom_config.rate_limit`) governs both auth and content
+limits.
+
+### M11 — `X-Forwarded-For` trust documentation
+
+**Closed by PR #57 (2026-04-22).**
+
+**Fix applied:** New "Proxy trust and `X-Forwarded-For`" section in
+`docs/DEVELOPER-GUIDE.md` covering deployment requirements (trusted
+proxy must strip client-supplied XFF, set XFF to real client IP, set
+`X-Forwarded-Proto: https` on TLS connections) and warns against
+`$proxy_add_x_forwarded_for` in nginx. Code unchanged — the leftmost-
+entry behavior was already correct under the documented model.
+
+### M12 — Audit log coverage for delete/update operations
+
+**Closed by PR #57 (2026-04-22).**
+
+**Fix applied:** Added `AuditLog::record(...)` calls to the success
+path of: `MapController::updateMap`, `MapController::deleteMap`,
+`AnnotationController::updateAnnotation`,
+`AnnotationController::deleteAnnotation`, `NoteController::updateNote`,
+`NoteController::deleteNote`, `NoteGroupController::updateGroup`,
+`NoteGroupController::deleteGroup`, `TenantController::updateBranding`.
+Detail JSON includes `mapId` and the resource's own ID where applicable.
+Event types: `map_update`, `map_delete`, `annotation_update`,
+`annotation_delete`, `note_update`, `note_delete`, `notegroup_update`,
+`notegroup_delete`, `branding_update`.
+
+### L4 — `Permissions-Policy` header
+
+**Closed by PR #57 (2026-04-22).**
+
+**Fix applied:** Backend pre-send advice now emits
+`Permissions-Policy: geolocation=(), microphone=(), camera=(), usb=()`.
+Done opportunistically while editing the same code block for M6/M7.


### PR DESCRIPTION
## Summary

Closes #57. Eight findings from the 2026-04-17 audit, plus L4 done opportunistically (it lives in the same code block as M6/M7).

## Files changed

- \`backend/src/ErrorResponse.h\` — New \`checkMaxLen()\` helper + \`MAX_TITLE_LEN\`, \`MAX_NAME_LEN\`, \`MAX_DESCRIPTION_LEN\`, \`MAX_TEXT_LEN\` constants (M8)
- \`backend/src/controllers/AnnotationController.cpp\` — Length limits on create+update (M8); atomic INSERT-with-limit-check (M9); audit log on update+delete (M12); AuditLog include
- \`backend/src/controllers/AnnotationController.h\` — \`RateLimitFilter\` on POST/PUT/DELETE routes (M10)
- \`backend/src/controllers/MapController.cpp\` — Same pattern: M8, M9, M12
- \`backend/src/controllers/MapController.h\` — RateLimitFilter wiring (M10)
- \`backend/src/controllers/NoteController.cpp\` — M8, M9, M12; AuditLog include
- \`backend/src/controllers/NoteController.h\` — RateLimitFilter wiring (M10)
- \`backend/src/controllers/NoteGroupController.cpp\` — M8 (create+update); M12 audit on update+delete; AuditLog include; \`userId\` extraction added
- \`backend/src/controllers/NoteGroupController.h\` — RateLimitFilter wiring (M10)
- \`backend/src/controllers/TenantController.cpp\` — M12 audit on \`updateBranding\` (\`branding_update\` event)
- \`backend/src/filters/RateLimitFilter.cpp\` — Per-user keying when \`userId\` request attribute is present (M10); inline comment about XFF trust (cross-refs M11 doc)
- \`backend/src/main.cpp\` — CSP (M6), Permissions-Policy (L4), HSTS gated on \`PRODUCTION=1\` + \`X-Forwarded-Proto: https\` (M7); reads \`PRODUCTION\` env var
- \`docs/DEVELOPER-GUIDE.md\` — New "Proxy trust and X-Forwarded-For" section (M11); audit-event list updated to include the M12 events
- \`docs/SECURITY-AUDIT.md\` — M6-M12 + L4 moved to closed findings; summary counts updated (now 0 open Highs, 5 open Mediums, 4 open Lows); posture bullets refreshed

## Verification

- ✅ \`python3 database/tests/run-db-tests.py\` → 110 passed
- ✅ \`python3 backend/tests/run-tests.py --tier fast\` → all suites passed
- ✅ Headers verified in live response: \`Content-Security-Policy: default-src 'none'; frame-ancestors 'none'\`, \`Permissions-Policy: geolocation=(), microphone=(), camera=(), usb=()\` always present; HSTS absent in dev.
- ✅ HSTS conditional verified: with \`PRODUCTION=1\` + \`X-Forwarded-Proto: https\` → \`strict-transport-security: max-age=31536000; includeSubDomains\`. Without either condition → no HSTS header.

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none** (only \`InternalServerError\` enum and ephemeral \`annmaps-prod-test\` container name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)