### PR TITLE
Test: Set up Playwright for end-to-end testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ frontend/.env
 frontend/.env.local
 frontend/.env.*.local
 
+# Playwright artifacts
+frontend/test-results/
+frontend/playwright-report/
+frontend/blob-report/
+frontend/playwright/.cache/
+
 # ─── Backend ──────────────────────────────────────────────────────────────────
 backend/build/
 backend/logs/

--- a/docs/TESTING-E2E.md
+++ b/docs/TESTING-E2E.md
@@ -1,0 +1,115 @@
+# End-to-End (Playwright) Tests
+
+Browser-driven tests that exercise the full stack — frontend, backend, MySQL —
+the way a real user would. Complements the lower-level test tiers:
+
+| Tier | Tool | What it tests |
+|------|------|---------------|
+| Database | `database/tests/*.sql` | Schema, constraints, triggers |
+| Backend integration | `backend/tests/test_*.py` | HTTP API, controllers, filters |
+| **End-to-end** | **`frontend/tests/e2e/*.spec.ts`** | **Real browser → frontend → backend → DB** |
+
+E2E tests are the most expensive to run and the most representative of user
+experience. Use them for flows where the frontend's behavior matters
+(rendering, routing, click handlers), and lean on backend tests for
+permission/data-correctness assertions where they're cheaper.
+
+## Prerequisites
+
+- Docker Compose stack running: `docker compose up -d` and wait for
+  `Annotated Maps backend starting on port 8080` in the backend logs.
+- Frontend dependencies installed: `cd frontend && npm install`.
+- Playwright browser binaries installed: `cd frontend && npx playwright install chromium`.
+
+The browser install is a one-time ~100 MB download to
+`~/Library/Caches/ms-playwright/` (macOS) or `~/.cache/ms-playwright/` (Linux).
+
+## Running tests
+
+```bash
+cd frontend
+npm run test:e2e            # all suites, headless
+npx playwright test smoke   # one file
+npx playwright test --ui    # interactive UI mode
+npx playwright test --debug # step through with inspector
+```
+
+After a failing run, view the rendered HTML report:
+
+```bash
+npx playwright show-report
+```
+
+## Where tests live
+
+```
+frontend/
+├── playwright.config.ts        # config
+├── tests/
+│   └── e2e/
+│       ├── smoke.spec.ts       # minimal: login page renders
+│       └── *.spec.ts           # one file per feature area (auth, maps, etc.)
+└── ...
+```
+
+Per-area suites are tracked in #34–#38. Until those land, only the smoke
+test exists.
+
+## Configuration
+
+[`frontend/playwright.config.ts`](../frontend/playwright.config.ts) sets:
+
+- **`baseURL`**: `http://localhost:5173` (the Vite dev server in the
+  Docker stack). Override with `PLAYWRIGHT_BASE_URL=...` for a deployed
+  environment.
+- **`workers`**: 1 locally (sequential — easier to follow when watching),
+  Playwright's default in CI.
+- **`retries`**: 0 locally, 1 in CI (absorbs occasional network flakes
+  without masking real failures).
+- **`trace`/`screenshot`/`video`**: only on retry/failure. Cheap by
+  default, useful when you need them.
+- **`projects`**: `chromium` only. Cross-browser is unnecessary at v0.1
+  scope; add Firefox/WebKit projects later if a specific compatibility
+  concern surfaces.
+
+## Conventions
+
+- **Test by accessible role/label**, not CSS selector. Survives DOM
+  restructuring and forces accessibility hygiene:
+  - ✅ `page.getByRole('button', { name: /sign in/i })`
+  - ❌ `page.locator('.btn-primary')`
+- **One assertion per behavior**, not one per element. A test that
+  asserts "the form rendered" should make several assertions in one
+  test, not three separate tests.
+- **No mocking** — tests run against the real backend and real DB. If you
+  need a starting state, register a fresh user in test setup. Don't
+  share state between tests; each test should set up what it needs.
+- **No sleeps**. Use Playwright's auto-waiting (`expect(locator).toBeVisible()`
+  waits up to `expect.timeout`). If you find yourself reaching for
+  `page.waitForTimeout(...)`, you're probably awaiting something
+  observable instead — wait for *that*.
+
+## CI integration
+
+Currently local-only. PR-workflow integration is tracked in #39
+(smoke only) and nightly/weekend in #40/#41.
+
+## Troubleshooting
+
+**`Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/login`**
+The frontend isn't running. `docker compose up -d` and wait for the
+Vite dev server to log `ready in N ms`.
+
+**`Error: Browser closed`**
+Browser binary missing or out of date.
+`cd frontend && npx playwright install chromium` to (re)install.
+
+**Test passes locally but fails in CI**
+Almost always a race condition. Add an `await expect(...).toBeVisible()`
+on the element you're about to interact with — Playwright's auto-wait
+will absorb the timing difference.
+
+**A "Sign Up" or other duplicate element causes "strict mode violation"**
+Playwright requires unambiguous selectors. The page probably has the
+element in two places (e.g., navbar + form footer). Scope by parent:
+`page.getByText(/don't have an account/i).getByRole('link', { name: /sign up/i })`.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "zustand": "^4.5.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/leaflet": "^1.9.12",
         "@types/leaflet-draw": "^1.0.11",
         "@types/react": "^18.3.3",
