### PR TITLE
CI: Run Playwright E2E suite in nightly workflow (#40)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,23 @@ jobs:
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,scope=frontend,mode=max
 
+      # Install frontend deps on the runner BEFORE starting the stack so
+      # frontend/node_modules exists owned by `runner`. The frontend
+      # container bind-mounts ./frontend:/app with an anonymous volume on
+      # /app/node_modules to shadow the host dir; without pre-creating the
+      # dir as `runner`, Docker creates it as root and the runner's later
+      # npm ci EACCES'es. Same fix as pr-tests.yml.
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
       - name: Start stack
         run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d
 
@@ -76,6 +93,41 @@ jobs:
         run: python3 backend/tests/run-tests.py --tier nightly
         env:
           CURL_TIMEOUT: "30"
+
+      # ── E2E (Playwright) ────────────────────────────────────────────────────
+      # Runs the full E2E suite. Chromium is reinstalled each run (~30s);
+      # we don't cache ~/.cache/ms-playwright — the cache is workflow-trigger
+      # scoped and on first MISS the upload can stall at ~75% indefinitely
+      # (see pr-tests.yml comment for the full story).
+      - name: Install Playwright + system deps
+        run: npx playwright install --with-deps chromium
+        working-directory: frontend
+
+      - name: Wait for frontend
+        run: |
+          echo "Waiting for frontend..."
+          for i in $(seq 1 18); do
+            if curl -sf -o /dev/null http://localhost:5173 2>/dev/null; then
+              echo "Frontend is ready"
+              break
+            fi
+            echo "  attempt $i..."
+            sleep 5
+          done
+
+      - name: Run E2E tests (Playwright)
+        run: npm run test:e2e
+        working-directory: frontend
+        env:
+          CI: "true"
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 14
 
       - name: Show backend logs on failure
         if: failure()

--- a/docs/TESTING-E2E.md
+++ b/docs/TESTING-E2E.md
@@ -108,10 +108,10 @@ If the E2E suite fails, the workflow uploads `frontend/playwright-report/`
 as a `playwright-report` artifact. Download it from the run page and
 open `index.html` to see traces, screenshots, and videos.
 
-Nightly/weekend integration is deferred — the suite is fast enough
-(<10s on the current set) that running it on every PR is the only
-tier currently needed. Tracked in #40/#41 if/when the suite grows
-slow enough to warrant a separate cadence.
+The same suite also runs in `.github/workflows/nightly.yml` (#40)
+after the nightly backend tier — flake-detection on a real schedule.
+Failed-run reports are kept as `playwright-report` artifacts for 14
+days. Weekend integration is tracked in #41.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Closes #40. Adds the full Playwright E2E suite (29 tests across auth / maps / annotations / notes / cross-tenant) to the existing nightly workflow, mirroring the `pr-tests.yml` setup. Runs after the backend nightly tier (which already includes the 300s rate-limit window expiry test).

## What runs in the nightly job (in order, after this change)

1–4. (existing) Checkout, Buildx, build backend image, build frontend image
5. **Set up Node.js + npm ci** (new — must run before `Start stack`, see comment in workflow for the bind-mount race that bit pr-tests.yml)
6–10. (existing) Start stack, wait for MySQL/backend, db tests, backend nightly tier
11. **Install Playwright + chromium** (new)
12. **Wait for frontend** (new)
13. **Run E2E tests** (new — `npm run test:e2e`)
14. **Upload Playwright report on failure** (new — `playwright-report` artifact, 14-day retention since nightly failures may not be looked at until the next workday)
15–16. (existing) Show backend logs on failure, stop stack

## Notes

- **No `~/.cache/ms-playwright` cache.** Same reasoning as pr-tests.yml — the cache is workflow-trigger scoped and on first MISS the upload can stall at ~75% indefinitely. Chromium reinstall is ~30s, well below the 30-min job timeout.
- **Email notification** (issue task #4): GitHub Actions sends the default workflow-failure email automatically; any E2E failure will trip that. Nothing extra needed.

## Files changed

- `.github/workflows/nightly.yml` — Add Set up Node.js + Install frontend deps before `Start stack`; add Install Playwright + Wait for frontend + Run E2E + Upload Playwright report after the backend tier
- `docs/TESTING-E2E.md` — Update CI integration section to mention nightly cadence; flag that #41 (weekend) is the next thing

## Verification

- YAML parses cleanly via PyYAML; the test job has the expected 17 steps in the expected order
- Same Playwright invocation that already passes in pr-tests.yml (37/37 in the most recent runs after the makeUser fix from #76)

The first scheduled nightly run (or a `workflow_dispatch` trigger from the Actions tab) is the actual integration test for this change.

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none** (only `localhost:5173` and `localhost:8080` which are intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)