### PR TITLE
Test: E2E auth flows + fix CORS preflight regression

### DIFF
--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -132,18 +132,37 @@ int main(int argc, char* argv[]) {
             }
         });
 
-    // Handle preflight OPTIONS globally
-    drogon::app().registerHandler(
-        "/{path}",
-        [](const drogon::HttpRequestPtr& req,
-           std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
-            if (req->method() == drogon::Options) {
-                auto resp = drogon::HttpResponse::newHttpResponse();
-                resp->setStatusCode(drogon::k204NoContent);
-                callback(resp);
+    // Handle preflight OPTIONS globally via sync advice. This runs before
+    // any route matching, so it catches OPTIONS for every URL regardless
+    // of whether a handler is registered for that path.
+    //
+    // Previously this used `registerHandler("/{path}", ...)` which only
+    // matched single-segment paths — multi-segment routes like
+    // /api/v1/auth/register returned 403/404 on OPTIONS and broke the
+    // CORS preflight in the browser.
+    //
+    // Sync advice short-circuits the response BEFORE pre-sending advice
+    // runs, so we must set the CORS headers here rather than rely on the
+    // shared advice below.
+    drogon::app().registerSyncAdvice(
+        [allowedOrigins](const drogon::HttpRequestPtr& req) -> drogon::HttpResponsePtr {
+            if (req->method() != drogon::Options) {
+                return drogon::HttpResponsePtr{};
             }
-        },
-        {drogon::Options});
+            auto resp = drogon::HttpResponse::newHttpResponse();
+            resp->setStatusCode(drogon::k204NoContent);
+
+            const auto& origin = req->getHeader("Origin");
+            if (!origin.empty() && allowedOrigins.count(origin) > 0) {
+                resp->addHeader("Access-Control-Allow-Origin", origin);
+                resp->addHeader("Access-Control-Allow-Credentials", "true");
+                resp->addHeader("Access-Control-Allow-Methods",
+                                "GET,POST,PUT,DELETE,OPTIONS");
+                resp->addHeader("Access-Control-Allow-Headers",
+                                "Content-Type,Authorization");
+            }
+            return resp;
+        });
 
     std::cout << "Annotated Maps backend starting on port 8080…\n";
     drogon::app().run();

--- a/docs/SECURITY-AUDIT.md
+++ b/docs/SECURITY-AUDIT.md
@@ -157,6 +157,10 @@ These are known decisions, not findings. Documented for future auditors.
 
 Three parallel explore agents independently audited backend, frontend, and database layers. Their raw findings were cross-checked against source code by reading the cited file:line references. Findings that turned out to be non-issues (e.g., agents flagged `listTenants` as missing `TenantFilter` — correct behavior, no tenantId in path; flagged `username_taken` distinction as user-enumeration — intentional trade-off documented above) were removed. Severities were calibrated downward where agents were generous, and upward for a few items where agents underestimated exploitability.
 
+### Bugs found by E2E tests after the audit
+
+While building the auth-flow E2E suite (#34), Playwright caught a CORS preflight bug that all three audit agents had missed: the global OPTIONS fallback in `main.cpp` registered against `/{path}`, which Drogon only matches as a single segment. Multi-segment routes like `/api/v1/auth/register` returned 403 on OPTIONS, breaking the browser CORS preflight for every authenticated API call. The bug was masked locally because (a) the dev workflow was clicking through the UI infrequently, and (b) the integration tests use Python's `urllib`, which doesn't trigger CORS preflight. The audit agents read the response-header logic and saw `Access-Control-Allow-Origin` being added on every response — which was true for matched routes, but not for unmatched OPTIONS requests that never reached the pre-sending advice. **Lesson for the next audit:** explicitly check that OPTIONS preflights succeed on every route family, not just that CORS headers are present in successful responses. This is exactly the class of regression that motivated #34-#38 in the first place.
+
 ---
 
 ## Closed findings (audit trail)

--- a/docs/TESTING-E2E.md
+++ b/docs/TESTING-E2E.md
@@ -47,13 +47,15 @@ frontend/
 ├── playwright.config.ts        # config
 ├── tests/
 │   └── e2e/
+│       ├── helpers.ts          # shared utilities (e.g. makeUser())
 │       ├── smoke.spec.ts       # minimal: login page renders
-│       └── *.spec.ts           # one file per feature area (auth, maps, etc.)
+│       ├── auth.spec.ts        # registration / login / logout (#34)
+│       └── *.spec.ts           # one file per feature area
 └── ...
 ```
 
-Per-area suites are tracked in #34–#38. Until those land, only the smoke
-test exists.
+Per-area suites land incrementally — `auth.spec.ts` is in (#34); maps,
+annotations, notes, and cross-tenant are tracked in #35–#38.
 
 ## Configuration
 

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect, Page } from '@playwright/test';
+import { makeUser } from './helpers';
+
+/**
+ * E2E coverage for the auth flows (#34). Each test creates fresh
+ * users — no shared fixture state, so failures are easy to bisect
+ * and the suite is safe to run in parallel.
+ */
+
+// Map URL after a successful login/register lands at /tenants/{N}/maps
+// via the LoginForm → navigate('/maps') → DefaultRedirect chain.
+const MAPS_URL_RE = /\/tenants\/\d+\/maps/;
+
+async function fillRegisterForm(
+  page: Page,
+  user: { username: string; email: string; password: string },
+) {
+  await page.goto('/register');
+  await page.getByLabel('Username').fill(user.username);
+  await page.getByLabel('Email').fill(user.email);
+  await page.getByLabel('Password',         { exact: true }).fill(user.password);
+  await page.getByLabel('Confirm Password', { exact: true }).fill(user.password);
+}
+
+test.describe('Registration', () => {
+  test('new user is redirected to the maps page', async ({ page }) => {
+    const user = makeUser('reg');
+    await fillRegisterForm(page, user);
+    await page.getByRole('button', { name: /create account/i }).click();
+
+    await expect(page).toHaveURL(MAPS_URL_RE);
+    // Navbar shows the username — confirms the auth state actually persisted.
+    await expect(page.getByText(user.username)).toBeVisible();
+  });
+
+  test('duplicate email shows a specific error', async ({ page }) => {
+    // First registration — succeeds.
+    const original = makeUser('dup_email');
+    await fillRegisterForm(page, original);
+    await page.getByRole('button', { name: /create account/i }).click();
+    await expect(page).toHaveURL(MAPS_URL_RE);
+
+    // Second registration with the same email but a fresh username.
+    const collision = { ...makeUser('dup_email_2'), email: original.email };
+    await fillRegisterForm(page, collision);
+    await page.getByRole('button', { name: /create account/i }).click();
+
+    await expect(
+      page.getByText(/this email address is already registered/i)
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\/register$/); // didn't navigate
+  });
+
+  test('duplicate username shows a specific error', async ({ page }) => {
+    const original = makeUser('dup_user');
+    await fillRegisterForm(page, original);
+    await page.getByRole('button', { name: /create account/i }).click();
+    await expect(page).toHaveURL(MAPS_URL_RE);
+
+    const collision = { ...makeUser('dup_user_2'), username: original.username };
+    await fillRegisterForm(page, collision);
+    await page.getByRole('button', { name: /create account/i }).click();
+
+    await expect(
+      page.getByText(/this username is already taken/i)
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\/register$/);
+  });
+});
+
+test.describe('Login', () => {
+  test('valid credentials redirect to the maps page', async ({ page }) => {
+    // Register first (the only way to mint a user via the public surface).
+    const user = makeUser('login_ok');
+    await fillRegisterForm(page, user);
+    await page.getByRole('button', { name: /create account/i }).click();
+    await expect(page).toHaveURL(MAPS_URL_RE);
+
+    // Log out so we can prove the login flow works end-to-end.
+    await page.getByRole('button', { name: /sign out/i }).click();
+    await expect(page).toHaveURL(/\/login$/);
+
+    // Log in.
+    await page.getByLabel('Email').fill(user.email);
+    await page.getByLabel('Password').fill(user.password);
+    await page.getByRole('button', { name: /sign in/i }).click();
+
+    await expect(page).toHaveURL(MAPS_URL_RE);
+  });
+
+  test('wrong password shows a persistent error (not a flash)', async ({ page }) => {
+    const user = makeUser('login_wrong_pw');
+    await fillRegisterForm(page, user);
+    await page.getByRole('button', { name: /create account/i }).click();
+    await expect(page).toHaveURL(MAPS_URL_RE);
+    await page.getByRole('button', { name: /sign out/i }).click();
+    await expect(page).toHaveURL(/\/login$/);
+
+    await page.getByLabel('Email').fill(user.email);
+    await page.getByLabel('Password').fill('definitely_not_the_real_password');
+    await page.getByRole('button', { name: /sign in/i }).click();
+
+    // The error must be visible AND we must still be on /login.
+    // (Bug #55 was that the 401 interceptor redirected to /login,
+    // dropping the error mid-flash. Asserting URL still matches /login
+    // and that the error text is visible catches a regression of that.)
+    await expect(page.getByText(/invalid email or password/i)).toBeVisible();
+    await expect(page).toHaveURL(/\/login$/);
+  });
+
+  test('non-existent email returns the same generic error', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(`nobody_${Date.now().toString(36)}@e2e.test`);
+    await page.getByLabel('Password').fill('whatever_password_will_do');
+    await page.getByRole('button', { name: /sign in/i }).click();
+
+    // Identical message to the wrong-password case — server hides the
+    // distinction to prevent email enumeration on the login endpoint.
+    await expect(page.getByText(/invalid email or password/i)).toBeVisible();
+    await expect(page).toHaveURL(/\/login$/);
+  });
+});
+
+test.describe('Logout', () => {
+  test('logout returns to /login and protected routes redirect back', async ({ page }) => {
+    const user = makeUser('logout');
+    await fillRegisterForm(page, user);
+    await page.getByRole('button', { name: /create account/i }).click();
+    await expect(page).toHaveURL(MAPS_URL_RE);
+
+    // Capture the post-login URL so we can try to revisit it after logout.
+    const protectedUrl = page.url();
+
+    // Log out via the navbar button.
+    await page.getByRole('button', { name: /sign out/i }).click();
+    await expect(page).toHaveURL(/\/login$/);
+
+    // Visiting the previously-authenticated map page should bounce back.
+    await page.goto(protectedUrl);
+    await expect(page).toHaveURL(/\/login(\?.*)?$/);
+  });
+});

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -1,0 +1,31 @@
+/**
+ * Helpers shared across E2E specs.
+ *
+ * Tests run against a live backend with a persistent database, so each
+ * test must use unique credentials to avoid duplicate-key collisions
+ * with prior runs.
+ */
+
+let counter = 0;
+
+/**
+ * Generate a unique user object scoped to the current test run.
+ * `tag` should be a short test-identifying string (e.g. 'reg', 'login')
+ * to make it easy to spot leftover rows in the dev DB.
+ */
+export function makeUser(tag: string): {
+  username: string;
+  email: string;
+  password: string;
+} {
+  // 8-char base36 from the high bits of Date.now() collides only across
+  // ~50-day windows, plus a per-test counter so tests in the same
+  // millisecond stay unique.
+  counter += 1;
+  const id = Date.now().toString(36).slice(-8) + counter.toString(36);
+  return {
+    username: `e2e_${tag}_${id}`,
+    email:    `e2e_${tag}_${id}@e2e.test`,
+    password: 'pw_for_e2e_test_only',
+  };
+}


### PR DESCRIPTION
## Summary

Closes #34. Adds the auth-flow E2E suite covering all 7 task items: registration (success, duplicate email, duplicate username), login (valid credentials, wrong password, non-existent email), and logout (return to \`/login\` + protected-route redirect-back).

While writing these tests, Playwright surfaced a CORS preflight bug in \`main.cpp\` that the security audit had missed. **Fix included in this PR.**

## The CORS bug

The global OPTIONS fallback in \`main.cpp\` registered against \`/{path}\`. Drogon only matches \`{path}\` against a single segment, so multi-segment routes like \`/api/v1/auth/register\` returned **403 on OPTIONS**, breaking the browser CORS preflight for every authenticated API call.

Why nobody caught it before:
- Manual UI testing was sporadic (click here, click there) — easy to miss
- Backend integration tests use Python's \`urllib\`, which doesn't trigger CORS preflight (no \`Origin\` header)
- The audit agents checked that CORS headers were present in successful responses; they never checked OPTIONS specifically

**Fix:** Replace \`registerHandler("/{path}", ..., {drogon::Options})\` with \`registerSyncAdvice(...)\` that intercepts OPTIONS before route matching. Sync advice short-circuits the response before pre-sending advice runs, so the CORS headers are set inline in the OPTIONS handler. Manual verification: OPTIONS for \`/foo\`, \`/api\`, \`/api/v1/auth/register\`, and \`/api/v1/tenants/1/maps\` all return 204 with correct CORS headers.

\`SECURITY-AUDIT.md\` gained a "Bugs found by E2E tests after the audit" subsection documenting the miss for future-audit hygiene.

## Files changed

- \`backend/src/main.cpp\` — Replace OPTIONS handler with \`registerSyncAdvice\` that sets CORS headers inline
- \`docs/SECURITY-AUDIT.md\` — Document the CORS preflight bug as a lesson for the next audit
- \`docs/TESTING-E2E.md\` — Update file layout to mention \`auth.spec.ts\` and \`helpers.ts\`
- \`frontend/tests/e2e/auth.spec.ts\` — New: 7 tests covering all #34 task items
- \`frontend/tests/e2e/helpers.ts\` — New: \`makeUser(tag)\` for unique-per-test credentials

## Test plan

- [x] \`npm run test:e2e\` → 8 passed (~7s)
- [x] \`python3 database/tests/run-db-tests.py\` → 110 passed
- [x] \`python3 backend/tests/run-tests.py --tier fast\` → all suites passed
- [x] Manual: OPTIONS preflight at multiple path depths returns 204 + CORS headers
- [x] Manual: backend startup logs unchanged

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none** (only false positive: \`localhost:5173\` in test code, which is intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)