### PR TITLE
Phase 2b.i.a: Visibility groups CRUD (admin-only) (#85)

### DIFF
--- a/backend/src/controllers/VisibilityGroupController.cpp
+++ b/backend/src/controllers/VisibilityGroupController.cpp
@@ -1,0 +1,257 @@
+#include "VisibilityGroupController.h"
+#include "ErrorResponse.h"
+#include <drogon/drogon.h>
+
+// Phase 2b.i.a: CRUD on visibility_groups, tenant-admin-only. Member
+// management + manages_visibility-based authorization + the
+// tenant-creation bootstrap of a default "Visibility Managers" group
+// land in Phase 2b.i.b (#98).
+//
+// Tagging nodes/notes with these groups arrives in #86 (nodes) and
+// #87 (notes); read-time filtering using effective visibility is in #99.
+
+static int callerUserId(const drogon::HttpRequestPtr& req) {
+    try { return req->getAttributes()->get<int>("userId"); }
+    catch (...) { return 0; }
+}
+
+namespace {
+
+// Throughout this phase, only tenant admins can manage visibility groups.
+// The manager-flag escape hatch is wired up in #98.
+bool requireAdmin(const drogon::HttpRequestPtr& req,
+                  const std::function<void(const drogon::HttpResponsePtr&)>& callback) {
+    try {
+        const std::string role = req->getAttributes()->get<std::string>("tenantRole");
+        if (role == "admin") return true;
+    } catch (...) {}
+    callback(errorResponse(drogon::k403Forbidden,
+        "forbidden", "Only tenant admins can manage visibility groups"));
+    return false;
+}
+
+Json::Value rowToGroup(const drogon::orm::Row& row) {
+    Json::Value g;
+    g["id"]                 = row["id"].as<int>();
+    g["tenantId"]           = row["tenant_id"].as<int>();
+    g["name"]               = row["name"].as<std::string>();
+    g["description"]        = row["description"].isNull()
+                                ? "" : row["description"].as<std::string>();
+    g["managesVisibility"]  = row["manages_visibility"].as<bool>();
+    g["createdBy"]          = row["created_by"].as<int>();
+    g["createdAt"]          = row["created_at"].as<std::string>();
+    g["updatedAt"]          = row["updated_at"].as<std::string>();
+    return g;
+}
+
+} // anonymous namespace
+
+// ─── GET /api/v1/tenants/{tenantId}/visibility-groups ───────────────────────
+
+void VisibilityGroupController::listGroups(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId) {
+
+    if (!requireAdmin(req, callback)) return;
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT id, tenant_id, name, description, manages_visibility, "
+        "       created_by, created_at, updated_at "
+        "FROM visibility_groups "
+        "WHERE tenant_id = ? "
+        "ORDER BY name ASC",
+        [callback](const drogon::orm::Result& r) {
+            Json::Value arr(Json::arrayValue);
+            for (const auto& row : r) arr.append(rowToGroup(row));
+            callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to fetch visibility groups"));
+        },
+        tenantId);
+}
+
+// ─── POST /api/v1/tenants/{tenantId}/visibility-groups ──────────────────────
+
+void VisibilityGroupController::createGroup(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId) {
+
+    if (!requireAdmin(req, callback)) return;
+
+    int userId = callerUserId(req);
+    auto body  = req->getJsonObject();
+    if (!body || !body->isMember("name")) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "name is required"));
+        return;
+    }
+
+    std::string name        = (*body)["name"].asString();
+    std::string description = (*body).get("description", "").asString();
+    bool managesVisibility  = (*body).get("managesVisibility", false).asBool();
+
+    if (name.empty()) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "name cannot be empty"));
+        return;
+    }
+    if (!checkMaxLen("name", name, MAX_NAME_LEN, callback)) return;
+    if (!checkMaxLen("description", description, MAX_DESCRIPTION_LEN, callback)) return;
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "INSERT INTO visibility_groups "
+        "  (tenant_id, name, description, manages_visibility, created_by) "
+        "VALUES (?, ?, NULLIF(?, ''), ?, ?)",
+        [callback, tenantId, userId, name, description, managesVisibility]
+        (const drogon::orm::Result& r) {
+            int newId = static_cast<int>(r.insertId());
+            Json::Value g;
+            g["id"]                 = newId;
+            g["tenantId"]           = tenantId;
+            g["name"]               = name;
+            g["description"]        = description;
+            g["managesVisibility"]  = managesVisibility;
+            g["createdBy"]          = userId;
+            auto resp = drogon::HttpResponse::newHttpJsonResponse(g);
+            resp->setStatusCode(drogon::k201Created);
+            callback(resp);
+        },
+        [callback](const drogon::orm::DrogonDbException& ex) {
+            // MariaDB error 1062 = duplicate key (UNIQUE on (tenant_id, name))
+            // Match the same pattern AuthController uses for duplicate keys.
+            if (std::string(ex.base().what()).find("Duplicate") != std::string::npos) {
+                callback(errorResponse(drogon::k409Conflict,
+                    "conflict", "A visibility group with this name already exists in this tenant"));
+                return;
+            }
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to create visibility group"));
+        },
+        tenantId, name, description, managesVisibility, userId);
+}
+
+// ─── GET /api/v1/tenants/{tenantId}/visibility-groups/{id} ──────────────────
+
+void VisibilityGroupController::getGroup(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id) {
+
+    if (!requireAdmin(req, callback)) return;
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT id, tenant_id, name, description, manages_visibility, "
+        "       created_by, created_at, updated_at "
+        "FROM visibility_groups WHERE id = ? AND tenant_id = ?",
+        [callback](const drogon::orm::Result& r) {
+            if (r.empty()) {
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "Visibility group not found"));
+                return;
+            }
+            callback(drogon::HttpResponse::newHttpJsonResponse(rowToGroup(r[0])));
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error"));
+        },
+        id, tenantId);
+}
+
+// ─── PUT /api/v1/tenants/{tenantId}/visibility-groups/{id} ──────────────────
+
+void VisibilityGroupController::updateGroup(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id) {
+
+    if (!requireAdmin(req, callback)) return;
+
+    auto body = req->getJsonObject();
+    if (!body) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "Request body required"));
+        return;
+    }
+
+    std::string name        = (*body).get("name", "").asString();
+    std::string description = (*body).get("description", "").asString();
+    bool hasManages         = body->isMember("managesVisibility");
+    bool managesVisibility  = hasManages ? (*body)["managesVisibility"].asBool() : false;
+
+    if (!checkMaxLen("name", name, MAX_NAME_LEN, callback)) return;
+    if (!checkMaxLen("description", description, MAX_DESCRIPTION_LEN, callback)) return;
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "UPDATE visibility_groups SET "
+        "  name               = IF(?='', name, ?), "
+        "  description        = IF(?='', description, ?), "
+        "  manages_visibility = IF(?, ?, manages_visibility) "
+        "WHERE id = ? AND tenant_id = ?",
+        [callback, id](const drogon::orm::Result& r) {
+            if (r.affectedRows() == 0) {
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "Visibility group not found"));
+                return;
+            }
+            Json::Value v;
+            v["id"]      = id;
+            v["updated"] = true;
+            callback(drogon::HttpResponse::newHttpJsonResponse(v));
+        },
+        [callback](const drogon::orm::DrogonDbException& ex) {
+            // Match the same pattern AuthController uses for duplicate keys.
+            if (std::string(ex.base().what()).find("Duplicate") != std::string::npos) {
+                callback(errorResponse(drogon::k409Conflict,
+                    "conflict", "A visibility group with this name already exists in this tenant"));
+                return;
+            }
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to update visibility group"));
+        },
+        name, name,
+        description, description,
+        hasManages, managesVisibility,
+        id, tenantId);
+}
+
+// ─── DELETE /api/v1/tenants/{tenantId}/visibility-groups/{id} ───────────────
+//
+// Junction tables (visibility_group_members, node_visibility,
+// note_visibility) are FK CASCADE'd via the schema, so deleting a
+// group cleans up its memberships and tagging without a manual sweep.
+
+void VisibilityGroupController::deleteGroup(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id) {
+
+    if (!requireAdmin(req, callback)) return;
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "DELETE FROM visibility_groups WHERE id = ? AND tenant_id = ?",
+        [callback](const drogon::orm::Result& r) {
+            if (r.affectedRows() == 0) {
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "Visibility group not found"));
+                return;
+            }
+            auto resp = drogon::HttpResponse::newHttpResponse();
+            resp->setStatusCode(drogon::k204NoContent);
+            callback(resp);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to delete visibility group"));
+        },
+        id, tenantId);
+}

