### PR TITLE
Test: CORS preflight coverage + CORS helper consolidation

### DIFF
--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -87,10 +87,26 @@ int main(int argc, char* argv[]) {
     const char* prodEnv = std::getenv("PRODUCTION");
     const bool isProduction = prodEnv && std::string(prodEnv) == "1";
 
+    // CORS header helper. Both the OPTIONS sync advice (preflight) and the
+    // pre-sending advice (every other response) need to add the same
+    // headers when Origin is in the allowlist. Single source of truth.
+    auto applyCorsHeaders =
+        [allowedOrigins](const drogon::HttpRequestPtr& req,
+                         const drogon::HttpResponsePtr& resp) {
+            const auto& origin = req->getHeader("Origin");
+            if (origin.empty() || allowedOrigins.count(origin) == 0) return;
+            resp->addHeader("Access-Control-Allow-Origin", origin);
+            resp->addHeader("Access-Control-Allow-Credentials", "true");
+            resp->addHeader("Access-Control-Allow-Methods",
+                            "GET,POST,PUT,DELETE,OPTIONS");
+            resp->addHeader("Access-Control-Allow-Headers",
+                            "Content-Type,Authorization");
+        };
+
     // ── H2 + M6 + M7 + L4: Security headers + CORS ───────────────────────────
     drogon::app().registerPreSendingAdvice(
-        [allowedOrigins, isProduction](const drogon::HttpRequestPtr& req,
-                                       const drogon::HttpResponsePtr& resp) {
+        [applyCorsHeaders, isProduction](const drogon::HttpRequestPtr& req,
+                                         const drogon::HttpResponsePtr& resp) {
             // Baseline security headers on every response
             resp->addHeader("X-Content-Type-Options", "nosniff");
             resp->addHeader("X-Frame-Options", "DENY");
@@ -120,16 +136,7 @@ int main(int argc, char* argv[]) {
                 }
             }
 
-            // CORS — only allow whitelisted origins
-            const auto& origin = req->getHeader("Origin");
-            if (!origin.empty() && allowedOrigins.count(origin) > 0) {
-                resp->addHeader("Access-Control-Allow-Origin", origin);
-                resp->addHeader("Access-Control-Allow-Credentials", "true");
-                resp->addHeader("Access-Control-Allow-Methods",
-                                "GET,POST,PUT,DELETE,OPTIONS");
-                resp->addHeader("Access-Control-Allow-Headers",
-                                "Content-Type,Authorization");
-            }
+            applyCorsHeaders(req, resp);
         });
 
     // Handle preflight OPTIONS globally via sync advice. This runs before
@@ -142,25 +149,17 @@ int main(int argc, char* argv[]) {
     // CORS preflight in the browser.
     //
     // Sync advice short-circuits the response BEFORE pre-sending advice
-    // runs, so we must set the CORS headers here rather than rely on the
-    // shared advice below.
+    // runs, so we must apply CORS headers inline here too rather than
+    // rely on the pre-sending advice. The helper above keeps the two
+    // sites consistent.
     drogon::app().registerSyncAdvice(
-        [allowedOrigins](const drogon::HttpRequestPtr& req) -> drogon::HttpResponsePtr {
+        [applyCorsHeaders](const drogon::HttpRequestPtr& req) -> drogon::HttpResponsePtr {
             if (req->method() != drogon::Options) {
                 return drogon::HttpResponsePtr{};
             }
             auto resp = drogon::HttpResponse::newHttpResponse();
             resp->setStatusCode(drogon::k204NoContent);
-
-            const auto& origin = req->getHeader("Origin");
-            if (!origin.empty() && allowedOrigins.count(origin) > 0) {
-                resp->addHeader("Access-Control-Allow-Origin", origin);
-                resp->addHeader("Access-Control-Allow-Credentials", "true");
-                resp->addHeader("Access-Control-Allow-Methods",
-                                "GET,POST,PUT,DELETE,OPTIONS");
-                resp->addHeader("Access-Control-Allow-Headers",
-                                "Content-Type,Authorization");
-            }
+            applyCorsHeaders(req, resp);
             return resp;
         });
 

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -33,6 +33,8 @@ def assert_status(test_name: str, expected: int, actual: int):
         _errors.append(msg)
 
 
+
+
 def assert_json_field(test_name: str, body: dict, keys: list, expected):
     global _passed, _failed
     try:
@@ -75,13 +77,13 @@ def assert_json_exists(test_name: str, body: dict, keys: list):
         _errors.append(msg)
 
 
-def assert_true(test_name: str, condition: bool):
+def assert_true(test_name: str, condition: bool, detail: str = ""):
     global _passed, _failed
     if condition:
         print(f"PASS: {test_name}")
         _passed += 1
     else:
-        msg = f"FAIL: {test_name}"
+        msg = f"FAIL: {test_name}" + (f" — {detail}" if detail else "")
         print(msg)
         _failed += 1
         _errors.append(msg)
@@ -134,6 +136,32 @@ def http_put(path: str, data: dict = None, token: str = None) -> tuple:
 
 def http_delete(path: str, token: str = None) -> tuple:
     return _request("DELETE", path, token=token)
+
+
+SERVER = API.rsplit("/api/", 1)[0]  # e.g. http://localhost:8080
+
+
+def http_options(path: str, origin: str = None) -> tuple:
+    """OPTIONS preflight request.
+
+    `path` is server-absolute (must start with /), so this can hit paths
+    outside the /api/v1 prefix (e.g., '/foo' to verify single-segment
+    OPTIONS handling).
+
+    Returns (status_code, headers_dict).
+    """
+    url = f"{SERVER}{path}"
+    headers = {"Access-Control-Request-Method": "POST"}
+    if origin is not None:
+        headers["Origin"] = origin
+    req = urllib.request.Request(url, headers=headers, method="OPTIONS")
+    try:
+        with urllib.request.urlopen(req, timeout=CURL_TIMEOUT) as resp:
+            return resp.status, dict(resp.headers)
+    except urllib.error.HTTPError as e:
+        return e.code, dict(e.headers)
+    except Exception:
+        return 0, {}
 
 
 def http_get_headers(path: str) -> dict:

--- a/backend/tests/run-tests.py
+++ b/backend/tests/run-tests.py
@@ -44,6 +44,7 @@ FAST_TESTS = [
     "test_11_notes.py",
     "test_12_annotation_edit_delete_move.py",
     "test_13_note_groups.py",
+    "test_15_cors.py",
 ]
 
 NIGHTLY_EXTRA = ["test_07_rate_limit_slow.py"]

--- a/backend/tests/test_15_cors.py
+++ b/backend/tests/test_15_cors.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""test_15_cors.py — CORS preflight coverage.
+
+Regression net for the bug PR #66 discovered: the OPTIONS fallback
+only matched single-segment paths, so multi-segment routes returned
+403 on preflight and broke CORS for the browser. These tests exercise
+OPTIONS at multiple path depths and verify CORS headers are set
+correctly based on the Origin header.
+
+The Python integration tests don't normally send an Origin header
+(they use urllib, not a browser), so this file is the only place the
+CORS preflight path is tested without the full browser stack.
+"""
+
+import os
+import sys
+import urllib.request
+import urllib.error
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import (
+    reset_counters, report, assert_status, assert_true, http_options, API,
+)
+
+reset_counters()
+
+# The dev backend configures http://localhost:5173 as an allowed origin
+# (see backend/config.docker.json `allowed_origins`). We assert against
+# that value directly — if the config changes, this test updates with it.
+ALLOWED_ORIGIN = "http://localhost:5173"
+BOGUS_ORIGIN   = "https://attacker.example"
+
+print("=== CORS Preflight Tests ===")
+
+# ─── Path depth coverage ──────────────────────────────────────────────────────
+# Confirms the OPTIONS handler matches paths of arbitrary depth. Before the
+# PR #66 fix, everything except the /foo case returned 403.
+
+print("  --- Path depth ---")
+
+for path in [
+    "/foo",                             # single segment (worked even before fix)
+    "/api",                             # single, under /api
+    "/api/v1",                          # two segments
+    "/api/v1/auth/register",            # four segments — the actual broken case
+    "/api/v1/tenants/1/maps",           # five segments
+    "/api/v1/tenants/1/maps/99/notes",  # seven segments
+    "/this/path/does/not/exist/at/all", # nonexistent — the handler is global
+]:
+    status, _ = http_options(path, origin=ALLOWED_ORIGIN)
+    assert_status(f"OPTIONS {path} returns 204", 204, status)
+
+# ─── CORS header correctness ──────────────────────────────────────────────────
+
+print("  --- CORS header correctness (allowed origin) ---")
+
+_, headers = http_options("/api/v1/auth/register", origin=ALLOWED_ORIGIN)
+hl = {k.lower(): v for k, v in headers.items()}
+
+assert_true("Allow-Origin echoes the allowed Origin",
+            hl.get("access-control-allow-origin") == ALLOWED_ORIGIN,
+            detail=f"got {hl.get('access-control-allow-origin')!r}")
+assert_true("Allow-Credentials is true",
+            hl.get("access-control-allow-credentials") == "true")
+methods = hl.get("access-control-allow-methods", "")
+for verb in ("GET", "POST", "PUT", "DELETE", "OPTIONS"):
+    assert_true(f"Allow-Methods includes {verb}", verb in methods)
+allowed_headers = hl.get("access-control-allow-headers", "")
+assert_true("Allow-Headers includes Content-Type",
+            "Content-Type" in allowed_headers)
+assert_true("Allow-Headers includes Authorization",
+            "Authorization" in allowed_headers)
+
+# ─── Disallowed origin ────────────────────────────────────────────────────────
+# Preflight must still return 204 (the handler fires), but
+# Access-Control-Allow-Origin must NOT echo the attacker's origin.
+# The browser then rejects the real request because there's no matching
+# Allow-Origin.
+
+print("  --- CORS header correctness (disallowed origin) ---")
+
+status, headers = http_options("/api/v1/auth/register", origin=BOGUS_ORIGIN)
+hl = {k.lower(): v for k, v in headers.items()}
+assert_status("OPTIONS with disallowed Origin still returns 204", 204, status)
+assert_true("disallowed Origin is NOT echoed in Allow-Origin",
+            hl.get("access-control-allow-origin") is None,
+            detail=f"got {hl.get('access-control-allow-origin')!r}")
+
+# ─── No Origin header ─────────────────────────────────────────────────────────
+# Same-origin or non-browser requests won't send Origin. Preflight still
+# succeeds (204); no CORS headers set.
+
+print("  --- No Origin header ---")
+
+status, headers = http_options("/api/v1/auth/register", origin=None)
+hl = {k.lower(): v for k, v in headers.items()}
+assert_status("OPTIONS without Origin returns 204", 204, status)
+assert_true("no Origin → no Allow-Origin header",
+            hl.get("access-control-allow-origin") is None)
+
+# ─── Non-OPTIONS responses also include CORS for allowed origin ───────────────
+# The CORS helper is called from both the OPTIONS sync advice and the
+# pre-sending advice. This verifies the pre-sending path still works
+# after the refactor that consolidated the two copies.
+
+print("  --- Non-OPTIONS responses still include CORS ---")
+
+req = urllib.request.Request(
+    f"{API}/auth/login", data=b'{}', method="POST"
+)
+req.add_header("Content-Type", "application/json")
+req.add_header("Origin", ALLOWED_ORIGIN)
+try:
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        post_headers = {k.lower(): v for k, v in dict(resp.headers).items()}
+except urllib.error.HTTPError as e:
+    # Empty login body returns 400 — that's what we want; we just need
+    # to read the response headers.
+    post_headers = {k.lower(): v for k, v in dict(e.headers).items()}
+
+assert_true("POST error response still includes Allow-Origin",
+            post_headers.get("access-control-allow-origin") == ALLOWED_ORIGIN,
+            detail=f"got {post_headers.get('access-control-allow-origin')!r}")
+
+sys.exit(0 if report() else 1)

--- a/docs/TESTING-BACKEND.md
+++ b/docs/TESTING-BACKEND.md
@@ -50,6 +50,7 @@ python3 backend/tests/run-tests.py --only 1
 | `test_11_notes.py` | fast | Notes CRUD, cross-org isolation |
 | `test_12_annotation_edit_delete_move.py` | fast | Annotation edit, delete, move for all geometry types |
 | `test_13_note_groups.py` | fast | Note group CRUD, note-group assignment, filtering, permissions |
+| `test_15_cors.py` | fast | CORS preflight: OPTIONS at all path depths, Allow-Origin echo for allowed Origins, absence for bogus ones |
 
 ## How it works
 


### PR DESCRIPTION
## Summary

Closes #67. Regression net at the integration tier for the CORS preflight bug PR #66 found, plus the small refactor (B) folded in.

- **\`test_15_cors.py\`** (21 assertions) — OPTIONS at all path depths, correct header echo for allowed Origin, no echo for disallowed Origin, no CORS headers when Origin is absent, and verification that the non-OPTIONS pre-sending-advice path still sets CORS for allowed Origins
- **\`helpers.py\`** — new \`http_options()\` helper and \`SERVER\` constant derived from \`API\`; added optional \`detail=\` to the existing \`assert_true\` (backward-compatible)
- **\`main.cpp\`** — consolidated the CORS header logic into an \`applyCorsHeaders\` lambda used by both the OPTIONS sync advice and the pre-sending advice (was duplicated after PR #66's fix)
- **\`TESTING-BACKEND.md\`** + **\`run-tests.py\`** — wire the new test into the fast tier

## Files changed

- \`backend/src/main.cpp\` — Extract \`applyCorsHeaders\` lambda; both advice sites use it (no behavior change)
- \`backend/tests/helpers.py\` — \`http_options()\`, \`SERVER\` constant, optional \`detail=\` on \`assert_true\`
- \`backend/tests/run-tests.py\` — Add \`test_15_cors.py\` to \`FAST_TESTS\`
- \`backend/tests/test_15_cors.py\` — New test file, 21 assertions
- \`docs/TESTING-BACKEND.md\` — File table includes \`test_15_cors.py\`

## Test plan

- [x] \`python3 backend/tests/run-tests.py --only 15\` → 21/21 passed
- [x] \`python3 backend/tests/run-tests.py --tier fast\` → all suites passed (including the new one)
- [x] \`python3 database/tests/run-db-tests.py\` → 110 passed
- [x] \`cd frontend && npm run test:e2e\` → 8 passed (auth suite still green after the refactor)

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none** (only \`https://attacker.example\` which is a deliberate test value for the disallowed-Origin assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)