### PR TITLE
Phase 2b.i.b: Visibility group members + tenant bootstrap (#98)

### DIFF
--- a/backend/src/controllers/AuthController.cpp
+++ b/backend/src/controllers/AuthController.cpp
@@ -143,6 +143,25 @@ void AuthController::registerUser(
                                         "VALUES (?,?,?)",
                                         [callback, req, newId, username, email, orgId, tenantId, this]
                                         (const drogon::orm::Result&) {
+                                    // Step 6: Bootstrap a default "Visibility Managers"
+                                    // group for the new tenant, with manages_visibility=TRUE
+                                    // and the registering user as the sole member. Lets
+                                    // the user delegate visibility-group management without
+                                    // promoting someone to full tenant admin (Phase 2b.i.b).
+                                    auto db6 = drogon::app().getDbClient();
+                                    db6->execSqlAsync(
+                                        "INSERT INTO visibility_groups "
+                                        "  (tenant_id, name, manages_visibility, created_by) "
+                                        "VALUES (?, 'Visibility Managers', TRUE, ?)",
+                                        [callback, req, newId, username, email, orgId, tenantId, this]
+                                        (const drogon::orm::Result& rvg) {
+                                    int vgId = static_cast<int>(rvg.insertId());
+                                    auto db7 = drogon::app().getDbClient();
+                                    db7->execSqlAsync(
+                                        "INSERT INTO visibility_group_members "
+                                        "  (visibility_group_id, user_id) VALUES (?, ?)",
+                                        [callback, req, newId, username, email, orgId, tenantId, this]
+                                        (const drogon::orm::Result&) {
                                     AuditLog::record("register", req, newId);
                                     std::string token = issueToken(newId, username, orgId);
 
@@ -168,6 +187,22 @@ void AuthController::registerUser(
                                         drogon::HttpResponse::newHttpJsonResponse(resp);
                                     httpResp->setStatusCode(drogon::k201Created);
                                     callback(httpResp);
+                                        },
+                                        [callback](const drogon::orm::DrogonDbException&) {
+                                            auto resp = drogon::HttpResponse::newHttpJsonResponse(
+                                                errorJson("db_error", "Failed to add to default visibility group"));
+                                            resp->setStatusCode(drogon::k500InternalServerError);
+                                            callback(resp);
+                                        },
+                                        vgId, newId);
+                                        },
+                                        [callback](const drogon::orm::DrogonDbException&) {
+                                            auto resp = drogon::HttpResponse::newHttpJsonResponse(
+                                                errorJson("db_error", "Failed to bootstrap default visibility group"));
+                                            resp->setStatusCode(drogon::k500InternalServerError);
+                                            callback(resp);
+                                        },
+                                        tenantId, newId);
                                         },
                                         [callback](const drogon::orm::DrogonDbException&) {
                                             auto resp = drogon::HttpResponse::newHttpJsonResponse(

--- a/backend/src/controllers/VisibilityGroupController.cpp
+++ b/backend/src/controllers/VisibilityGroupController.cpp
@@ -2,32 +2,72 @@
 #include "ErrorResponse.h"
 #include <drogon/drogon.h>
 
-// Phase 2b.i.a: CRUD on visibility_groups, tenant-admin-only. Member
-// management + manages_visibility-based authorization + the
-// tenant-creation bootstrap of a default "Visibility Managers" group
-// land in Phase 2b.i.b (#98).
+// Phase 2b.i.b: Member management endpoints + the manages_visibility-
+// based authorization helper + tenant-creation bootstrap (which lives
+// in AuthController, since that's where new tenants are created).
 //
-// Tagging nodes/notes with these groups arrives in #86 (nodes) and
-// #87 (notes); read-time filtering using effective visibility is in #99.
+// Tagging nodes/notes with these groups arrives in #86/#87; read-time
+// filtering using effective visibility is in #99.
 
 static int callerUserId(const drogon::HttpRequestPtr& req) {
     try { return req->getAttributes()->get<int>("userId"); }
     catch (...) { return 0; }
 }
 
+static int callerOrgId(const drogon::HttpRequestPtr& req) {
+    try { return req->getAttributes()->get<int>("orgId"); }
+    catch (...) { return 0; }
+}
+
 namespace {
 
-// Throughout this phase, only tenant admins can manage visibility groups.
-// The manager-flag escape hatch is wired up in #98.
-bool requireAdmin(const drogon::HttpRequestPtr& req,
-                  const std::function<void(const drogon::HttpResponsePtr&)>& callback) {
+bool isTenantAdmin(const drogon::HttpRequestPtr& req) {
     try {
-        const std::string role = req->getAttributes()->get<std::string>("tenantRole");
-        if (role == "admin") return true;
-    } catch (...) {}
-    callback(errorResponse(drogon::k403Forbidden,
-        "forbidden", "Only tenant admins can manage visibility groups"));
-    return false;
+        return req->getAttributes()->get<std::string>("tenantRole") == "admin";
+    } catch (...) { return false; }
+}
+
+// Authorization helper for visibility-group management. Allowed if:
+//   * Caller is a tenant admin (sync path), OR
+//   * Caller is a member of any visibility_group in this tenant with
+//     manages_visibility = TRUE (async path — one DB query).
+//
+// On success, calls onAllowed(). On denial or DB error, sends a 403/500
+// via callback. Pattern mirrors how filter chains hand off to the next
+// step — each handler wraps its real logic in onAllowed.
+void requireVisibilityGroupManager(
+    const drogon::HttpRequestPtr& req,
+    int tenantId,
+    int userId,
+    const std::function<void(const drogon::HttpResponsePtr&)>& callback,
+    std::function<void()> onAllowed) {
+
+    if (isTenantAdmin(req)) {
+        onAllowed();
+        return;
+    }
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT 1 FROM visibility_group_members vgm "
+        "JOIN visibility_groups vg ON vg.id = vgm.visibility_group_id "
+        "WHERE vgm.user_id = ? AND vg.tenant_id = ? "
+        "  AND vg.manages_visibility = TRUE LIMIT 1",
+        [callback, onAllowed = std::move(onAllowed)](const drogon::orm::Result& r) {
+            if (r.empty()) {
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden",
+                    "Only tenant admins or visibility-group managers "
+                    "can manage visibility groups"));
+                return;
+            }
+            onAllowed();
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to check authorization"));
+        },
+        userId, tenantId);
 }
 
 Json::Value rowToGroup(const drogon::orm::Row& row) {
@@ -44,6 +84,15 @@ Json::Value rowToGroup(const drogon::orm::Row& row) {
     return g;
 }
 
+Json::Value rowToMember(const drogon::orm::Row& row) {
+    Json::Value m;
+    m["userId"]   = row["user_id"].as<int>();
+    m["username"] = row["username"].as<std::string>();
+    m["email"]    = row["email"].as<std::string>();
+    m["joinedAt"] = row["joined_at"].as<std::string>();
+    return m;
+}
+
 } // anonymous namespace
 
 // ─── GET /api/v1/tenants/{tenantId}/visibility-groups ───────────────────────
@@ -53,25 +102,27 @@ void VisibilityGroupController::listGroups(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId) {
 
-    if (!requireAdmin(req, callback)) return;
-
-    auto db = drogon::app().getDbClient();
-    db->execSqlAsync(
-        "SELECT id, tenant_id, name, description, manages_visibility, "
-        "       created_by, created_at, updated_at "
-        "FROM visibility_groups "
-        "WHERE tenant_id = ? "
-        "ORDER BY name ASC",
-        [callback](const drogon::orm::Result& r) {
-            Json::Value arr(Json::arrayValue);
-            for (const auto& row : r) arr.append(rowToGroup(row));
-            callback(drogon::HttpResponse::newHttpJsonResponse(arr));
-        },
-        [callback](const drogon::orm::DrogonDbException&) {
-            callback(errorResponse(drogon::k500InternalServerError,
-                "db_error", "Failed to fetch visibility groups"));
-        },
-        tenantId);
+    int userId = callerUserId(req);
+    requireVisibilityGroupManager(req, tenantId, userId, callback,
+        [callback, tenantId]() {
+            auto db = drogon::app().getDbClient();
+            db->execSqlAsync(
+                "SELECT id, tenant_id, name, description, manages_visibility, "
+                "       created_by, created_at, updated_at "
+                "FROM visibility_groups "
+                "WHERE tenant_id = ? "
+                "ORDER BY name ASC",
+                [callback](const drogon::orm::Result& r) {
+                    Json::Value arr(Json::arrayValue);
+                    for (const auto& row : r) arr.append(rowToGroup(row));
+                    callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to fetch visibility groups"));
+                },
+                tenantId);
+        });
 }
 
 // ─── POST /api/v1/tenants/{tenantId}/visibility-groups ──────────────────────
@@ -81,10 +132,9 @@ void VisibilityGroupController::createGroup(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId) {
 
-    if (!requireAdmin(req, callback)) return;
-
     int userId = callerUserId(req);
-    auto body  = req->getJsonObject();
+
+    auto body = req->getJsonObject();
     if (!body || !body->isMember("name")) {
         callback(errorResponse(drogon::k400BadRequest,
             "bad_request", "name is required"));
@@ -103,37 +153,49 @@ void VisibilityGroupController::createGroup(
     if (!checkMaxLen("name", name, MAX_NAME_LEN, callback)) return;
     if (!checkMaxLen("description", description, MAX_DESCRIPTION_LEN, callback)) return;
 
-    auto db = drogon::app().getDbClient();
-    db->execSqlAsync(
-        "INSERT INTO visibility_groups "
-        "  (tenant_id, name, description, manages_visibility, created_by) "
-        "VALUES (?, ?, NULLIF(?, ''), ?, ?)",
-        [callback, tenantId, userId, name, description, managesVisibility]
-        (const drogon::orm::Result& r) {
-            int newId = static_cast<int>(r.insertId());
-            Json::Value g;
-            g["id"]                 = newId;
-            g["tenantId"]           = tenantId;
-            g["name"]               = name;
-            g["description"]        = description;
-            g["managesVisibility"]  = managesVisibility;
-            g["createdBy"]          = userId;
-            auto resp = drogon::HttpResponse::newHttpJsonResponse(g);
-            resp->setStatusCode(drogon::k201Created);
-            callback(resp);
-        },
-        [callback](const drogon::orm::DrogonDbException& ex) {
-            // MariaDB error 1062 = duplicate key (UNIQUE on (tenant_id, name))
-            // Match the same pattern AuthController uses for duplicate keys.
-            if (std::string(ex.base().what()).find("Duplicate") != std::string::npos) {
-                callback(errorResponse(drogon::k409Conflict,
-                    "conflict", "A visibility group with this name already exists in this tenant"));
-                return;
-            }
-            callback(errorResponse(drogon::k500InternalServerError,
-                "db_error", "Failed to create visibility group"));
-        },
-        tenantId, name, description, managesVisibility, userId);
+    // Escalation guard: only tenant admins can CREATE a manages_visibility
+    // group. Managers can create regular groups but not promote a group
+    // to manager status. Symmetric with the PUT guard below.
+    if (managesVisibility && !isTenantAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden",
+            "Only tenant admins can create a managesVisibility group"));
+        return;
+    }
+
+    requireVisibilityGroupManager(req, tenantId, userId, callback,
+        [callback, tenantId, userId, name, description, managesVisibility]() {
+            auto db = drogon::app().getDbClient();
+            db->execSqlAsync(
+                "INSERT INTO visibility_groups "
+                "  (tenant_id, name, description, manages_visibility, created_by) "
+                "VALUES (?, ?, NULLIF(?, ''), ?, ?)",
+                [callback, tenantId, userId, name, description, managesVisibility]
+                (const drogon::orm::Result& r) {
+                    int newId = static_cast<int>(r.insertId());
+                    Json::Value g;
+                    g["id"]                 = newId;
+                    g["tenantId"]           = tenantId;
+                    g["name"]               = name;
+                    g["description"]        = description;
+                    g["managesVisibility"]  = managesVisibility;
+                    g["createdBy"]          = userId;
+                    auto resp = drogon::HttpResponse::newHttpJsonResponse(g);
+                    resp->setStatusCode(drogon::k201Created);
+                    callback(resp);
+                },
+                [callback](const drogon::orm::DrogonDbException& ex) {
+                    if (std::string(ex.base().what()).find("Duplicate") != std::string::npos) {
+                        callback(errorResponse(drogon::k409Conflict,
+                            "conflict",
+                            "A visibility group with this name already exists in this tenant"));
+                        return;
+                    }
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to create visibility group"));
+                },
+                tenantId, name, description, managesVisibility, userId);
+        });
 }
 
 // ─── GET /api/v1/tenants/{tenantId}/visibility-groups/{id} ──────────────────
@@ -143,26 +205,28 @@ void VisibilityGroupController::getGroup(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId, int id) {
 
-    if (!requireAdmin(req, callback)) return;
-
-    auto db = drogon::app().getDbClient();
-    db->execSqlAsync(
-        "SELECT id, tenant_id, name, description, manages_visibility, "
-        "       created_by, created_at, updated_at "
-        "FROM visibility_groups WHERE id = ? AND tenant_id = ?",
-        [callback](const drogon::orm::Result& r) {
-            if (r.empty()) {
-                callback(errorResponse(drogon::k404NotFound,
-                    "not_found", "Visibility group not found"));
-                return;
-            }
-            callback(drogon::HttpResponse::newHttpJsonResponse(rowToGroup(r[0])));
-        },
-        [callback](const drogon::orm::DrogonDbException&) {
-            callback(errorResponse(drogon::k500InternalServerError,
-                "db_error", "Database error"));
-        },
-        id, tenantId);
+    int userId = callerUserId(req);
+    requireVisibilityGroupManager(req, tenantId, userId, callback,
+        [callback, tenantId, id]() {
+            auto db = drogon::app().getDbClient();
+            db->execSqlAsync(
+                "SELECT id, tenant_id, name, description, manages_visibility, "
+                "       created_by, created_at, updated_at "
+                "FROM visibility_groups WHERE id = ? AND tenant_id = ?",
+                [callback](const drogon::orm::Result& r) {
+                    if (r.empty()) {
+                        callback(errorResponse(drogon::k404NotFound,
+                            "not_found", "Visibility group not found"));
+                        return;
+                    }
+                    callback(drogon::HttpResponse::newHttpJsonResponse(rowToGroup(r[0])));
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Database error"));
+                },
+                id, tenantId);
+        });
 }
 
 // ─── PUT /api/v1/tenants/{tenantId}/visibility-groups/{id} ──────────────────
@@ -172,7 +236,7 @@ void VisibilityGroupController::updateGroup(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId, int id) {
 
-    if (!requireAdmin(req, callback)) return;
+    int userId = callerUserId(req);
 
     auto body = req->getJsonObject();
     if (!body) {
@@ -189,69 +253,207 @@ void VisibilityGroupController::updateGroup(
     if (!checkMaxLen("name", name, MAX_NAME_LEN, callback)) return;
     if (!checkMaxLen("description", description, MAX_DESCRIPTION_LEN, callback)) return;
 
-    auto db = drogon::app().getDbClient();
-    db->execSqlAsync(
-        "UPDATE visibility_groups SET "
-        "  name               = IF(?='', name, ?), "
-        "  description        = IF(?='', description, ?), "
-        "  manages_visibility = IF(?, ?, manages_visibility) "
-        "WHERE id = ? AND tenant_id = ?",
-        [callback, id](const drogon::orm::Result& r) {
-            if (r.affectedRows() == 0) {
-                callback(errorResponse(drogon::k404NotFound,
-                    "not_found", "Visibility group not found"));
-                return;
-            }
-            Json::Value v;
-            v["id"]      = id;
-            v["updated"] = true;
-            callback(drogon::HttpResponse::newHttpJsonResponse(v));
-        },
-        [callback](const drogon::orm::DrogonDbException& ex) {
-            // Match the same pattern AuthController uses for duplicate keys.
-            if (std::string(ex.base().what()).find("Duplicate") != std::string::npos) {
-                callback(errorResponse(drogon::k409Conflict,
-                    "conflict", "A visibility group with this name already exists in this tenant"));
-                return;
-            }
-            callback(errorResponse(drogon::k500InternalServerError,
-                "db_error", "Failed to update visibility group"));
-        },
-        name, name,
-        description, description,
-        hasManages, managesVisibility,
-        id, tenantId);
+    // Escalation guard: only tenant admins can change managesVisibility.
+    // Managers cannot promote themselves (or peers) into more power.
+    if (hasManages && !isTenantAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden",
+            "Only tenant admins can change managesVisibility"));
+        return;
+    }
+
+    requireVisibilityGroupManager(req, tenantId, userId, callback,
+        [callback, tenantId, id, name, description, hasManages, managesVisibility]() {
+            auto db = drogon::app().getDbClient();
+            db->execSqlAsync(
+                "UPDATE visibility_groups SET "
+                "  name               = IF(?='', name, ?), "
+                "  description        = IF(?='', description, ?), "
+                "  manages_visibility = IF(?, ?, manages_visibility) "
+                "WHERE id = ? AND tenant_id = ?",
+                [callback, id](const drogon::orm::Result& r) {
+                    if (r.affectedRows() == 0) {
+                        callback(errorResponse(drogon::k404NotFound,
+                            "not_found", "Visibility group not found"));
+                        return;
+                    }
+                    Json::Value v;
+                    v["id"]      = id;
+                    v["updated"] = true;
+                    callback(drogon::HttpResponse::newHttpJsonResponse(v));
+                },
+                [callback](const drogon::orm::DrogonDbException& ex) {
+                    if (std::string(ex.base().what()).find("Duplicate") != std::string::npos) {
+                        callback(errorResponse(drogon::k409Conflict,
+                            "conflict",
+                            "A visibility group with this name already exists in this tenant"));
+                        return;
+                    }
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to update visibility group"));
+                },
+                name, name,
+                description, description,
+                hasManages, managesVisibility,
+                id, tenantId);
+        });
 }
 
 // ─── DELETE /api/v1/tenants/{tenantId}/visibility-groups/{id} ───────────────
-//
-// Junction tables (visibility_group_members, node_visibility,
-// note_visibility) are FK CASCADE'd via the schema, so deleting a
-// group cleans up its memberships and tagging without a manual sweep.
 
 void VisibilityGroupController::deleteGroup(
     const drogon::HttpRequestPtr& req,
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId, int id) {
 
-    if (!requireAdmin(req, callback)) return;
+    int userId = callerUserId(req);
+    requireVisibilityGroupManager(req, tenantId, userId, callback,
+        [callback, tenantId, id]() {
+            auto db = drogon::app().getDbClient();
+            db->execSqlAsync(
+                "DELETE FROM visibility_groups WHERE id = ? AND tenant_id = ?",
+                [callback](const drogon::orm::Result& r) {
+                    if (r.affectedRows() == 0) {
+                        callback(errorResponse(drogon::k404NotFound,
+                            "not_found", "Visibility group not found"));
+                        return;
+                    }
+                    auto resp = drogon::HttpResponse::newHttpResponse();
+                    resp->setStatusCode(drogon::k204NoContent);
+                    callback(resp);
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to delete visibility group"));
+                },
+                id, tenantId);
+        });
+}
 
-    auto db = drogon::app().getDbClient();
-    db->execSqlAsync(
-        "DELETE FROM visibility_groups WHERE id = ? AND tenant_id = ?",
-        [callback](const drogon::orm::Result& r) {
-            if (r.affectedRows() == 0) {
-                callback(errorResponse(drogon::k404NotFound,
-                    "not_found", "Visibility group not found"));
-                return;
-            }
-            auto resp = drogon::HttpResponse::newHttpResponse();
-            resp->setStatusCode(drogon::k204NoContent);
-            callback(resp);
-        },
-        [callback](const drogon::orm::DrogonDbException&) {
-            callback(errorResponse(drogon::k500InternalServerError,
-                "db_error", "Failed to delete visibility group"));
-        },
-        id, tenantId);
+// ─── GET .../visibility-groups/{id}/members ─────────────────────────────────
+
+void VisibilityGroupController::listMembers(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id) {
+
+    int userId = callerUserId(req);
+    requireVisibilityGroupManager(req, tenantId, userId, callback,
+        [callback, tenantId, id]() {
+            auto db = drogon::app().getDbClient();
+            db->execSqlAsync(
+                "SELECT vgm.user_id, u.username, u.email, vgm.joined_at "
+                "FROM visibility_group_members vgm "
+                "JOIN visibility_groups vg ON vg.id = vgm.visibility_group_id "
+                "JOIN users u ON u.id = vgm.user_id "
+                "WHERE vgm.visibility_group_id = ? AND vg.tenant_id = ? "
+                "ORDER BY u.username ASC",
+                [callback](const drogon::orm::Result& r) {
+                    Json::Value arr(Json::arrayValue);
+                    for (const auto& row : r) arr.append(rowToMember(row));
+                    callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to fetch members"));
+                },
+                id, tenantId);
+        });
+}
+
+// ─── POST .../visibility-groups/{id}/members ────────────────────────────────
+
+void VisibilityGroupController::addMember(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id) {
+
+    int callerId  = callerUserId(req);
+    int callerOrg = callerOrgId(req);
+
+    auto body = req->getJsonObject();
+    if (!body || !body->isMember("userId")) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "userId is required"));
+        return;
+    }
+    int targetUserId = (*body)["userId"].asInt();
+
+    requireVisibilityGroupManager(req, tenantId, callerId, callback,
+        [callback, tenantId, id, callerOrg, targetUserId]() {
+            // Verify the target user is in the same org. Visibility-group
+            // membership is tenant-scoped but cross-org members are
+            // intentionally rejected (matches the map-permission-add rule).
+            auto db = drogon::app().getDbClient();
+            db->execSqlAsync(
+                "SELECT 1 FROM visibility_groups vg "
+                "JOIN users u ON u.id = ? AND u.org_id = ? "
+                "WHERE vg.id = ? AND vg.tenant_id = ? LIMIT 1",
+                [callback, id, targetUserId](const drogon::orm::Result& r) {
+                    if (r.empty()) {
+                        callback(errorResponse(drogon::k400BadRequest,
+                            "bad_request",
+                            "Visibility group not found or user is in a different organization"));
+                        return;
+                    }
+                    auto db2 = drogon::app().getDbClient();
+                    db2->execSqlAsync(
+                        "INSERT IGNORE INTO visibility_group_members "
+                        "  (visibility_group_id, user_id) VALUES (?, ?)",
+                        [callback, id, targetUserId](const drogon::orm::Result&) {
+                            Json::Value v;
+                            v["visibilityGroupId"] = id;
+                            v["userId"]            = targetUserId;
+                            v["added"]             = true;
+                            auto resp = drogon::HttpResponse::newHttpJsonResponse(v);
+                            resp->setStatusCode(drogon::k201Created);
+                            callback(resp);
+                        },
+                        [callback](const drogon::orm::DrogonDbException&) {
+                            callback(errorResponse(drogon::k500InternalServerError,
+                                "db_error", "Failed to add member"));
+                        },
+                        id, targetUserId);
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Database error"));
+                },
+                targetUserId, callerOrg, id, tenantId);
+        });
+}
+
+// ─── DELETE .../visibility-groups/{id}/members/{userId} ─────────────────────
+
+void VisibilityGroupController::removeMember(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id, int userId) {
+
+    int callerId = callerUserId(req);
+    requireVisibilityGroupManager(req, tenantId, callerId, callback,
+        [callback, tenantId, id, userId]() {
+            auto db = drogon::app().getDbClient();
+            db->execSqlAsync(
+                "DELETE vgm FROM visibility_group_members vgm "
+                "JOIN visibility_groups vg ON vg.id = vgm.visibility_group_id "
+                "WHERE vgm.visibility_group_id = ? AND vgm.user_id = ? "
+                "  AND vg.tenant_id = ?",
+                [callback](const drogon::orm::Result& r) {
+                    if (r.affectedRows() == 0) {
+                        callback(errorResponse(drogon::k404NotFound,
+                            "not_found",
+                            "Member not found in this visibility group"));
+                        return;
+                    }
+                    auto resp = drogon::HttpResponse::newHttpResponse();
+                    resp->setStatusCode(drogon::k204NoContent);
+                    callback(resp);
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to remove member"));
+                },
+                id, userId, tenantId);
+        });
 }