--- a/backend/src/controllers/VisibilityGroupController.h
+++ b/backend/src/controllers/VisibilityGroupController.h
@@ -1,0 +1,62 @@
+#pragma once
+#include <drogon/HttpController.h>
+
+/**
+ * VisibilityGroupController — tenant-scoped, admin-only CRUD.
+ *
+ * GET    /api/v1/tenants/{tenantId}/visibility-groups
+ * POST   /api/v1/tenants/{tenantId}/visibility-groups
+ * GET    /api/v1/tenants/{tenantId}/visibility-groups/{id}
+ * PUT    /api/v1/tenants/{tenantId}/visibility-groups/{id}
+ * DELETE /api/v1/tenants/{tenantId}/visibility-groups/{id}
+ *
+ * Visibility groups are tenant-scoped, generic audiences. No GM/Player
+ * baked in — each tenant defines its own. The `manages_visibility`
+ * flag designates a group whose members can manage visibility groups
+ * (used by Phase 2b.i.b's auth helper); for THIS phase, only tenant
+ * admins can CRUD groups, regardless of the flag.
+ *
+ * Member management endpoints + the manages_visibility-based auth
+ * helper + tenant-creation bootstrap arrive in Phase 2b.i.b (#98).
+ *
+ * Body shape:
+ *   { "name": "...", "description": "...", "managesVisibility": false }
+ *
+ * `name` is unique per tenant (enforced via UNIQUE KEY (tenant_id, name)).
+ */
+class VisibilityGroupController : public drogon::HttpController<VisibilityGroupController> {
+public:
+    METHOD_LIST_BEGIN
+        ADD_METHOD_TO(VisibilityGroupController::listGroups,
+                      "/api/v1/tenants/{tenantId}/visibility-groups",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+        ADD_METHOD_TO(VisibilityGroupController::createGroup,
+                      "/api/v1/tenants/{tenantId}/visibility-groups",
+                      drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(VisibilityGroupController::getGroup,
+                      "/api/v1/tenants/{tenantId}/visibility-groups/{id}",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+        ADD_METHOD_TO(VisibilityGroupController::updateGroup,
+                      "/api/v1/tenants/{tenantId}/visibility-groups/{id}",
+                      drogon::Put, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(VisibilityGroupController::deleteGroup,
+                      "/api/v1/tenants/{tenantId}/visibility-groups/{id}",
+                      drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
+    METHOD_LIST_END
+
+    void listGroups(const drogon::HttpRequestPtr&,
+                    std::function<void(const drogon::HttpResponsePtr&)>&&,
+                    int tenantId);
+    void createGroup(const drogon::HttpRequestPtr&,
+                     std::function<void(const drogon::HttpResponsePtr&)>&&,
+                     int tenantId);
+    void getGroup(const drogon::HttpRequestPtr&,
+                  std::function<void(const drogon::HttpResponsePtr&)>&&,
+                  int tenantId, int id);
+    void updateGroup(const drogon::HttpRequestPtr&,
+                     std::function<void(const drogon::HttpResponsePtr&)>&&,
+                     int tenantId, int id);
+    void deleteGroup(const drogon::HttpRequestPtr&,
+                     std::function<void(const drogon::HttpResponsePtr&)>&&,
+                     int tenantId, int id);
+};

--- a/backend/tests/run-tests.py
+++ b/backend/tests/run-tests.py
@@ -44,11 +44,13 @@ FAST_TESTS = [
     "test_15_cors.py",
     "test_16_notes.py",
     "test_17_media.py",
+    "test_18_visibility_groups.py",
 ]
 
 # test_14_nodes.py landed in #96 (NodeController CRUD + tree + max-depth).
 # test_16_notes.py landed in #83 (Note CRUD restructured under nodes).
 # test_17_media.py landed in #84 (Media for nodes and notes).
+# test_18_visibility_groups.py landed in #85 (visibility-group CRUD only).
 # Annotation/note-group tests are gone permanently — those concepts were
 # consolidated into nodes and visibility groups during the rebuild.
 
@@ -69,6 +71,7 @@ TEST_DESCRIPTIONS = {
     15: "CORS preflight",
     16: "Notes (CRUD attached to nodes, pinned-first sort, cross-tenant)",
     17: "Media on nodes and notes (CRUD, scheme validation, CASCADE)",
+    18: "Visibility groups (admin-only CRUD; member mgmt in #98)",
 }
 
 

--- a/backend/tests/test_18_visibility_groups.py
+++ b/backend/tests/test_18_visibility_groups.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""test_18_visibility_groups.py — Visibility groups CRUD (Phase 2b.i.a).
+
+This phase is admin-only. Member management + the manages_visibility
+escape hatch + tenant-creation bootstrap arrive in Phase 2b.i.b (#98);
+proper non-admin authorization tests live there too. Personal-tenant
+users (the only thing test infrastructure can produce today) are always
+admins of their own tenant, so non-admin coverage is deferred.
+"""
+
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import (
+    reset_counters, report, assert_status, assert_json_field, assert_json_exists,
+    assert_true, http_post, http_get, http_put, http_delete,
+    register_user, json_field,
+)
+
+reset_counters()
+RUN_ID = os.getpid()
+
+print("=== Visibility Group Tests ===")
+
+# Two tenants for cross-tenant checks
+TOKEN_A = register_user(f"t18_a_{RUN_ID}", f"t18_a_{RUN_ID}@test.com", "testpass123")
+_, body_a = http_post("/auth/login",
+    {"email": f"t18_a_{RUN_ID}@test.com", "password": "testpass123"})
+TENANT_A = json_field(body_a, ["tenantId"])
+
+TOKEN_B = register_user(f"t18_b_{RUN_ID}", f"t18_b_{RUN_ID}@test.com", "testpass123")
+
+BASE = f"/tenants/{TENANT_A}/visibility-groups"
+
+# ─── Create ──────────────────────────────────────────────────────────────────
+
+print("  --- Create ---")
+
+status, body = http_post(BASE, {"name": "Players"}, TOKEN_A)
+assert_status("create: minimal returns 201", 201, status)
+G_PLAYERS = json_field(body, ["id"])
+assert_json_field("create: name", body, ["name"], "Players")
+assert_json_field("create: managesVisibility defaults false",
+                  body, ["managesVisibility"], False)
+assert_json_field("create: tenantId set", body, ["tenantId"], str(TENANT_A))
+
+status, body = http_post(BASE, {
+    "name": "GMs",
+    "description": "Game masters",
+    "managesVisibility": True,
+}, TOKEN_A)
+assert_status("create: with description + flag returns 201", 201, status)
+G_GMS = json_field(body, ["id"])
+assert_json_field("create: managesVisibility true", body, ["managesVisibility"], True)
+assert_json_field("create: description set", body, ["description"], "Game masters")
+
+# Validation: missing name
+status, _ = http_post(BASE, {"description": "no name"}, TOKEN_A)
+assert_status("create: missing name returns 400", 400, status)
+
+# Validation: empty name
+status, _ = http_post(BASE, {"name": ""}, TOKEN_A)
+assert_status("create: empty name returns 400", 400, status)
+
+# Duplicate (tenant_id, name) → 409
+status, _ = http_post(BASE, {"name": "Players"}, TOKEN_A)
+assert_status("create: duplicate name returns 409", 409, status)
+
+# Cross-tenant blocked at the TenantFilter
+status, _ = http_post(BASE, {"name": "Trespass"}, TOKEN_B)
+assert_status("create: cross-tenant blocked", 403, status)
+
+print("  All create tests passed.")
+
+# ─── List ────────────────────────────────────────────────────────────────────
+
+print("  --- List ---")
+
+status, body = http_get(BASE, TOKEN_A)
+assert_status("list: returns 200", 200, status)
+assert_true("list: returns array", isinstance(body, list))
+assert_true("list: contains both groups", len(body) >= 2)
+
+names = sorted(g["name"] for g in body)
+assert_true("list: alphabetical-ish (or at least both names present)",
+            "GMs" in names and "Players" in names)
+
+# Cross-tenant blocked
+status, _ = http_get(BASE, TOKEN_B)
+assert_status("list: cross-tenant blocked", 403, status)
+
+print("  All list tests passed.")
+
+# ─── Get ─────────────────────────────────────────────────────────────────────
+
+print("  --- Get ---")
+
+status, body = http_get(f"{BASE}/{G_PLAYERS}", TOKEN_A)
+assert_status("get: returns 200", 200, status)
+assert_json_field("get: name", body, ["name"], "Players")
+assert_json_exists("get: has createdAt", body, ["createdAt"])
+
+# Not found
+status, _ = http_get(f"{BASE}/9999999", TOKEN_A)
+assert_status("get: missing returns 404", 404, status)
+
+# Cross-tenant blocked
+status, _ = http_get(f"{BASE}/{G_PLAYERS}", TOKEN_B)
+assert_status("get: cross-tenant blocked", 403, status)
+
+print("  All get tests passed.")
+
+# ─── Update ──────────────────────────────────────────────────────────────────
+
+print("  --- Update ---")
+
+status, _ = http_put(f"{BASE}/{G_PLAYERS}",
+    {"description": "Player characters"}, TOKEN_A)
+assert_status("update: description returns 200", 200, status)
+status, body = http_get(f"{BASE}/{G_PLAYERS}", TOKEN_A)
+assert_json_field("update: description persisted",
+                  body, ["description"], "Player characters")
+
+# Toggle managesVisibility
+status, _ = http_put(f"{BASE}/{G_PLAYERS}", {"managesVisibility": True}, TOKEN_A)
+status, body = http_get(f"{BASE}/{G_PLAYERS}", TOKEN_A)
+assert_json_field("update: managesVisibility true persisted",
+                  body, ["managesVisibility"], True)
+status, _ = http_put(f"{BASE}/{G_PLAYERS}", {"managesVisibility": False}, TOKEN_A)
+status, body = http_get(f"{BASE}/{G_PLAYERS}", TOKEN_A)
+assert_json_field("update: managesVisibility false persisted",
+                  body, ["managesVisibility"], False)
+
+# Rename (and prove uniqueness still enforced)
+status, _ = http_put(f"{BASE}/{G_PLAYERS}", {"name": "GMs"}, TOKEN_A)
+assert_status("update: rename to existing name returns 409", 409, status)
+
+# Cross-tenant cannot update
+status, _ = http_put(f"{BASE}/{G_PLAYERS}", {"name": "hacked"}, TOKEN_B)
+assert_status("update: cross-tenant blocked", 403, status)
+
+# Missing record
+status, _ = http_put(f"{BASE}/9999999", {"description": "x"}, TOKEN_A)
+assert_status("update: missing returns 404", 404, status)
+
+print("  All update tests passed.")
+
+# ─── Delete ──────────────────────────────────────────────────────────────────
+
+print("  --- Delete ---")
+
+# Cross-tenant blocked
+status, _ = http_delete(f"{BASE}/{G_PLAYERS}", TOKEN_B)
+assert_status("delete: cross-tenant blocked", 403, status)
+
+# Missing record
+status, _ = http_delete(f"{BASE}/9999999", TOKEN_A)
+assert_status("delete: missing returns 404", 404, status)
+
+# Owner deletes
+status, _ = http_delete(f"{BASE}/{G_PLAYERS}", TOKEN_A)
+assert_status("delete: returns 204", 204, status)
+
+# Verify gone
+status, _ = http_get(f"{BASE}/{G_PLAYERS}", TOKEN_A)
+assert_status("delete: group is gone", 404, status)
+
+print("  All delete tests passed.")
+
+sys.exit(0 if report() else 1)


### PR DESCRIPTION
## Summary

Closes #85. New \`VisibilityGroupController\` with five endpoints exposing CRUD for visibility groups. Tenant admins only at this phase — the manager-flag authorization helper, member management, and tenant-creation bootstrap of a default \"Visibility Managers\" group all arrive in Phase 2b.i.b (#98).

## Routes

| Method | Path |
|---|---|
| GET    | \`/api/v1/tenants/{tid}/visibility-groups\` |
| POST   | \`/api/v1/tenants/{tid}/visibility-groups\` |
| GET    | \`/api/v1/tenants/{tid}/visibility-groups/{id}\` |
| PUT    | \`/api/v1/tenants/{tid}/visibility-groups/{id}\` |
| DELETE | \`/api/v1/tenants/{tid}/visibility-groups/{id}\` |

## Body shape

\`\`\`json
{ "name": "Players", "description": "Optional", "managesVisibility": false }
\`\`\`

- \`name\` is required, capped at \`MAX_NAME_LEN\`, **unique per tenant**.
- \`description\` is optional, capped at \`MAX_DESCRIPTION_LEN\`.
- \`managesVisibility\` defaults to false. Updateable via PUT. The flag has **no auth effect at this phase** (admins only) — it becomes load-bearing in #98 when the auth helper reads it to decide who else can manage visibility groups.

## Behavior worth flagging

- **Duplicate \`(tenant_id, name)\` returns 409 Conflict.** Matches the duplicate-key handling pattern already in \`AuthController\` (string-match on \"Duplicate\" in the exception). Verified by tests for both create and rename-via-update.
- **CASCADE on delete:** \`visibility_group_members\`, \`node_visibility\`, and \`note_visibility\` all FK CASCADE on \`visibility_groups.id\` (in the schema since #97). Deleting a group cleans up memberships and tagging without a manual sweep.

## Permission model

Tenant admins only for all five endpoints at this phase. The \`manages_visibility\` group-membership escape hatch arrives in #98.

## Tests

New \`backend/tests/test_18_visibility_groups.py\` (32 assertions, all passing locally):
- Admin CRUD happy paths
- Missing-name → 400
- Empty-name → 400
- Duplicate name → 409 (on create AND on rename via update)
- \`managesVisibility\` round-trips correctly
- Cross-tenant blocked at the \`TenantFilter\` (returns 403 before the controller runs)
- 404 on missing records (get / update / delete)

Added to \`FAST_TESTS\`. Full fast tier passes in 13s locally.

**Non-admin authorization tests are deferred to #98.** Personal-tenant test users are always admins of their own tenant, so producing a non-admin user requires the member-add endpoint that lands in the next phase.

## Test expectations (CI on \`nodes-rebuild\`)

| Job | Expected | Why |
|---|---|---|
| \`lint\` | ✅ pass | No frontend changes. |
| \`security\` | ✅ pass | No new dependencies. |
| \`compile\` | ✅ pass | New controller compiles cleanly locally. |
| \`integration\` (db tests) | ✅ pass | 179/179 unchanged. |
| \`integration\` (backend tests) | ✅ pass | 12/12 suites pass locally including new \`test_18_visibility_groups.py\`. |
| \`integration\` (E2E) | ❌ **expected fail** | Frontend rebuild lands in #92 / #101 / #102. |

\`integration\` will report red overall because of E2E. Mid-rebuild informational state — \`main\` remains the enforced gate.

## Files changed

- \`backend/src/controllers/VisibilityGroupController.h\` — Routes + method declarations.
- \`backend/src/controllers/VisibilityGroupController.cpp\` — Five handlers + \`requireAdmin\` helper + duplicate-key handling.
- \`backend/tests/test_18_visibility_groups.py\` — 32 integration test assertions.
- \`backend/tests/run-tests.py\` — Add \`test_18_visibility_groups.py\` to \`FAST_TESTS\`; add description.

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)