### PR TITLE
Phase 2a.ii: Note CRUD attached to Nodes (#83)

### DIFF
--- a/backend/src/controllers/NoteController.cpp
+++ b/backend/src/controllers/NoteController.cpp
@@ -3,23 +3,47 @@
 #include "ErrorResponse.h"
 #include <drogon/drogon.h>
 
-// Phase 2a.i wiring: minimal pass to keep notes working under the new
-// schema. Notes attach to nodes via `node_id` (no own coordinates, no
-// group_id). The route shape stays under `/maps/{mapId}/notes/...` for
-// now — Phase 2a.ii restructures the routes to nest under nodes and
-// fleshes out the API. Visibility filtering arrives in Phase 2b.iii.
+// Phase 2a.ii: Notes attach to nodes via the URL path. List/create
+// nest under /maps/{mapId}/nodes/{nodeId}/notes; get/put/delete sit
+// under /maps/{mapId}/notes/{id} since the note id alone identifies
+// it within the map. Visibility filtering arrives in Phase 2b.iii.
 
 static int callerUserId(const drogon::HttpRequestPtr& req) {
     try { return req->getAttributes()->get<int>("userId"); }
     catch (...) { return 0; }
 }
 
-// ─── GET /api/v1/tenants/{tenantId}/maps/{mapId}/notes ────────────────────────
+namespace {
+
+// Build a JSON note from a result row. Shape is consistent across all
+// read endpoints.
+Json::Value rowToNote(const drogon::orm::Row& row) {
+    Json::Value n;
+    n["id"]                  = row["id"].as<int>();
+    n["nodeId"]              = row["node_id"].as<int>();
+    n["mapId"]               = row["map_id"].as<int>();
+    n["createdBy"]           = row["created_by"].as<int>();
+    n["createdByUsername"]   = row["creator_username"].as<std::string>();
+    n["title"]               = row["title"].isNull() ? "" : row["title"].as<std::string>();
+    n["text"]                = row["text"].as<std::string>();
+    n["pinned"]              = row["pinned"].as<bool>();
+    n["color"]               = row["color"].isNull()
+                                 ? Json::Value() : Json::Value(row["color"].as<std::string>());
+    n["visibilityOverride"]  = row["visibility_override"].as<bool>();
+    n["createdAt"]           = row["created_at"].as<std::string>();
+    n["updatedAt"]           = row["updated_at"].as<std::string>();
+    n["canEdit"]             = row["can_edit"].as<bool>();
+    return n;
+}
+
+} // anonymous namespace
+
+// ─── GET /api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{nodeId}/notes ────────
 
 void NoteController::listNotes(
     const drogon::HttpRequestPtr& req,
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
-    int tenantId, int mapId) {
+    int tenantId, int mapId, int nodeId) {
 
     int userId = callerUserId(req);
 
@@ -36,7 +60,7 @@ void NoteController::listNotes(
         LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ?
         LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL
                                         AND mp_pub.level IN ('view','comment','edit','moderate','admin')
-        WHERE nd.map_id = ? AND m.tenant_id = ?
+        WHERE n.node_id = ? AND nd.map_id = ? AND m.tenant_id = ?
           AND (m.owner_id = ? OR mp.level IN ('view','comment','edit','moderate','admin') OR mp_pub.level IN ('view','comment','edit','moderate','admin'))
         ORDER BY n.pinned DESC, n.created_at ASC
     )";
@@ -46,61 +70,44 @@ void NoteController::listNotes(
         sql,
         [callback](const drogon::orm::Result& r) {
             Json::Value arr(Json::arrayValue);
-            for (const auto& row : r) {
-                Json::Value n;
-                n["id"]                 = row["id"].as<int>();
-                n["nodeId"]             = row["node_id"].as<int>();
-                n["mapId"]              = row["map_id"].as<int>();
-                n["createdBy"]          = row["created_by"].as<int>();
-                n["createdByUsername"]  = row["creator_username"].as<std::string>();
-                n["title"]              = row["title"].isNull() ? "" : row["title"].as<std::string>();
-                n["text"]               = row["text"].as<std::string>();
-                n["pinned"]             = row["pinned"].as<bool>();
-                n["color"]              = row["color"].isNull() ? Json::Value() : Json::Value(row["color"].as<std::string>());
-                n["visibilityOverride"] = row["visibility_override"].as<bool>();
-                n["createdAt"]          = row["created_at"].as<std::string>();
-                n["updatedAt"]          = row["updated_at"].as<std::string>();
-                n["canEdit"]            = row["can_edit"].as<bool>();
-                arr.append(n);
-            }
+            for (const auto& row : r) arr.append(rowToNote(row));
             callback(drogon::HttpResponse::newHttpJsonResponse(arr));
         },
         [callback](const drogon::orm::DrogonDbException&) {
             callback(errorResponse(drogon::k500InternalServerError,
                 "db_error", "Failed to fetch notes"));
         },
-        userId, userId, userId, mapId, tenantId, userId);
+        userId, userId, userId, nodeId, mapId, tenantId, userId);
 }
 