@@ -2287,6 +2288,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@react-leaflet/core": {
@@ -5983,6 +6000,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "axios": "^1.7.2",
@@ -20,6 +21,7 @@
     "zustand": "^4.5.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/leaflet": "^1.9.12",
     "@types/leaflet-draw": "^1.0.11",
     "@types/react": "^18.3.3",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for end-to-end tests.
+ *
+ * Tests assume the Docker Compose stack is already running (mysql,
+ * backend, frontend). Start it with `docker compose up -d` and wait
+ * for the backend log line "Annotated Maps backend starting on port
+ * 8080" before running `npm run test:e2e`.
+ *
+ * See ../docs/TESTING-E2E.md.
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  // Fail the build on `test.only` left in source.
+  forbidOnly: !!process.env.CI,
+  // Single retry in CI to absorb flakes; none locally so failures are loud.
+  retries: process.env.CI ? 1 : 0,
+  // Sequential locally so the dev sees what's happening; parallel in CI.
+  workers: process.env.CI ? undefined : 1,
+  // Default per-test timeout. Individual tests can override.
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  reporter: process.env.CI
+    ? [['list'], ['html', { open: 'never' }]]
+    : 'list',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173',
+    // Capture trace on retry only (cheap, useful for debugging flakes).
+    trace: 'on-first-retry',
+    // Screenshots/videos on failure only.
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Smoke test — verifies the Playwright + Vite + backend stack is wired
+ * up correctly. If this fails, none of the other E2E suites
+ * (#34-#38) will run, so it's intentionally minimal: load the login
+ * page and confirm the form renders.
+ */
+test.describe('Login page smoke', () => {
+  test('renders email, password, and submit', async ({ page }) => {
+    await page.goto('/login');
+
+    // Page heading.
+    await expect(page.getByRole('heading', { name: /sign in/i })).toBeVisible();
+
+    // Form fields. We assert by accessible role/label rather than CSS
+    // selector so the test survives DOM restructuring.
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await expect(page.getByLabel('Password')).toBeVisible();
+    await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible();
+
+    // "Sign Up" link is present in the auth-card footer (sanity check that
+    // React Router rendered the LoginForm component, not just navbar shell).
+    // Two "Sign Up" links exist on this page — navbar and form footer —
+    // so we scope to the form's footer text "Don't have an account?".
+    await expect(
+      page.getByText(/don't have an account/i)
+        .getByRole('link', { name: /sign up/i })
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6. Foundation for the E2E suite tracked in #34-#38 and CI integration in #39-#41.

- \`@playwright/test\` + chromium browser binary (one-time ~100 MB download to user's Playwright cache)
- \`frontend/playwright.config.ts\` — testDir \`tests/e2e\`, baseURL \`http://localhost:5173\` (override via \`PLAYWRIGHT_BASE_URL\`), chromium-only, sequential locally / parallel in CI, trace+screenshot+video on retry/failure only
- \`frontend/tests/e2e/smoke.spec.ts\` — minimal smoke loading \`/login\` and asserting form elements render. Will be the canary in front of the feature suites
- \`npm run test:e2e\` script
- \`.gitignore\` entries for Playwright artifacts
- \`docs/TESTING-E2E.md\` — prerequisites, how to run, conventions (test by accessible role/label, no mocking, no sleeps), troubleshooting

## Files changed

- \`.gitignore\` — Add Playwright artifact paths (\`frontend/test-results/\`, \`frontend/playwright-report/\`, \`frontend/blob-report/\`, \`frontend/playwright/.cache/\`)
- \`docs/TESTING-E2E.md\` — New doc covering the E2E tier
- \`frontend/package-lock.json\` — Lock \`@playwright/test\`
- \`frontend/package.json\` — Add \`@playwright/test\` devDep + \`test:e2e\` script
- \`frontend/playwright.config.ts\` — New Playwright config
- \`frontend/tests/e2e/smoke.spec.ts\` — New smoke test

## Test plan

- [x] \`npm run test:e2e\` against the running Docker stack → smoke passes in ~2s
- [x] Frontend \`tsc --noEmit\` + \`npm run lint\` clean
- [x] One real catch by Playwright during development: it correctly flagged a "strict mode violation" when there were two "Sign Up" links on the login page (navbar + form footer). Fixed the test by scoping to the form footer; this is a small validation that the framework is enforcing the right discipline.

Out of scope (tracked separately):
- CI integration (#39, #40, #41)
- Feature E2E suites (#34, #35, #36, #37, #38)

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none** (only false positive: \`>=11.0.0\` in a Node version constraint matches the IP regex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)