### PR TITLE
Phase 2b.ii.b: Effective-visibility CTE + read filtering + owner_xray (#99)

### DIFF
--- a/backend/src/controllers/NodeController.cpp
+++ b/backend/src/controllers/NodeController.cpp
@@ -78,6 +78,53 @@ const std::string MAP_EDIT_PREDICATE =
     " AND (m.owner_id = ? "
     "      OR mp.level IN ('edit','moderate','admin'))";
 
+// ─── Effective-visibility CTE (#99) ──────────────────────────────────────────
+// Recursive walk up the parent chain to find each node's "resolver" —
+// the nearest ancestor (or self) with visibility_override = TRUE. The
+// visibility groups tagged on the resolver are the node's effective set.
+//
+// `resolve` rows: (start_id, cur_id, parent_id, visibility_override, depth)
+//   Anchor: every node on the map at depth 0 (cur_id = start_id).
+//   Step:   if cur didn't have override, walk to its parent. Recursion
+//           halts once we hit override = TRUE (no further row produced
+//           from that branch) or hit the depth ceiling.
+//
+// `visible_starts`: for each start_id whose resolver tags include any
+// visibility group the caller is a member of, that start_id is visible.
+//
+// Bound MAX_NODE_DEPTH so a malicious deep chain can't stall us.
+//
+// The CTE prefix binds 2 parameters: (mapId, userId).
+
+const std::string VISIBILITY_RESOLVE_CTE =
+    "WITH RECURSIVE resolve AS ("
+    "  SELECT n.id AS start_id, n.id AS cur_id, n.parent_id, "
+    "         n.visibility_override, 0 AS depth "
+    "  FROM nodes n WHERE n.map_id = ? "
+    "  UNION ALL "
+    "  SELECT r.start_id, p.id, p.parent_id, p.visibility_override, r.depth + 1 "
+    "  FROM resolve r JOIN nodes p ON p.id = r.parent_id "
+    "  WHERE r.visibility_override = FALSE AND r.depth < " +
+        std::to_string(MAX_NODE_DEPTH) +
+    "), visible_starts AS ( "
+    "  SELECT DISTINCT r.start_id FROM resolve r "
+    "  JOIN node_visibility nv "
+    "       ON nv.node_id = r.cur_id AND r.visibility_override = TRUE "
+    "  JOIN visibility_group_members vgm "
+    "       ON vgm.visibility_group_id = nv.visibility_group_id "
+    "  WHERE vgm.user_id = ? "
+    ") ";
+
+// Predicate to AND into WHERE for non-admin callers. Binds 1 param: (userId).
+// Owner X-ray bypass is included so map owners with owner_xray = TRUE see
+// every node regardless of visibility tagging. Note: non-xray owners are
+// still bound by visibility — this matches the design intent (a GM who
+// owns the map only sees nodes tagged for them, unless they explicitly
+// opt into xray).
+const std::string VISIBILITY_PREDICATE =
+    " AND ((m.owner_id = ? AND m.owner_xray = TRUE) "
+    "      OR n.id IN (SELECT start_id FROM visible_starts)) ";
+
 // Build a JSON response for a single node row.
 Json::Value rowToNode(const drogon::orm::Row& row) {
     Json::Value n;
@@ -114,6 +161,7 @@ void NodeController::listNodes(
     int tenantId, int mapId) {
 
     int userId = callerUserId(req);
+    bool isAdmin = isTenantAdmin(req);
 
     // Parent-id filter: present-and-empty means "top-level only";
     // present-and-numeric means "children of N"; absent means "all".
@@ -130,22 +178,27 @@ void NodeController::listNodes(
         }
     }
 
-    std::string sql = R"(
-        SELECT n.id, n.map_id, n.parent_id, n.name, n.geo_json, n.description,
-               n.color, n.visibility_override, n.created_by,
-               u.username AS creator_username,
-               n.created_at, n.updated_at
-        FROM nodes n
-        JOIN maps m  ON m.id = n.map_id
-        JOIN users u ON u.id = n.created_by
-        LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ?
-        LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL
-                                        AND mp_pub.level IN ('view','comment','edit','moderate','admin')
-        WHERE n.map_id = ? AND m.tenant_id = ?
-          AND (m.owner_id = ?
-               OR mp.level IN ('view','comment','edit','moderate','admin')
-               OR mp_pub.level IN ('view','comment','edit','moderate','admin'))
-    )";
+    // Tenant admins bypass the visibility filter and see every node
+    // (per the #99 design). For non-admins, prepend the resolve CTE
+    // and AND in the visibility predicate.
+    std::string sql;
+    if (!isAdmin) sql = VISIBILITY_RESOLVE_CTE;
+    sql +=
+        "SELECT n.id, n.map_id, n.parent_id, n.name, n.geo_json, n.description, "
+        "       n.color, n.visibility_override, n.created_by, "
+        "       u.username AS creator_username, "
+        "       n.created_at, n.updated_at "
+        "FROM nodes n "
+        "JOIN maps m  ON m.id = n.map_id "
+        "JOIN users u ON u.id = n.created_by "
+        "LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ? "
+        "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
+        "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
+        "WHERE n.map_id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? "
+        "       OR mp.level IN ('view','comment','edit','moderate','admin') "
+        "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))";
+    if (!isAdmin) sql += VISIBILITY_PREDICATE;
     if (topLevelOnly) {
         sql += " AND n.parent_id IS NULL";
     } else if (hasParentFilter) {
@@ -153,9 +206,27 @@ void NodeController::listNodes(
     }
     sql += " ORDER BY n.created_at ASC";
 
+    // After fetching, null out parent_id on rows whose parent isn't
+    // also visible. Otherwise a child leaks the existence of a hidden
+    // ancestor via its parentId field. (Only matters when a non-admin
+    // can see a child but not its parent — possible if the parent is
+    // tagged with a different group than the child or has different
+    // override status.)
     auto resultCb = [callback](const drogon::orm::Result& r) {
+        std::set<int> visibleIds;
+        for (const auto& row : r) visibleIds.insert(row["id"].as<int>());
+
         Json::Value arr(Json::arrayValue);
-        for (const auto& row : r) arr.append(rowToNode(row));
+        for (const auto& row : r) {
+            Json::Value n = rowToNode(row);
+            if (!n["parentId"].isNull()) {
+                int p = n["parentId"].asInt();
+                if (visibleIds.find(p) == visibleIds.end()) {
+                    n["parentId"] = Json::Value();
+                }
+            }
+            arr.append(n);
+        }
         callback(drogon::HttpResponse::newHttpJsonResponse(arr));
     };
     auto errCb = [callback](const drogon::orm::DrogonDbException&) {
@@ -163,13 +234,38 @@ void NodeController::listNodes(
             "db_error", "Failed to fetch nodes"));
     };
 
+    // Param order:
+    //   non-admin: mapId, userId   (CTE)
+    //              userId           (mp.user_id JOIN)
+    //              mapId, tenantId  (WHERE)
+    //              userId           (owner_id check)
+    //              userId           (visibility predicate xray check)
+    //              [parentFilter]   (only when child filter active)
+    //   admin:     userId, mapId, tenantId, userId[, parentFilter]
     auto db = drogon::app().getDbClient();
-    if (hasParentFilter && !topLevelOnly) {
-        db->execSqlAsync(sql, resultCb, errCb,
-            userId, mapId, tenantId, userId, parentFilter);
+    if (isAdmin) {
+        if (hasParentFilter && !topLevelOnly) {
+            db->execSqlAsync(sql, resultCb, errCb,
+                userId, mapId, tenantId, userId, parentFilter);
+        } else {
+            db->execSqlAsync(sql, resultCb, errCb,
+                userId, mapId, tenantId, userId);
+        }
     } else {
-        db->execSqlAsync(sql, resultCb, errCb,
-            userId, mapId, tenantId, userId);
+        if (hasParentFilter && !topLevelOnly) {
+            db->execSqlAsync(sql, resultCb, errCb,
+                mapId, userId,                 // CTE
+                userId,                        // mp join
+                mapId, tenantId, userId,       // WHERE map gating
+                userId,                        // visibility xray
+                parentFilter);
+        } else {
+            db->execSqlAsync(sql, resultCb, errCb,
+                mapId, userId,
+                userId,
+                mapId, tenantId, userId,
+                userId);
+        }
     }
 }
 
@@ -359,8 +455,11 @@ void NodeController::getNode(
     int tenantId, int mapId, int id) {
 
     int userId = callerUserId(req);
-    auto db    = drogon::app().getDbClient();
-    db->execSqlAsync(
+    bool isAdmin = isTenantAdmin(req);
+
+    std::string sql;
+    if (!isAdmin) sql = VISIBILITY_RESOLVE_CTE;
+    sql +=
         "SELECT n.id, n.map_id, n.parent_id, n.name, n.geo_json, n.description, "
         "       n.color, n.visibility_override, n.created_by, "
         "       u.username AS creator_username, "
@@ -372,20 +471,74 @@ void NodeController::getNode(
         "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
         "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
         "WHERE n.id = ? AND n.map_id = ? AND m.tenant_id = ? "
-        "  AND (m.owner_id = ? OR mp.level IN ('view','comment','edit','moderate','admin') OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
-        [callback](const drogon::orm::Result& r) {
-            if (r.empty()) {
-                callback(errorResponse(drogon::k404NotFound,
-                    "not_found", "Node not found or no permission"));
-                return;
-            }
-            callback(drogon::HttpResponse::newHttpJsonResponse(rowToNode(r[0])));
-        },
-        [callback](const drogon::orm::DrogonDbException&) {
-            callback(errorResponse(drogon::k500InternalServerError,
-                "db_error", "Database error"));
-        },
-        userId, id, mapId, tenantId, userId);
+        "  AND (m.owner_id = ? OR mp.level IN ('view','comment','edit','moderate','admin') OR mp_pub.level IN ('view','comment','edit','moderate','admin'))";
+    if (!isAdmin) sql += VISIBILITY_PREDICATE;
+
+    auto onResult = [callback, req, tenantId, mapId, userId, isAdmin]
+        (const drogon::orm::Result& r) {
+        if (r.empty()) {
+            callback(errorResponse(drogon::k404NotFound,
+                "not_found", "Node not found or no permission"));
+            return;
+        }
+        Json::Value n = rowToNode(r[0]);
+
+        // Same hidden-parent rule as listNodes: if the parent isn't
+        // visible to the caller, null out parentId. Admins skip this
+        // check (they see everything).
+        if (isAdmin || n["parentId"].isNull()) {
+            callback(drogon::HttpResponse::newHttpJsonResponse(n));
+            return;
+        }
+        int parentId = n["parentId"].asInt();
+
+        // One-shot existence-via-visibility check on the parent.
+        std::string vSql = VISIBILITY_RESOLVE_CTE +
+            "SELECT 1 FROM nodes n "
+            "JOIN maps m ON m.id = n.map_id "
+            "LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ? "
+            "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
+            "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
+            "WHERE n.id = ? AND n.map_id = ? AND m.tenant_id = ? "
+            "  AND (m.owner_id = ? OR mp.level IN ('view','comment','edit','moderate','admin') OR mp_pub.level IN ('view','comment','edit','moderate','admin'))" +
+            VISIBILITY_PREDICATE;
+        auto db = drogon::app().getDbClient();
+        db->execSqlAsync(vSql,
+            [callback, n](const drogon::orm::Result& rp) mutable {
+                if (rp.empty()) n["parentId"] = Json::Value();
+                callback(drogon::HttpResponse::newHttpJsonResponse(n));
+            },
+            [callback, n](const drogon::orm::DrogonDbException&) mutable {
+                // On DB error checking parent visibility, fail closed:
+                // hide the parent rather than risk leaking it.
+                n["parentId"] = Json::Value();
+                callback(drogon::HttpResponse::newHttpJsonResponse(n));
+            },
+            mapId, userId,            // CTE
+            userId,                   // mp join
+            parentId, mapId, tenantId, userId,  // WHERE
+            userId);                  // xray check
+    };
+
+    auto db = drogon::app().getDbClient();
+    if (isAdmin) {
+        db->execSqlAsync(sql, onResult,
+            [callback](const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Database error"));
+            },
+            userId, id, mapId, tenantId, userId);
+    } else {
+        db->execSqlAsync(sql, onResult,
+            [callback](const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Database error"));
+            },
+            mapId, userId,            // CTE
+            userId,                   // mp join
+            id, mapId, tenantId, userId,  // WHERE
+            userId);                  // xray check
+    }
 }
 
 // ─── PUT /api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{id} ──────────────────

--- a/backend/tests/run-tests.py
+++ b/backend/tests/run-tests.py
@@ -46,6 +46,7 @@ FAST_TESTS = [
     "test_17_media.py",
     "test_18_visibility_groups.py",
     "test_19_node_visibility.py",
+    "test_20_node_visibility_filter.py",
 ]
 
 # test_14_nodes.py landed in #96 (NodeController CRUD + tree + max-depth).
@@ -53,6 +54,8 @@ FAST_TESTS = [
 # test_17_media.py landed in #84 (Media for nodes and notes).
 # test_18_visibility_groups.py landed in #85 (visibility-group CRUD only).
 # test_19_node_visibility.py landed in #86 (node visibility tagging).
+# test_20_node_visibility_filter.py landed in #99 (effective-visibility CTE
+#   + read-time filtering + owner_xray bypass on GET nodes / GET nodes/{id}).
 # Annotation/note-group tests are gone permanently — those concepts were
 # consolidated into nodes and visibility groups during the rebuild.
 
@@ -75,6 +78,7 @@ TEST_DESCRIPTIONS = {
     17: "Media on nodes and notes (CRUD, scheme validation, CASCADE)",
     18: "Visibility groups (admin-only CRUD; member mgmt in #98)",
     19: "Node visibility tagging (set/get override + groupIds on nodes)",
+    20: "Node visibility read filter (admin bypass, inheritance, owner_xray)",
 }
 
 

--- a/backend/tests/test_20_node_visibility_filter.py
+++ b/backend/tests/test_20_node_visibility_filter.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""test_20_node_visibility_filter.py — Phase 2b.ii.b: read-time effective
+visibility filtering on GET nodes / GET nodes/{id}, plus owner_xray bypass.
+
+Setup uses direct SQL for two fixture moves the personal-tenant API can't
+naturally produce:
+  1. Move B's user.org_id into A's org (so cross-org visibility-group
+     membership rejection in #98 doesn't get in the way of the test).
+  2. Insert B into A's tenant_members as 'viewer' (a same-tenant non-admin
+     user — required to exercise the non-admin filter path; admins bypass).
+  3. Reassign maps.owner_id to B, toggling owner_xray, to test the xray
+     bypass.
+
+These bypass the API surface but stay within database invariants; the
+behaviour under test is the read filter itself, not how members are
+provisioned.
+
+Tree built on map M (under tenant A_T):
+
+    Root (override=FALSE, no tags)  → admin-only (root fallback)
+    ├── Pin (override=FALSE, no tags)            → admin-only
+    ├── PlayersOnly (override=TRUE, [Players])   → visible to Players group
+    │   └── PlayersChild (override=FALSE)        → inherits PlayersOnly
+    ├── GmOnly (override=TRUE, [GMs])            → visible to GMs group
+    │   └── GmChild (override=FALSE)             → inherits GmOnly
+    └── GmBranch (override=TRUE, [GMs])          → visible to GMs
+        └── PlayerUnderGm (override=TRUE, [Players])  → visible to Players;
+            (parent GmBranch hidden from B → parentId nulled in response)
+
+A is tenant admin (sees everything).
+B is non-admin, member of Players (sees PlayersOnly, PlayersChild, PlayerUnderGm).
+"""
+
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import (
+    reset_counters, report, assert_status, assert_json_field, assert_true,
+    http_post, http_get, register_user, json_field, mysql_query,
+)
+
+reset_counters()
+RUN_ID = os.getpid()
+
+print("=== Node Visibility Read Filter Tests ===")
+
+# ─── Setup ───────────────────────────────────────────────────────────────────
+
+TOKEN_A = register_user(f"t20_a_{RUN_ID}", f"t20_a_{RUN_ID}@test.com", "testpass123")
+_, body_a = http_post("/auth/login",
+    {"email": f"t20_a_{RUN_ID}@test.com", "password": "testpass123"})
+TENANT_A = json_field(body_a, ["tenantId"])
+USER_A_ID = json_field(body_a, ["user", "id"])
+
+TOKEN_B = register_user(f"t20_b_{RUN_ID}", f"t20_b_{RUN_ID}@test.com", "testpass123")
+_, body_b = http_post("/auth/login",
+    {"email": f"t20_b_{RUN_ID}@test.com", "password": "testpass123"})
+USER_B_ID = json_field(body_b, ["user", "id"])
+
+# Move B into A's org so visibility-group membership is allowed,
+# then insert B into A's tenant as a viewer (non-admin).
+A_ORG_ID = mysql_query(f"SELECT org_id FROM users WHERE id={USER_A_ID};")
+mysql_query(f"UPDATE users SET org_id={A_ORG_ID} WHERE id={USER_B_ID};")
+mysql_query(
+    f"INSERT INTO tenant_members (tenant_id, user_id, role) "
+    f"VALUES ({TENANT_A}, {USER_B_ID}, 'viewer');")
+
+# A creates a map and two visibility groups.
+_, body = http_post(f"/tenants/{TENANT_A}/maps", {
+    "title": "VisFilter Map",
+    "coordinateSystem": {"type": "wgs84", "center": {"lat": 0, "lng": 0}, "zoom": 3},
+}, TOKEN_A)
+MAP_ID = json_field(body, ["id"])
+
+# Grant B view permission on the map. (Tenant membership alone doesn't
+# carry map-level read permission — the existing map gating in NodeController
+# requires owner / per-user / public.) Bypass the API for fixture brevity.
+mysql_query(
+    f"INSERT INTO map_permissions (map_id, user_id, level) "
+    f"VALUES ({MAP_ID}, {USER_B_ID}, 'view');")
+
+VG_BASE = f"/tenants/{TENANT_A}/visibility-groups"
+_, body = http_post(VG_BASE, {"name": "Players"}, TOKEN_A)
+G_PLAYERS = json_field(body, ["id"])
+_, body = http_post(VG_BASE, {"name": "GMs"}, TOKEN_A)
+G_GMS = json_field(body, ["id"])
+
+# A adds B to Players (now allowed — same org).
+_, _ = http_post(f"{VG_BASE}/{G_PLAYERS}/members",
+                 {"userId": USER_B_ID}, TOKEN_A)
+
+# Build the tree.
+NODES_BASE = f"/tenants/{TENANT_A}/maps/{MAP_ID}/nodes"
+
+def mknode(name, parent_id=None):
+    body_in = {"name": name}
+    if parent_id is not None:
+        body_in["parentId"] = parent_id
+    _, b = http_post(NODES_BASE, body_in, TOKEN_A)
+    return json_field(b, ["id"])
+
+def settag(node_id, override, group_ids):
+    http_post(f"{NODES_BASE}/{node_id}/visibility",
+              {"override": override, "groupIds": group_ids}, TOKEN_A)
+
+ROOT          = mknode("Root")
+PIN           = mknode("Pin", ROOT)
+PLAYERS_ONLY  = mknode("PlayersOnly", ROOT);     settag(PLAYERS_ONLY,  True, [G_PLAYERS])
+PLAYERS_CHILD = mknode("PlayersChild", PLAYERS_ONLY)
+GM_ONLY       = mknode("GmOnly", ROOT);          settag(GM_ONLY,       True, [G_GMS])
+GM_CHILD      = mknode("GmChild", GM_ONLY)
+GM_BRANCH     = mknode("GmBranch", ROOT);        settag(GM_BRANCH,     True, [G_GMS])
+PLAYER_UNDER_GM = mknode("PlayerUnderGm", GM_BRANCH)
+settag(PLAYER_UNDER_GM, True, [G_PLAYERS])
+
+ALL_NODES = {ROOT, PIN, PLAYERS_ONLY, PLAYERS_CHILD, GM_ONLY, GM_CHILD,
+             GM_BRANCH, PLAYER_UNDER_GM}
+B_VISIBLE = {PLAYERS_ONLY, PLAYERS_CHILD, PLAYER_UNDER_GM}
+
+# ─── Admin sees everything (bypass) ──────────────────────────────────────────
+
+print("  --- Admin bypass ---")
+
+status, body = http_get(NODES_BASE, TOKEN_A)
+assert_status("admin: list returns 200", 200, status)
+admin_ids = {n["id"] for n in body}
+assert_true("admin: sees every node",
+            admin_ids == ALL_NODES)
+
+for nid in ALL_NODES:
+    status, _ = http_get(f"{NODES_BASE}/{nid}", TOKEN_A)
+    assert_status(f"admin: get node {nid} returns 200", 200, status)
+
+print("  All admin-bypass tests passed.")
+
+# ─── Non-admin filtering (B with Players membership) ─────────────────────────
+
+print("  --- Non-admin filter ---")
+
+status, body = http_get(NODES_BASE, TOKEN_B)
+assert_status("B: list returns 200", 200, status)
+b_ids = {n["id"] for n in body}
+assert_true("B: list contains exactly visible set",
+            b_ids == B_VISIBLE)
+
+# GET visible nodes → 200
+for nid in B_VISIBLE:
+    status, _ = http_get(f"{NODES_BASE}/{nid}", TOKEN_B)
+    assert_status(f"B: get visible node {nid} returns 200", 200, status)
+
+# GET hidden nodes → 404 (don't leak existence)
+for nid in ALL_NODES - B_VISIBLE:
+    status, _ = http_get(f"{NODES_BASE}/{nid}", TOKEN_B)
+    assert_status(f"B: get hidden node {nid} returns 404", 404, status)
+
+# Hidden parent leak check: PlayerUnderGm is visible to B, GmBranch
+# (its parent) is not. The list response must report parentId=null
+# rather than leaking the hidden ancestor's id.
+b_by_id = {n["id"]: n for n in body}
+assert_true("B: visible-child-of-hidden-parent has parentId nulled",
+            b_by_id[PLAYER_UNDER_GM]["parentId"] is None)
+
+# Conversely, when a child's parent IS visible (PlayersChild → PlayersOnly),
+# parentId should still report the parent.
+assert_true("B: visible-child-of-visible-parent keeps parentId",
+            b_by_id[PLAYERS_CHILD]["parentId"] == PLAYERS_ONLY)
+
+# Same null-out behaviour on the single-node GET endpoint.
+status, body_one = http_get(f"{NODES_BASE}/{PLAYER_UNDER_GM}", TOKEN_B)
+assert_status("B: single-get visible-of-hidden returns 200", 200, status)
+assert_true("B: single-get parentId nulled when parent hidden",
+            body_one["parentId"] is None)
+
+print("  All non-admin-filter tests passed.")
+
+# ─── parentId child-filter still works on filtered results ───────────────────
+
+print("  --- parentId query param ---")
+
+# B asking for direct children of PlayersOnly should see PlayersChild only.
+status, body = http_get(f"{NODES_BASE}?parentId={PLAYERS_ONLY}", TOKEN_B)
+assert_status("B: parentId filter returns 200", 200, status)
+ids = {n["id"] for n in body}
+assert_true("B: children of PlayersOnly = {PlayersChild}",
+            ids == {PLAYERS_CHILD})
+
+# B asking for children of GmOnly (which B can't see) should get an empty
+# list — and certainly not GmChild.
+status, body = http_get(f"{NODES_BASE}?parentId={GM_ONLY}", TOKEN_B)
+assert_status("B: parentId filter on hidden parent returns 200", 200, status)
+assert_true("B: children of hidden parent are filtered out",
+            len(body) == 0)
+
+print("  All parentId-filter tests passed.")
+
+# ─── owner_xray bypass ───────────────────────────────────────────────────────
+# Reassign map owner to B, and toggle xray. xray=TRUE → B sees everything;
+# xray=FALSE → B is bound by visibility (back to the Players-only set).
+
+print("  --- owner_xray ---")
+
+mysql_query(
+    f"UPDATE maps SET owner_id={USER_B_ID}, owner_xray=TRUE WHERE id={MAP_ID};")
+
+status, body = http_get(NODES_BASE, TOKEN_B)
+b_ids_xray = {n["id"] for n in body}
+assert_true("xray=TRUE owner: sees every node",
+            b_ids_xray == ALL_NODES)
+status, _ = http_get(f"{NODES_BASE}/{ROOT}", TOKEN_B)
+assert_status("xray=TRUE owner: get hidden-by-default node returns 200",
+              200, status)
+
+mysql_query(f"UPDATE maps SET owner_xray=FALSE WHERE id={MAP_ID};")
+
+status, body = http_get(NODES_BASE, TOKEN_B)
+b_ids_no_xray = {n["id"] for n in body}
+assert_true("xray=FALSE owner: bound by visibility filter",
+            b_ids_no_xray == B_VISIBLE)
+status, _ = http_get(f"{NODES_BASE}/{ROOT}", TOKEN_B)
+assert_status("xray=FALSE owner: get admin-only node still 404",
+              404, status)
+
+print("  All owner_xray tests passed.")
+
+# ─── Override-with-empty-junction = admin-only ───────────────────────────────
+# A node with override=TRUE but no visibility_group tags = explicit
+# admin-only. Verify B can't see it but admin can.
+
+print("  --- empty-junction admin-only ---")
+
+mysql_query(f"UPDATE maps SET owner_id={USER_A_ID} WHERE id={MAP_ID};")
+EXPLICIT_LOCK = mknode("ExplicitLock", ROOT)
+settag(EXPLICIT_LOCK, True, [])  # override TRUE, empty tag set
+
+status, _ = http_get(f"{NODES_BASE}/{EXPLICIT_LOCK}", TOKEN_A)
+assert_status("explicit-lock: admin sees it", 200, status)
+status, _ = http_get(f"{NODES_BASE}/{EXPLICIT_LOCK}", TOKEN_B)
+assert_status("explicit-lock: non-admin gets 404", 404, status)
+
+print("  All empty-junction tests passed.")
+
+sys.exit(0 if report() else 1)


### PR DESCRIPTION
Closes #99 (will close manually after merge — auto-close skips non-default-branch PRs).

## Summary

Wires up the **read-time filtering** half of node visibility — the architecturally interesting part split out of the original #86 design. A recursive CTE resolves each node's "effective" visibility set by walking up `parent_id` to the nearest ancestor (or self) with `visibility_override = TRUE`, and the result is applied as a `WHERE` predicate on `GET .../nodes` and `GET .../nodes/{id}`.

## Effective-visibility resolution

For each node:
1. If `visibility_override = TRUE` → effective set = its `node_visibility` rows (possibly empty = admin-only).
2. Else walk up `parent_id` to the first ancestor with override = TRUE; use **its** rows.
3. If no ancestor has override = TRUE (root reached) → empty set (admin-only).

A user can see a node if any of:
- They're a tenant admin (filter bypassed entirely).
- They're a member of any visibility group in the effective set.
- They're the map owner **and** `maps.owner_xray = TRUE`.

## SQL shape

Two-part CTE bound to `MAX_NODE_DEPTH` so a malicious deep chain can't stall the query:

```sql
WITH RECURSIVE resolve AS (
  SELECT n.id AS start_id, n.id AS cur_id, n.parent_id,
         n.visibility_override, 0 AS depth
  FROM nodes n WHERE n.map_id = ?
  UNION ALL
  SELECT r.start_id, p.id, p.parent_id, p.visibility_override, r.depth + 1
  FROM resolve r JOIN nodes p ON p.id = r.parent_id
  WHERE r.visibility_override = FALSE AND r.depth < 15
), visible_starts AS (
  SELECT DISTINCT r.start_id FROM resolve r
  JOIN node_visibility nv
       ON nv.node_id = r.cur_id AND r.visibility_override = TRUE
  JOIN visibility_group_members vgm
       ON vgm.visibility_group_id = nv.visibility_group_id
  WHERE vgm.user_id = ?
)
SELECT n.* FROM nodes n
JOIN maps m ON m.id = n.map_id
... [existing map view gating] ...
AND ((m.owner_id = ? AND m.owner_xray = TRUE)
     OR n.id IN (SELECT start_id FROM visible_starts))
```

For tenant admins the CTE is skipped entirely — they fall through to the existing map-gated query, no perf cost.

## Behaviour worth flagging

- **Non-xray map owners are still bound by visibility.** A GM who owns the map only sees nodes tagged for them unless they explicitly enable `owner_xray`. This matches the design intent in #99 — owner_xray is the opt-in escape hatch.
- **Hidden ancestors don't leak via `parentId`.** When a child is visible but its parent isn't, the response body's `parentId` is nulled out. Applies to both list and single-get endpoints. Implemented in C++ over the result rows for the list path (cheap set lookup); the single-get does one extra visibility-filtered query against the parent id.
- **Empty effective set = admin-only.** A node with `override = TRUE` and no `node_visibility` rows is explicitly locked to admins (and xray owners). Deliberately distinct from "no override anywhere up the chain" which falls back to the same admin-only state — both routes converge on the same outcome.
- **Hidden node GET returns 404, not 403.** Don't leak existence to non-members.

## Files changed

- **backend/src/controllers/NodeController.cpp** — Two new SQL constants in the anonymous namespace (`VISIBILITY_RESOLVE_CTE`, `VISIBILITY_PREDICATE`); `listNodes` and `getNode` rewritten to branch on `isTenantAdmin(req)` (skip CTE for admins) and to null out hidden parent_ids in the response builder.
- **backend/tests/test_20_node_visibility_filter.py** — New 34-assertion suite covering admin bypass, the inheritance walk (root fallback, override mid-chain, override-with-empty-junction), member-based visibility, `parentId` nulling on both endpoints, the `parentId` query-param filter against hidden parents, and the owner_xray TRUE/FALSE bypass. Uses two direct SQL fixtures (move B's `org_id` into A's org so visibility-group membership is allowed; insert B as a `viewer` `tenant_member`) — no API path produces a same-org non-admin user from personal tenants alone, and these are the documented fixture moves.
- **backend/tests/run-tests.py** — Adds `test_20_node_visibility_filter.py` to `FAST_TESTS`; description.

## Test plan

- [x] `python3 backend/tests/test_20_node_visibility_filter.py` — 34 passed, 0 failed
- [x] `python3 backend/tests/run-tests.py --tier fast` — all 14 suites pass; existing `test_14_nodes.py` and `test_19_node_visibility.py` unchanged.
- [ ] CI green on PR (E2E expected red — see below)

## Test expectations (CI on `nodes-rebuild`)

| Job | Expected | Why |
|---|---|---|
| `lint` | ✅ pass | No frontend changes. |
| `security` | ✅ pass | No new dependencies. |
| `compile` | ✅ pass | New CTE constants + handler rewrites compile cleanly. |
| `integration` (db tests) | ✅ pass | Schema unchanged; 179/179. |
| `integration` (backend tests) | ✅ pass | 14/14 suites pass locally including new `test_20_node_visibility_filter.py`. |
| `integration` (E2E) | ❌ **expected fail** | Annotations / cross-tenant E2E specs reference the old annotations frontend that was ripped out for the rebuild. Frontend rebuild lands in the #94 series. |

`integration` will report red overall because of the E2E sub-step. Mid-rebuild informational state — `main` remains the enforced gate.

## Out of scope

- Note visibility (`#87` — same pattern, separate ticket).
- Frontend UI (#94 series).

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)