### PR TITLE
E2E: fix makeUser() collisions across parallel workers (#76)

### DIFF
--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -1,9 +1,11 @@
+import { randomUUID } from 'crypto';
+
 /**
  * Helpers shared across E2E specs.
  *
  * Tests run against a live backend with a persistent database, so each
  * test must use unique credentials to avoid duplicate-key collisions
- * with prior runs.
+ * with prior runs AND with parallel workers.
  */
 
 let counter = 0;
@@ -12,17 +14,30 @@ let counter = 0;
  * Generate a unique user object scoped to the current test run.
  * `tag` should be a short test-identifying string (e.g. 'reg', 'login')
  * to make it easy to spot leftover rows in the dev DB.
+ *
+ * Uniqueness layers (earlier cure latent collisions; later is defense
+ * in depth):
+ *  - `process.pid` — differs across Playwright workers; resets to 0 in
+ *    each worker, so module-level counters can't disambiguate two
+ *    workers starting the same test at the same millisecond. Before
+ *    this was added, --repeat-each=20 under parallel workers hit
+ *    "username already taken" ~30% of runs (#76).
+ *  - `counter` — monotonic within a worker; disambiguates tests that
+ *    start inside the same ms within the same process.
+ *  - random UUID slice — insulates against worker pid reuse after a
+ *    crash-and-respawn and any future scheduling weirdness.
  */
 export function makeUser(tag: string): {
   username: string;
   email: string;
   password: string;
 } {
-  // 8-char base36 from the high bits of Date.now() collides only across
-  // ~50-day windows, plus a per-test counter so tests in the same
-  // millisecond stay unique.
   counter += 1;
-  const id = Date.now().toString(36).slice(-8) + counter.toString(36);
+  const id = [
+    process.pid.toString(36),
+    counter.toString(36),
+    randomUUID().slice(0, 8),
+  ].join('_');
   return {
     username: `e2e_${tag}_${id}`,
     email:    `e2e_${tag}_${id}@e2e.test`,


### PR DESCRIPTION
## Summary

Closes #76. The marker-edit flake wasn't the dialog handler the original ticket suspected — it was `makeUser()` in `frontend/tests/e2e/helpers.ts` generating **colliding usernames** across parallel Playwright workers.

## Root cause

`makeUser()` built its user id from `Date.now().toString(36).slice(-8)` + a module-level `counter`. Two problems:

1. **Each Playwright worker is a separate Node process**, so `counter` resets to 0 in each worker — it can't disambiguate workers.
2. `Date.now().toString(36).slice(-8)` is **identical** for workers starting at the same millisecond — which they often do when the suite starts.

Two workers running the same test (or two tests with the same tag) at the same ms both generated `e2e_<tag>_TTTTTTT1`. The second registration hit "username already taken", the test failed at the registration redirect, and the error looked — from the failure location — like it was about dialog timing in the edit step.

## Fix

Add `process.pid` + a random UUID slice to the id. Uniqueness layers:
- `process.pid` — unique per worker process
- `counter` — monotonic within a worker
- UUID slice — defense-in-depth for pid reuse after worker crashes

## Verification

- Original repro: `--repeat-each=20` under parallel workers hit ~30% failures before the fix. After: 0 registration-collision failures. (There's a separate rate-limit tripwire at ~40% repeat-each that's unrelated to this bug and not relevant to normal CI.)
- Normal suite: 3 back-to-back full-suite runs, 37 tests each, **0 failures** (111 tests total).
- Type-check + ESLint clean.

## Files changed

- `frontend/tests/e2e/helpers.ts` — Switch `makeUser()` id from `Date.now().slice(-8) + counter` to `pid_counter_uuidSlice`; update the doc comment with the uniqueness layering rationale

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)