-// ─── POST /api/v1/tenants/{tenantId}/maps/{mapId}/notes ───────────────────────
+// ─── POST /api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{nodeId}/notes ───────
 
 void NoteController::createNote(
     const drogon::HttpRequestPtr& req,
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
-    int tenantId, int mapId) {
+    int tenantId, int mapId, int nodeId) {
 
     int userId = callerUserId(req);
     std::string callerUsername;
     try { callerUsername = req->getAttributes()->get<std::string>("username"); } catch (...) {}
-    auto body  = req->getJsonObject();
-    if (!body || !body->isMember("nodeId") || !(*body)["text"]) {
+
+    auto body = req->getJsonObject();
+    if (!body || !(*body)["text"]) {
         callback(errorResponse(drogon::k400BadRequest,
-            "bad_request", "nodeId and text are required"));
+            "bad_request", "text is required"));
         return;
     }
 
-    int nodeId        = (*body)["nodeId"].asInt();
     std::string title = (*body).get("title", "").asString();
     std::string text  = (*body)["text"].asString();
     std::string color = (*body).get("color", "").asString();
 
-    // M8: length limits
     if (!checkMaxLen("title", title, MAX_TITLE_LEN, callback)) return;
     if (!checkMaxLen("text", text, MAX_TEXT_LEN, callback)) return;
 
