### PR TITLE
Fix count_lines.py: actually enforce IGNORE_FILES (#78)

### DIFF
--- a/count_lines.py
+++ b/count_lines.py
@@ -43,7 +43,7 @@ def examine_directory(path):
         if filename.is_dir():
             if filename.name not in IGNORE_DIRECTORIES:
                 count += examine_directory(filename)
-        elif filename.suffix in DESIRED_SUFFIXES:
+        elif filename.suffix in DESIRED_SUFFIXES and filename.name not in IGNORE_FILES:
             data = filename.read_text()
             count += len(data.split('\n'))
             if (count == 0):


### PR DESCRIPTION
## Summary

Closes #78. `count_lines.py` defined `IGNORE_FILES = ['package-lock.json', 'package.json']` but the directory walker never consulted it — `package.json` and `package-lock.json` were still being counted in the totals despite the intent.

One-line fix: add the missing `and filename.name not in IGNORE_FILES` check on the file branch of [count_lines.py:46](count_lines.py#L46).

## Files changed

- `count_lines.py` — Add the missing IGNORE_FILES check in `examine_directory`

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)