### PR TITLE
ci: extend pr-tests.yml to also run on nodes-rebuild

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,7 +2,16 @@ name: PR Tests
 
 on:
   pull_request:
-    branches: [main]
+    # `nodes-rebuild` is a long-running rebuild branch; PRs into it run
+    # the full suite for visibility, though main is the enforced gate
+    # (no ruleset on nodes-rebuild — see PR description). E2E will fail
+    # on nodes-rebuild PRs until the frontend phases (#92+) catch up;
+    # that's expected mid-rebuild.
+    branches: [main, nodes-rebuild]
+  push:
+    # Verify the integrated state after each merge into nodes-rebuild,
+    # not just per-PR. Belt-and-suspenders for cumulative regressions.
+    branches: [nodes-rebuild]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary

Adds the long-running \`nodes-rebuild\` branch as a second target for the PR Tests workflow:

\`\`\`yaml
on:
  pull_request:
    branches: [main, nodes-rebuild]
  push:
    branches: [nodes-rebuild]
\`\`\`

PRs into \`nodes-rebuild\` (like #97) now run the full lint + security + compile + integration suite, and pushes to \`nodes-rebuild\` re-verify the integrated state after each merge.

No ruleset / required-check enforcement on \`nodes-rebuild\` — \`main\` remains the enforced gate. Mid-rebuild, the **E2E portion of the integration job will fail** on \`nodes-rebuild\` PRs until the frontend phases (#92, #101, #102, etc.) catch up to the new backend. That's expected and informational; backend + db tests will pass throughout.

When \`nodes-rebuild\` eventually merges into \`main\`, that final PR runs under main's existing ruleset (all four checks required) — the natural quality gate for the rebuild as a whole.

## Files changed

- \`.github/workflows/pr-tests.yml\` — Add \`nodes-rebuild\` to the \`pull_request.branches\` list and add a \`push\` trigger on \`nodes-rebuild\`. Inline comment explains the mid-rebuild E2E expectation.

## Verification

- YAML parses (\`pull_request.branches\` accepts an array; new \`push\` key is at the same level)
- No behavioral change for \`main\` PRs
- The change itself is too small to need its own E2E

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

## Follow-up

Once this lands, I'll apply the same change directly on \`nodes-rebuild\` (small follow-up PR) so PR #97 can be re-triggered to actually run CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)