--- a/backend/src/controllers/VisibilityGroupController.h
+++ b/backend/src/controllers/VisibilityGroupController.h
@@ -2,7 +2,7 @@
 #include <drogon/HttpController.h>
 
 /**
- * VisibilityGroupController — tenant-scoped, admin-only CRUD.
+ * VisibilityGroupController — tenant-scoped CRUD + member management.
  *
  * GET    /api/v1/tenants/{tenantId}/visibility-groups
  * POST   /api/v1/tenants/{tenantId}/visibility-groups
@@ -10,19 +10,25 @@
  * PUT    /api/v1/tenants/{tenantId}/visibility-groups/{id}
  * DELETE /api/v1/tenants/{tenantId}/visibility-groups/{id}
  *
- * Visibility groups are tenant-scoped, generic audiences. No GM/Player
- * baked in — each tenant defines its own. The `manages_visibility`
- * flag designates a group whose members can manage visibility groups
- * (used by Phase 2b.i.b's auth helper); for THIS phase, only tenant
- * admins can CRUD groups, regardless of the flag.
+ * GET    /api/v1/tenants/{tenantId}/visibility-groups/{id}/members
+ * POST   /api/v1/tenants/{tenantId}/visibility-groups/{id}/members
+ * DELETE /api/v1/tenants/{tenantId}/visibility-groups/{id}/members/{userId}
  *
- * Member management endpoints + the manages_visibility-based auth
- * helper + tenant-creation bootstrap arrive in Phase 2b.i.b (#98).
+ * Authorization: tenant admins always; plus any user who is a member of
+ * a visibility group with manages_visibility = TRUE in the same tenant.
  *
- * Body shape:
- *   { "name": "...", "description": "...", "managesVisibility": false }
+ * One escalation guard: setting managesVisibility = true on a group
+ * via PUT is admin-only — managers cannot bootstrap themselves into
+ * more power.
  *
- * `name` is unique per tenant (enforced via UNIQUE KEY (tenant_id, name)).
+ * Body shapes:
+ *   POST /visibility-groups       — { name, description?, managesVisibility? }
+ *   PUT  /visibility-groups/{id}  — same, all optional
+ *   POST /members                  — { userId }
+ *
+ * On registration of a new user (AuthController), a default
+ * "Visibility Managers" group is auto-created with manages_visibility
+ * = TRUE and the registering user as the sole member.
  */
 class VisibilityGroupController : public drogon::HttpController<VisibilityGroupController> {
 public:
@@ -42,6 +48,15 @@ public:
         ADD_METHOD_TO(VisibilityGroupController::deleteGroup,
                       "/api/v1/tenants/{tenantId}/visibility-groups/{id}",
                       drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(VisibilityGroupController::listMembers,
+                      "/api/v1/tenants/{tenantId}/visibility-groups/{id}/members",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+        ADD_METHOD_TO(VisibilityGroupController::addMember,
+                      "/api/v1/tenants/{tenantId}/visibility-groups/{id}/members",
+                      drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(VisibilityGroupController::removeMember,
+                      "/api/v1/tenants/{tenantId}/visibility-groups/{id}/members/{userId}",
+                      drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
     METHOD_LIST_END
 
     void listGroups(const drogon::HttpRequestPtr&,
@@ -59,4 +74,13 @@ public:
     void deleteGroup(const drogon::HttpRequestPtr&,
                      std::function<void(const drogon::HttpResponsePtr&)>&&,
                      int tenantId, int id);
+    void listMembers(const drogon::HttpRequestPtr&,
+                     std::function<void(const drogon::HttpResponsePtr&)>&&,
+                     int tenantId, int id);
+    void addMember(const drogon::HttpRequestPtr&,
+                   std::function<void(const drogon::HttpResponsePtr&)>&&,
+                   int tenantId, int id);
+    void removeMember(const drogon::HttpRequestPtr&,
+                      std::function<void(const drogon::HttpResponsePtr&)>&&,
+                      int tenantId, int id, int userId);
 };

--- a/backend/tests/test_18_visibility_groups.py
+++ b/backend/tests/test_18_visibility_groups.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python3
-"""test_18_visibility_groups.py — Visibility groups CRUD (Phase 2b.i.a).
+"""test_18_visibility_groups.py — Visibility groups CRUD + members + bootstrap.
 
-This phase is admin-only. Member management + the manages_visibility
-escape hatch + tenant-creation bootstrap arrive in Phase 2b.i.b (#98);
-proper non-admin authorization tests live there too. Personal-tenant
-users (the only thing test infrastructure can produce today) are always
-admins of their own tenant, so non-admin coverage is deferred.
+Phase 2b.i.a wired up admin-only CRUD; Phase 2b.i.b (#98) layers in:
+  * Member-management endpoints (list / add / remove)
+  * The manager-flag-based authorization helper (allows non-admin
+    members of any manages_visibility group to manage groups too)
+  * Tenant-creation bootstrap of a default "Visibility Managers"
+    group with the registering user as the sole member
+  * Escalation guards: only tenant admins can set/change the
+    managesVisibility flag
+
+Tests for non-admin managers actually exercising the manager-flag
+auth helper require a same-org non-admin user, which the personal-
+tenant test infrastructure can't produce. Documented inline; covered
+by code review for now.
 """
 
 import os
@@ -31,7 +39,33 @@ TENANT_A = json_field(body_a, ["tenantId"])
 
 TOKEN_B = register_user(f"t18_b_{RUN_ID}", f"t18_b_{RUN_ID}@test.com", "testpass123")
 
+USER_A_ID = json_field(body_a, ["user", "id"])
+
 BASE = f"/tenants/{TENANT_A}/visibility-groups"
+
+# ─── Tenant bootstrap ────────────────────────────────────────────────────────
+# Registration should auto-create a default "Visibility Managers" group
+# with manages_visibility=TRUE and the registering user as a member.
+
+print("  --- Bootstrap ---")
+
+status, body = http_get(BASE, TOKEN_A)
+assert_status("bootstrap: list returns 200", 200, status)
+managers = [g for g in body if g["name"] == "Visibility Managers"]
+assert_true("bootstrap: default Visibility Managers group exists",
+            len(managers) == 1)
+G_BOOTSTRAP = managers[0]["id"]
+assert_json_field("bootstrap: managesVisibility=true",
+                  managers[0], ["managesVisibility"], True)
+
+# Member of the bootstrap group should be the registering user.
+status, body = http_get(f"{BASE}/{G_BOOTSTRAP}/members", TOKEN_A)
+assert_status("bootstrap: list members returns 200", 200, status)
+member_ids = [m["userId"] for m in body]
+assert_true("bootstrap: caller is a member of Visibility Managers",
+            USER_A_ID in member_ids)
+
+print("  All bootstrap tests passed.")
 
 # ─── Create ──────────────────────────────────────────────────────────────────
 
@@ -167,5 +201,94 @@ status, _ = http_get(f"{BASE}/{G_PLAYERS}", TOKEN_A)
 assert_status("delete: group is gone", 404, status)
 
 print("  All delete tests passed.")
+
+# ─── Member management ──────────────────────────────────────────────────────
+
+print("  --- Members ---")
+
+# We deleted G_PLAYERS above; recreate one for member tests.
+_, body = http_post(BASE, {"name": "TestGroup"}, TOKEN_A)
+G_TEST = json_field(body, ["id"])
+
+# List is initially empty
+status, body = http_get(f"{BASE}/{G_TEST}/members", TOKEN_A)
+assert_status("members: list empty group returns 200", 200, status)
+assert_true("members: empty initially", isinstance(body, list) and len(body) == 0)
+
+# Add the caller (admin) as a member
+status, body = http_post(f"{BASE}/{G_TEST}/members", {"userId": USER_A_ID}, TOKEN_A)
+assert_status("members: add returns 201", 201, status)
+assert_json_field("members: visibilityGroupId in response",
+                  body, ["visibilityGroupId"], str(G_TEST))
+
+# Listing now returns 1
+status, body = http_get(f"{BASE}/{G_TEST}/members", TOKEN_A)
+assert_true("members: now contains 1", len(body) == 1)
+assert_json_field("members: userId correct", body[0], ["userId"], str(USER_A_ID))
+assert_json_exists("members: username present", body[0], ["username"])
+assert_json_exists("members: email present",    body[0], ["email"])
+
+# Idempotent (INSERT IGNORE): adding again still succeeds, list still shows 1
+status, _ = http_post(f"{BASE}/{G_TEST}/members", {"userId": USER_A_ID}, TOKEN_A)
+assert_status("members: dup add returns 201 (idempotent)", 201, status)
+status, body = http_get(f"{BASE}/{G_TEST}/members", TOKEN_A)
+assert_true("members: dup add stayed at 1", len(body) == 1)
+
+# Cross-org member rejected — login B again to extract user.id
+# (register_user helper only returns the token).
+_, body_b_login = http_post("/auth/login",
+    {"email": f"t18_b_{RUN_ID}@test.com", "password": "testpass123"})
+USER_B_ID = json_field(body_b_login, ["user", "id"])
+
+status, _ = http_post(f"{BASE}/{G_TEST}/members", {"userId": USER_B_ID}, TOKEN_A)
+assert_status("members: cross-org add rejected", 400, status)
+
+# Missing userId
+status, _ = http_post(f"{BASE}/{G_TEST}/members", {}, TOKEN_A)
+assert_status("members: missing userId returns 400", 400, status)
+
+# Cross-tenant blocked at TenantFilter
+status, _ = http_post(f"{BASE}/{G_TEST}/members", {"userId": USER_A_ID}, TOKEN_B)
+assert_status("members: cross-tenant add blocked", 403, status)
+
+# Remove the member
+status, _ = http_delete(f"{BASE}/{G_TEST}/members/{USER_A_ID}", TOKEN_A)
+assert_status("members: remove returns 204", 204, status)
+status, body = http_get(f"{BASE}/{G_TEST}/members", TOKEN_A)
+assert_true("members: list empty after remove", len(body) == 0)
+
+# Removing again returns 404
+status, _ = http_delete(f"{BASE}/{G_TEST}/members/{USER_A_ID}", TOKEN_A)
+assert_status("members: remove non-member returns 404", 404, status)
+
+# Cross-tenant remove blocked
+status, _ = http_delete(f"{BASE}/{G_TEST}/members/{USER_A_ID}", TOKEN_B)
+assert_status("members: cross-tenant remove blocked", 403, status)
+
+print("  All members tests passed.")
+
+# ─── managesVisibility escalation guard ─────────────────────────────────────
+# Setting managesVisibility=true is admin-only on both create and update.
+# The admin (TOKEN_A) can still do it freely; we cover the non-admin path
+# by code review since we can't produce a same-org non-admin user from
+# personal tenants alone.
+
+print("  --- managesVisibility escalation guard (admin happy paths) ---")
+
+# Admin creates a managesVisibility=true group OK
+status, body = http_post(BASE, {
+    "name": "AnotherManagerGroup", "managesVisibility": True,
+}, TOKEN_A)
+assert_status("escalation: admin creates managesVisibility group", 201, status)
+GMV = json_field(body, ["id"])
+
+# Admin can flip it back to false
+status, _ = http_put(f"{BASE}/{GMV}", {"managesVisibility": False}, TOKEN_A)
+assert_status("escalation: admin demotes the flag", 200, status)
+status, body = http_get(f"{BASE}/{GMV}", TOKEN_A)
+assert_json_field("escalation: managesVisibility=false persisted",
+                  body, ["managesVisibility"], False)
+
+print("  All escalation-guard happy paths passed.")
 
 sys.exit(0 if report() else 1)


### PR DESCRIPTION
Closes #98 (will close manually after merge — auto-close skips non-default-branch PRs).

## Summary

- Adds member-management endpoints (list / add / remove) under `/api/v1/tenants/{tid}/visibility-groups/{gid}/members`.
- Replaces the sync `requireAdmin` helper with an async `requireVisibilityGroupManager` helper that allows tenant admins **or** any user who is a member of a `manages_visibility = TRUE` group in the same tenant. All five existing CRUD handlers refactored to use it; the three new member handlers use it too.
- Bootstraps a default "Visibility Managers" group (with `manages_visibility = TRUE`) per tenant at user registration, with the registering user as the sole member.
- Escalation guard: setting `managesVisibility = true` (on POST or PUT) is admin-only — managers cannot bootstrap themselves into more power.
- `addMember` is idempotent (`INSERT IGNORE`) and rejects cross-org users (400).

## Files changed

- **backend/src/controllers/AuthController.cpp** — Steps 6+7 added to registration: insert default `Visibility Managers` group, then insert the registering user as a member.
- **backend/src/controllers/VisibilityGroupController.cpp** — async `requireVisibilityGroupManager` helper; refactor of 5 existing handlers to use it; new `listMembers` / `addMember` / `removeMember` handlers; escalation guards on `createGroup` + `updateGroup`.
- **backend/src/controllers/VisibilityGroupController.h** — three member-endpoint declarations + route entries; updated header docstring.
- **backend/tests/test_18_visibility_groups.py** — bootstrap section, members section (full CRUD + cross-org reject + idempotent dup-add + cross-tenant block), and escalation-guard happy-path tests.

## Test plan

- [x] `python3 backend/tests/test_18_visibility_groups.py` — 57 passed, 0 failed
- [x] `python3 backend/tests/run-tests.py --tier fast` — all suites pass
- [ ] CI green on PR (E2E expected red — see below)

## Test expectations (CI on `nodes-rebuild`)

| Job | Expected | Why |
|---|---|---|
| `lint` | ✅ pass | No frontend changes. |
| `security` | ✅ pass | No new dependencies. |
| `compile` | ✅ pass | New helper + handlers compile cleanly locally. |
| `integration` (db tests) | ✅ pass | 179/179 unchanged. |
| `integration` (backend tests) | ✅ pass | 12/12 suites pass locally including expanded `test_18_visibility_groups.py` (57 assertions). |
| `integration` (E2E) | ❌ **expected fail** | Annotations / cross-tenant E2E specs reference the old annotations frontend that was ripped out for the rebuild. Frontend rebuild lands in the #94 series (#92 / #101 / #102). |

`integration` will report red overall because of the E2E sub-step. Mid-rebuild informational state — `main` remains the enforced gate.

## Out of scope

- Non-admin escalation-guard rejection path (deferred to code review — personal-tenant test infra cannot produce a same-org non-admin user).
- Node tagging / filtering (Phase 2b.ii — tracked under #86, #99, #87).
- Frontend UI (#94 series).

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)