### PR TITLE
ci: mirror pr-tests.yml change onto nodes-rebuild (companion to #108)

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,7 +2,16 @@ name: PR Tests
 
 on:
   pull_request:
-    branches: [main]
+    # `nodes-rebuild` is a long-running rebuild branch; PRs into it run
+    # the full suite for visibility, though main is the enforced gate
+    # (no ruleset on nodes-rebuild — see PR description). E2E will fail
+    # on nodes-rebuild PRs until the frontend phases (#92+) catch up;
+    # that's expected mid-rebuild.
+    branches: [main, nodes-rebuild]
+  push:
+    # Verify the integrated state after each merge into nodes-rebuild,
+    # not just per-PR. Belt-and-suspenders for cumulative regressions.
+    branches: [nodes-rebuild]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary

Companion to **#108** (the same change going onto \`main\`). For \`pull_request\` events, GitHub Actions reads the workflow file from the **base branch's tip** — meaning even after #108 lands on \`main\`, PRs targeting \`nodes-rebuild\` won't trigger CI until the same change lives on \`nodes-rebuild\` itself.

This PR puts the change on \`nodes-rebuild\` so PR #97 (and every future PR into the rebuild branch) gets the full lint/security/compile/integration suite.

## What's identical to #108

\`\`\`yaml
on:
  pull_request:
    branches: [main, nodes-rebuild]
  push:
    branches: [nodes-rebuild]
\`\`\`

Same inline comments documenting the mid-rebuild E2E expectation.

## Files changed

- \`.github/workflows/pr-tests.yml\` — Add \`nodes-rebuild\` as a second target.

## Verification

- This PR itself **won't trigger CI** when opened (because the *current* nodes-rebuild workflow doesn't fire on PRs into nodes-rebuild — chicken-and-egg). Once merged, the next event on nodes-rebuild triggers CI under the new rules.
- After merge, PR #97 can be retriggered (close/reopen, or push an empty commit) to actually run CI.

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)