-    // Verify the node exists on the right map+tenant and the caller has
-    // at least view access to that map. The existing 10k-notes-per-map
-    // limit is preserved (counted via JOIN through nodes).
+    // Verify the node exists on the right map+tenant and the caller
+    // has at least view access to that map. The 10k-notes-per-map limit
+    // is preserved (counted via JOIN through nodes).
     auto db = drogon::app().getDbClient();
     db->execSqlAsync(
         "SELECT nd.id FROM nodes nd "
@@ -119,8 +126,8 @@ void NoteController::createNote(
                 return;
             }
 
-            // M9: atomic INSERT-with-limit-check (10,000 notes per map).
-            // Count via JOIN through nodes since notes no longer carry map_id.
+            // Atomic INSERT-with-limit-check (10k notes per map). Count
+            // via JOIN through nodes since notes carry node_id only.
             auto db2 = drogon::app().getDbClient();
             db2->execSqlAsync(
                 "INSERT INTO notes (node_id, created_by, title, text, color) "
@@ -137,17 +144,17 @@ void NoteController::createNote(
                     }
                     int newId = static_cast<int>(r2.insertId());
                     Json::Value n;
-                    n["id"]                 = newId;
-                    n["nodeId"]             = nodeId;
-                    n["mapId"]              = mapId;
-                    n["createdBy"]          = userId;
-                    n["createdByUsername"]  = callerUsername;
-                    n["title"]              = title;
-                    n["text"]               = text;
-                    n["pinned"]             = false;
-                    n["color"]              = color.empty() ? Json::Value() : Json::Value(color);
-                    n["visibilityOverride"] = false;
-                    n["canEdit"]            = true;
+                    n["id"]                  = newId;
+                    n["nodeId"]              = nodeId;
+                    n["mapId"]               = mapId;
+                    n["createdBy"]           = userId;
+                    n["createdByUsername"]   = callerUsername;
+                    n["title"]               = title;
+                    n["text"]                = text;
+                    n["pinned"]              = false;
+                    n["color"]               = color.empty() ? Json::Value() : Json::Value(color);
+                    n["visibilityOverride"]  = false;
+                    n["canEdit"]             = true;
                     auto resp = drogon::HttpResponse::newHttpJsonResponse(n);
                     resp->setStatusCode(drogon::k201Created);
                     callback(resp);
@@ -178,7 +185,7 @@ void NoteController::getNote(
         "SELECT n.id, n.node_id, nd.map_id, n.created_by, u.username AS creator_username, "
         "       n.title, n.text, n.pinned, n.color, n.visibility_override, "
         "       n.created_at, n.updated_at, "
-        "       CASE WHEN m.owner_id=? OR n.created_by=? OR mp.level IN ('edit','moderate','admin') "
+        "       CASE WHEN m.owner_id = ? OR n.created_by = ? OR mp.level IN ('edit','moderate','admin') "
         "            THEN 1 ELSE 0 END AS can_edit "
         "FROM notes n "
         "JOIN nodes nd ON nd.id = n.node_id "
@@ -195,22 +202,7 @@ void NoteController::getNote(
                     "not_found", "Note not found or no permission"));
                 return;
             }
-            const auto& row = r[0];
-            Json::Value n;
-            n["id"]                 = row["id"].as<int>();
-            n["nodeId"]             = row["node_id"].as<int>();
-            n["mapId"]              = row["map_id"].as<int>();
-            n["createdBy"]          = row["created_by"].as<int>();
-            n["createdByUsername"]  = row["creator_username"].as<std::string>();
-            n["title"]              = row["title"].isNull() ? "" : row["title"].as<std::string>();
-            n["text"]               = row["text"].as<std::string>();
-            n["pinned"]             = row["pinned"].as<bool>();
-            n["color"]              = row["color"].isNull() ? Json::Value() : Json::Value(row["color"].as<std::string>());
-            n["visibilityOverride"] = row["visibility_override"].as<bool>();
-            n["createdAt"]          = row["created_at"].as<std::string>();
-            n["updatedAt"]          = row["updated_at"].as<std::string>();
-            n["canEdit"]            = row["can_edit"].as<bool>();
-            callback(drogon::HttpResponse::newHttpJsonResponse(n));
+            callback(drogon::HttpResponse::newHttpJsonResponse(rowToNote(r[0])));
         },
         [callback](const drogon::orm::DrogonDbException&) {
             callback(errorResponse(drogon::k500InternalServerError,
@@ -237,8 +229,9 @@ void NoteController::updateNote(
     std::string newTitle = (*body).get("title", "").asString();
     std::string newText  = (*body).get("text", "").asString();
     std::string newColor = (*body).get("color", "").asString();
+    bool hasPinned       = body->isMember("pinned");
+    bool newPinned       = hasPinned ? (*body)["pinned"].asBool() : false;
 
-    // M8: length limits
     if (!checkMaxLen("title", newTitle, MAX_TITLE_LEN, callback)) return;
     if (!checkMaxLen("text", newText, MAX_TEXT_LEN, callback)) return;
 
@@ -248,9 +241,10 @@ void NoteController::updateNote(
         "JOIN nodes nd ON nd.id = n.node_id "
         "JOIN maps m   ON m.id  = nd.map_id "
         "LEFT JOIN map_permissions mp ON mp.map_id = m.id AND mp.user_id = ? "
-        "SET n.title = IF(?='', n.title, ?), "
-        "    n.text  = IF(?='', n.text,  ?), "
-        "    n.color = IF(?='', n.color, ?) "
+        "SET n.title  = IF(?='', n.title, ?), "
+        "    n.text   = IF(?='', n.text,  ?), "
+        "    n.color  = IF(?='', n.color, ?), "
+        "    n.pinned = IF(?, ?, n.pinned) "
         "WHERE n.id = ? AND nd.map_id = ? AND m.tenant_id = ? "
         "  AND (m.owner_id = ? OR mp.level IN ('edit','moderate','admin') OR n.created_by = ?)",
         [callback, req, userId, tenantId, mapId, id](const drogon::orm::Result& r) {
@@ -259,7 +253,6 @@ void NoteController::updateNote(
                     "forbidden", "Cannot update note"));
                 return;
             }
-            // M12: audit the update
             Json::Value detail;
             detail["mapId"]  = mapId;
             detail["noteId"] = id;
@@ -277,10 +270,11 @@ void NoteController::updateNote(
         newTitle, newTitle,
         newText,  newText,
         newColor, newColor,
+        hasPinned, newPinned,
         id, mapId, tenantId, userId, userId);
 }
 
-// ─── DELETE /api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id} ────────────────
+// ─── DELETE /api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id} ───────────────
 
 void NoteController::deleteNote(
     const drogon::HttpRequestPtr& req,
@@ -302,7 +296,6 @@ void NoteController::deleteNote(
                     "forbidden", "Cannot delete note"));
                 return;
             }
-            // M12: audit the deletion
             Json::Value detail;
             detail["mapId"]  = mapId;
             detail["noteId"] = id;

--- a/backend/src/controllers/NoteController.h
+++ b/backend/src/controllers/NoteController.h
@@ -2,22 +2,31 @@
 #include <drogon/HttpController.h>
 
 /**
- * NoteController — tenant-scoped
+ * NoteController — tenant-scoped, attached to a Node
  *
- * GET    /api/v1/tenants/{tenantId}/maps/{mapId}/notes
- * POST   /api/v1/tenants/{tenantId}/maps/{mapId}/notes
+ * Notes attach to a node (no own coordinates). The list/create routes
+ * nest under nodes; get/put/delete sit under maps because the note id
+ * is globally unique within a map and we don't need the parent node id
+ * to identify a note.
+ *
+ * GET    /api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{nodeId}/notes
+ * POST   /api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{nodeId}/notes
  * GET    /api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}
  * PUT    /api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}
  * DELETE /api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}
+ *
+ * Visibility filtering arrives in Phase 2b.iii (#87). For now, standard
+ * map view-access gates list/get; map edit-access (or note creator)
+ * gates update/delete.
  */
 class NoteController : public drogon::HttpController<NoteController> {
 public:
     METHOD_LIST_BEGIN
         ADD_METHOD_TO(NoteController::listNotes,
-                      "/api/v1/tenants/{tenantId}/maps/{mapId}/notes",
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{nodeId}/notes",
                       drogon::Get, "JwtFilter", "TenantFilter");
         ADD_METHOD_TO(NoteController::createNote,
-                      "/api/v1/tenants/{tenantId}/maps/{mapId}/notes",
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{nodeId}/notes",
                       drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
         ADD_METHOD_TO(NoteController::getNote,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}",
@@ -32,10 +41,10 @@ public:
 
     void listNotes(const drogon::HttpRequestPtr&,
                    std::function<void(const drogon::HttpResponsePtr&)>&&,
-                   int tenantId, int mapId);
+                   int tenantId, int mapId, int nodeId);
     void createNote(const drogon::HttpRequestPtr&,
                     std::function<void(const drogon::HttpResponsePtr&)>&&,
-                    int tenantId, int mapId);
+                    int tenantId, int mapId, int nodeId);
     void getNote(const drogon::HttpRequestPtr&,
                  std::function<void(const drogon::HttpResponsePtr&)>&&,
                  int tenantId, int mapId, int id);

--- a/backend/tests/run-tests.py
+++ b/backend/tests/run-tests.py
@@ -42,10 +42,11 @@ FAST_TESTS = [
     "test_09_security.py",
     "test_14_nodes.py",
     "test_15_cors.py",
+    "test_16_notes.py",
 ]
 
 # test_14_nodes.py landed in #96 (NodeController CRUD + tree + max-depth).
-# test_NN_notes.py returns in #83 (Note CRUD restructure).
+# test_16_notes.py landed in #83 (Note CRUD restructured under nodes).
 # Annotation/note-group tests are gone permanently — those concepts were
 # consolidated into nodes and visibility groups during the rebuild.
 
@@ -64,6 +65,7 @@ TEST_DESCRIPTIONS = {
     10: "Rate limit — soak (10min continuous) [extended]",
     14: "Nodes (CRUD, tree filtering, max-depth, cross-tenant)",
     15: "CORS preflight",
+    16: "Notes (CRUD attached to nodes, pinned-first sort, cross-tenant)",
 }
 
 

--- a/backend/tests/test_16_notes.py
+++ b/backend/tests/test_16_notes.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""test_16_notes.py — Note CRUD attached to Nodes (Phase 2a.ii).
+
+List/create nest under /maps/{mapId}/nodes/{nodeId}/notes; get/put/delete
+sit under /maps/{mapId}/notes/{id}.
+"""
+
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import (
+    reset_counters, report, assert_status, assert_json_field, assert_json_exists,
+    assert_true, http_post, http_get, http_put, http_delete,
+    register_user, json_field,
+)
+
+reset_counters()
+RUN_ID = os.getpid()
+
+print("=== Note Tests ===")
+
+# Two users in different tenants for cross-tenant checks.
+TOKEN_A = register_user(f"t16_a_{RUN_ID}", f"t16_a_{RUN_ID}@test.com", "testpass123")
+_, body_a = http_post("/auth/login",
+    {"email": f"t16_a_{RUN_ID}@test.com", "password": "testpass123"})
+TENANT_A = json_field(body_a, ["tenantId"])
+
+TOKEN_B = register_user(f"t16_b_{RUN_ID}", f"t16_b_{RUN_ID}@test.com", "testpass123")
+_, body_b = http_post("/auth/login",
+    {"email": f"t16_b_{RUN_ID}@test.com", "password": "testpass123"})
+TENANT_B = json_field(body_b, ["tenantId"])
+
+# Setup: A creates a map and two nodes.
+_, body = http_post(f"/tenants/{TENANT_A}/maps", {"title": "Note Test Map"}, TOKEN_A)
+MAP_A = json_field(body, ["id"])
+
+_, body = http_post(f"/tenants/{TENANT_A}/maps/{MAP_A}/nodes",
+    {"name": "AnchorA"}, TOKEN_A)
+NODE_A1 = json_field(body, ["id"])
+
+_, body = http_post(f"/tenants/{TENANT_A}/maps/{MAP_A}/nodes",
+    {"name": "AnchorB"}, TOKEN_A)
+NODE_A2 = json_field(body, ["id"])
+
+LIST_BASE = f"/tenants/{TENANT_A}/maps/{MAP_A}/nodes/{NODE_A1}/notes"
+NOTE_BASE = f"/tenants/{TENANT_A}/maps/{MAP_A}/notes"
+
+# ─── Create ──────────────────────────────────────────────────────────────────
+
+print("  --- Create ---")
+
+# Plain text-only note
+status, body = http_post(LIST_BASE, {"text": "Plain note"}, TOKEN_A)
+assert_status("create: text-only returns 201", 201, status)
+NOTE1 = json_field(body, ["id"])
+assert_json_field("create: text correct", body, ["text"], "Plain note")
+assert_json_field("create: nodeId set",   body, ["nodeId"], str(NODE_A1))
+assert_json_field("create: mapId derived", body, ["mapId"], str(MAP_A))
+assert_json_field("create: pinned defaults to false", body, ["pinned"], False)
+assert_json_field("create: canEdit true for creator", body, ["canEdit"], True)
+assert_json_exists("create: createdByUsername present", body, ["createdByUsername"])
+
+# Note with title and color
+status, body = http_post(LIST_BASE, {
+    "title": "Beware",
+    "text": "Watch the bartender",
+    "color": "#ff0000",
+}, TOKEN_A)
+assert_status("create: full note returns 201", 201, status)
+NOTE2 = json_field(body, ["id"])
+assert_json_field("create: color set", body, ["color"], "#ff0000")
+assert_json_field("create: title set", body, ["title"], "Beware")
+
+# Validation: missing text
+status, _ = http_post(LIST_BASE, {"title": "no text"}, TOKEN_A)
+assert_status("create: missing text returns 400", 400, status)
+
+# Validation: empty body
+status, _ = http_post(LIST_BASE, {}, TOKEN_A)
+assert_status("create: empty body returns 400", 400, status)
+
+# Note attached to a different node on the same map
+status, body = http_post(
+    f"/tenants/{TENANT_A}/maps/{MAP_A}/nodes/{NODE_A2}/notes",
+    {"text": "Note on B"}, TOKEN_A)
+assert_status("create: on second node returns 201", 201, status)
+NOTE3 = json_field(body, ["id"])
+assert_json_field("create: nodeId is second node", body, ["nodeId"], str(NODE_A2))
+
+# Cross-tenant cannot create
+status, _ = http_post(LIST_BASE, {"text": "hacked"}, TOKEN_B)
+assert_status("create: cross-tenant blocked", 403, status)
+
+# Non-existent node returns 403 (caller has no access to "this node on this map")
+status, _ = http_post(
+    f"/tenants/{TENANT_A}/maps/{MAP_A}/nodes/9999999/notes",
+    {"text": "orphan"}, TOKEN_A)
+assert_status("create: non-existent node returns 403", 403, status)
+
+print("  All create tests passed.")
+
+# ─── List ────────────────────────────────────────────────────────────────────
+
+print("  --- List ---")
+
+status, body = http_get(LIST_BASE, TOKEN_A)
+assert_status("list: returns 200", 200, status)
+assert_true("list: returns array", isinstance(body, list))
+assert_true("list: contains 2 notes on NODE_A1",
+            len([n for n in body if n["nodeId"] == NODE_A1]) == 2)
+
+# Note on NODE_A2 only shows under its own list
+status, body = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_A}/nodes/{NODE_A2}/notes", TOKEN_A)
+assert_true("list: NODE_A2 has only its note", len(body) == 1)
+
+# Cross-tenant cannot list
+status, _ = http_get(LIST_BASE, TOKEN_B)
+assert_status("list: cross-tenant blocked", 403, status)
+
+print("  All list tests passed.")
+
+# ─── Get ─────────────────────────────────────────────────────────────────────
+
+print("  --- Get ---")
+
+status, body = http_get(f"{NOTE_BASE}/{NOTE2}", TOKEN_A)
+assert_status("get: returns 200", 200, status)
+assert_json_field("get: text correct", body, ["text"], "Watch the bartender")
+assert_json_exists("get: has createdAt", body, ["createdAt"])
+
+# Cross-tenant blocked at the TenantFilter (returns 403 before the controller runs).
+status, _ = http_get(f"{NOTE_BASE}/{NOTE2}", TOKEN_B)
+assert_status("get: cross-tenant blocked", 403, status)
+
+# Not found
+status, _ = http_get(f"{NOTE_BASE}/9999999", TOKEN_A)
+assert_status("get: missing returns 404", 404, status)
+
+print("  All get tests passed.")
+
+# ─── Update ──────────────────────────────────────────────────────────────────
+
+print("  --- Update ---")
+
+# Update text
+status, _ = http_put(f"{NOTE_BASE}/{NOTE1}", {"text": "Updated text"}, TOKEN_A)
+assert_status("update: text returns 200", 200, status)
+status, body = http_get(f"{NOTE_BASE}/{NOTE1}", TOKEN_A)
+assert_json_field("update: text persisted", body, ["text"], "Updated text")
+
+# Update title
+status, _ = http_put(f"{NOTE_BASE}/{NOTE1}", {"title": "New Title"}, TOKEN_A)
+assert_status("update: title returns 200", 200, status)
+status, body = http_get(f"{NOTE_BASE}/{NOTE1}", TOKEN_A)
+assert_json_field("update: title persisted", body, ["title"], "New Title")
+
+# Pin and unpin
+status, _ = http_put(f"{NOTE_BASE}/{NOTE1}", {"pinned": True}, TOKEN_A)
+assert_status("update: pin returns 200", 200, status)
+status, body = http_get(f"{NOTE_BASE}/{NOTE1}", TOKEN_A)
+assert_json_field("update: pinned persisted", body, ["pinned"], True)
+status, _ = http_put(f"{NOTE_BASE}/{NOTE1}", {"pinned": False}, TOKEN_A)
+status, body = http_get(f"{NOTE_BASE}/{NOTE1}", TOKEN_A)
+assert_json_field("update: unpin persisted", body, ["pinned"], False)
+
+# Cross-tenant blocked
+status, _ = http_put(f"{NOTE_BASE}/{NOTE1}", {"text": "hacked"}, TOKEN_B)
+assert_status("update: cross-tenant blocked", 403, status)
+
+print("  All update tests passed.")
+
+# ─── Pinned-first sort ──────────────────────────────────────────────────────
+
+print("  --- Pinned-first sort ---")
+
+# Pin NOTE2; list should put it first
+http_put(f"{NOTE_BASE}/{NOTE2}", {"pinned": True}, TOKEN_A)
+status, body = http_get(LIST_BASE, TOKEN_A)
+assert_true("sort: pinned note appears first",
+            len(body) >= 2 and body[0]["pinned"] is True)
+
+print("  All sort tests passed.")
+
+# ─── Delete ──────────────────────────────────────────────────────────────────
+
+print("  --- Delete ---")
+
+# Cross-tenant blocked
+status, _ = http_delete(f"{NOTE_BASE}/{NOTE1}", TOKEN_B)
+assert_status("delete: cross-tenant blocked", 403, status)
+
+# Owner deletes
+status, _ = http_delete(f"{NOTE_BASE}/{NOTE1}", TOKEN_A)
+assert_status("delete: owner can delete", 204, status)
+status, _ = http_get(f"{NOTE_BASE}/{NOTE1}", TOKEN_A)
+assert_status("delete: note is gone", 404, status)
+
+# Deleting the parent node CASCADES to remaining notes on it
+status, _ = http_delete(f"/tenants/{TENANT_A}/maps/{MAP_A}/nodes/{NODE_A1}", TOKEN_A)
+assert_status("delete: parent node removal returns 204", 204, status)
+status, _ = http_get(f"{NOTE_BASE}/{NOTE2}", TOKEN_A)
+assert_status("delete: note cascaded with parent node", 404, status)
+
+print("  All delete tests passed.")
+
+sys.exit(0 if report() else 1)


### PR DESCRIPTION
## Summary

Closes #83. Restructures the Note API so the list/create endpoints nest under nodes, completing the rebuild's "notes attach to nodes" model. The minimal pass in #97 (Phase 2a.i.a) accepted `nodeId` in the body; this PR moves the relationship into the URL where it belongs.

## Routes

| Method | Path | Purpose |
|---|---|---|
| GET    | `/api/v1/tenants/{tid}/maps/{mid}/nodes/{nid}/notes` | List notes for a node |
| POST   | `/api/v1/tenants/{tid}/maps/{mid}/nodes/{nid}/notes` | Create attached to a node |
| GET    | `/api/v1/tenants/{tid}/maps/{mid}/notes/{id}` | Get one |
| PUT    | `/api/v1/tenants/{tid}/maps/{mid}/notes/{id}` | Update title / text / color / pinned |
| DELETE | `/api/v1/tenants/{tid}/maps/{mid}/notes/{id}` | Delete |

`get`/`put`/`delete` stay under `/maps/{mid}/notes/{id}` since the note id alone identifies a note within a map; threading `nodeId` through those URLs would be redundant.

## Notable details

- **`nodeId` comes from the URL on create** — clients no longer pass it in the body.
- **`mapId` is derived** via `nodes.map_id`. Tenant scoping joins through `nodes` → `maps` and is enforced via the existing `TenantFilter` chain.
- **10k-notes-per-map atomic insert-with-limit-check preserved** — the count subquery joins through `nodes` since notes carry only `node_id`.
- **Pinned toggle in PUT**: send `{ "pinned": true|false }` to flip; absent field leaves it unchanged.
- **Audit events**: `note_update` and `note_delete` with `{mapId, noteId}` detail. (Create doesn't audit per the existing convention.)

## Permission model

- **List / get:** map view-access (owner / per-user / public).
- **Create:** map view-access — any user who can see the map can leave a note (matches existing convention).
- **Update / delete:** map edit-access OR the note's creator.
- **No visibility filtering yet** — Phase 2b.iii (#87) wires that up.

## Tests

New `backend/tests/test_16_notes.py` (40 assertions, all passing locally):
- CRUD happy paths (text-only, with title/color, on a second node)
- Missing-text rejection → 400
- Empty-body rejection → 400
- Non-existent node on POST → 403
- Cross-tenant blocked at all five endpoints (returns 403 at the `TenantFilter`, before the controller runs)
- List scoped correctly per node
- Pin / unpin via PUT and verify persistence
- Pinned-first sort: pin a note, list returns it first
- CASCADE-from-parent-node delete: deleting a node removes its notes

Added to `FAST_TESTS` in `run-tests.py`. Full fast tier passes in 13s locally.

## Test expectations (CI on `nodes-rebuild`)

| Job | Expected | Why |
|---|---|---|
| `lint` | ✅ pass | No frontend changes. |
| `security` | ✅ pass | No new dependencies. |
| `compile` | ✅ pass | NoteController compiles cleanly locally. |
| `integration` (db tests) | ✅ pass | 179/179 pass against the 2a.i.a schema. |
| `integration` (backend tests) | ✅ pass | 10/10 suites pass locally including new `test_16_notes.py`. |
| `integration` (E2E / Playwright) | ❌ **expected fail** | Frontend still references the old API shape (notes had `lat`/`lng`, `groupId`, lived under `/maps/{mid}/notes`). Rebuild lands in #92 / #101 / #102. |

The `integration` job will report red overall because of E2E. Mid-rebuild informational state — `main` remains the enforced gate.

## Files changed

- `backend/src/controllers/NoteController.h` — Routes restructured: list/create take `nodeId` from path; get/put/delete unchanged.
- `backend/src/controllers/NoteController.cpp` — All five handlers updated for new path shape; pinned toggle added; rest of logic adapted via SQL joins through `nodes`.
- `backend/tests/test_16_notes.py` — New file: 40 integration test assertions.
- `backend/tests/run-tests.py` — Add `test_16_notes.py` to `FAST_TESTS`; add description.

## Verification (local)

- Database tests: 179 / 179 pass
- Backend integration tests: 10 / 10 suites pass at `fast` tier in 13s
- Backend builds cleanly

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)