### PR TITLE
CI: Run Playwright E2E suite in weekend workflow (#41)

### DIFF
--- a/.github/workflows/weekend.yml
+++ b/.github/workflows/weekend.yml
@@ -18,12 +18,30 @@ jobs:
         uses: actions/checkout@v4
 
       # No Docker layer cache — clean build to catch stale dependency issues
-      - name: Build and start stack (no cache)
-        run: |
-          docker compose build --no-cache
-          docker compose up -d
+      - name: Build stack (no cache)
+        run: docker compose build --no-cache
         env:
           DOCKER_BUILDKIT: 1
+
+      # Install frontend deps on the runner BEFORE starting the stack so
+      # frontend/node_modules exists owned by `runner`. The frontend
+      # container bind-mounts ./frontend:/app with an anonymous volume on
+      # /app/node_modules to shadow the host dir; without pre-creating the
+      # dir as `runner`, Docker creates it as root and the runner's later
+      # npm ci EACCES'es. Same fix as pr-tests.yml and nightly.yml.
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Start stack
+        run: docker compose up -d
 
       - name: Wait for MySQL to be healthy
         run: |
@@ -56,6 +74,40 @@ jobs:
         run: python3 backend/tests/run-tests.py --tier extended
         env:
           CURL_TIMEOUT: "30"
+
+      # ── E2E (Playwright) ────────────────────────────────────────────────────
+      # Same suite as nightly. Runs against the no-cache-built images so a
+      # broken dependency surfaces here even if the cached PR/nightly runs
+      # would have masked it.
+      - name: Install Playwright + system deps
+        run: npx playwright install --with-deps chromium
+        working-directory: frontend
+
+      - name: Wait for frontend
+        run: |
+          echo "Waiting for frontend..."
+          for i in $(seq 1 18); do
+            if curl -sf -o /dev/null http://localhost:5173 2>/dev/null; then
+              echo "Frontend is ready"
+              break
+            fi
+            echo "  attempt $i..."
+            sleep 5
+          done
+
+      - name: Run E2E tests (Playwright)
+        run: npm run test:e2e
+        working-directory: frontend
+        env:
+          CI: "true"
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 14
 
       - name: Show backend logs on failure
         if: failure()

--- a/docs/TESTING-E2E.md
+++ b/docs/TESTING-E2E.md
@@ -108,10 +108,12 @@ If the E2E suite fails, the workflow uploads `frontend/playwright-report/`
 as a `playwright-report` artifact. Download it from the run page and
 open `index.html` to see traces, screenshots, and videos.
 
-The same suite also runs in `.github/workflows/nightly.yml` (#40)
-after the nightly backend tier — flake-detection on a real schedule.
-Failed-run reports are kept as `playwright-report` artifacts for 14
-days. Weekend integration is tracked in #41.
+The same suite also runs in `.github/workflows/nightly.yml` (#40) and
+`.github/workflows/weekend.yml` (#41). Nightly catches flakes on a
+weekday cadence; the weekend run uses `--no-cache` Docker builds so
+the E2E suite is the canary for a broken dependency that the cached
+PR/nightly runs would have masked. Failed-run Playwright reports are
+kept as `playwright-report` artifacts for 14 days on both schedules.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Closes #41. Adds the full Playwright E2E suite to the weekend extended-tier workflow, mirroring the nightly setup from #40. The weekend job builds with `--no-cache`, so the E2E suite acts as a canary for dependency drift that the cached PR/nightly builds would have masked.

## Changes to weekend.yml

- **Split** "Build and start stack (no cache)" → "Build stack (no cache)" + "Start stack" so the runner can install Node.js and run `npm ci` between them (avoids the bind-mount/anon-volume race that bit pr-tests.yml; same fix as nightly).
- **Add** Set up Node.js + Install frontend dependencies before `Start stack`.
- **Add** Install Playwright + Wait for frontend + Run E2E + Upload Playwright report on failure (14-day retention) after the backend extended tier.

## Final step order (15 steps)

1. Checkout code
2. Build stack (no cache)
3–4. Set up Node.js, Install frontend deps
5. Start stack
6–7. Wait for MySQL, Wait for backend
8–9. Run database tests, Run backend tests (extended tier)
10–13. Install Playwright, Wait for frontend, Run E2E, Upload report on failure
14–15. Show backend logs on failure, Stop stack

## Files changed

- `.github/workflows/weekend.yml` — Split build/start; add Node.js + npm ci; add Playwright install + run + report upload
- `docs/TESTING-E2E.md` — Update CI integration section to mention both nightly and weekend cadences

## Verification

- YAML parses cleanly via PyYAML; 15 steps in expected order
- Same Playwright invocation as PR/nightly (already green there)
- First scheduled Saturday run (or `workflow_dispatch`) is the actual integration test

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none** (only `localhost:5173` and `localhost:8080`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)