### PR TITLE
Phase 2b.iii: Note visibility tagging + filtering (#87)

### DIFF
--- a/backend/src/controllers/NoteController.cpp
+++ b/backend/src/controllers/NoteController.cpp
@@ -1,12 +1,22 @@
 #include "NoteController.h"
 #include "AuditLog.h"
 #include "ErrorResponse.h"
+#include "NodeController.h"  // MAX_NODE_DEPTH for the resolve CTE
+#include "VisibilityAuth.h"
 #include <drogon/drogon.h>
+#include <set>
 
 // Phase 2a.ii: Notes attach to nodes via the URL path. List/create
 // nest under /maps/{mapId}/nodes/{nodeId}/notes; get/put/delete sit
 // under /maps/{mapId}/notes/{id} since the note id alone identifies
-// it within the map. Visibility filtering arrives in Phase 2b.iii.
+// it within the map.
+//
+// Phase 2b.iii (#87) adds visibility tagging + read filtering. The
+// effective-visibility CTE is structurally similar to the node one in
+// #99 (NodeController.cpp): walk up `parent_id` to the first override
+// = TRUE ancestor. The note version adds an extra hop at the bottom —
+// from the note to its attached node — and short-circuits when the
+// note itself has override = TRUE.
 
 static int callerUserId(const drogon::HttpRequestPtr& req) {
     try { return req->getAttributes()->get<int>("userId"); }
@@ -14,6 +24,59 @@ static int callerUserId(const drogon::HttpRequestPtr& req) {
 }
 
 namespace {
+
+// ─── Effective-visibility CTE for notes (#87) ────────────────────────────────
+// `node_resolve` and `node_visible_starts` are structurally identical to
+// the node version in NodeController.cpp (#99). `note_visible` then
+// produces the set of note ids visible to the caller, computed as:
+//   - note.override = TRUE: visible if user is in any tagged group on
+//     note_visibility for that note.
+//   - note.override = FALSE: visible if the attached node is in
+//     node_visible_starts (i.e., visible-by-inheritance via the node
+//     parent chain).
+//
+// Bound the recursion against MAX_NODE_DEPTH so a malicious deep chain
+// can't stall the query.
+//
+// CTE prefix binds 4 parameters (in order):
+//   (mapId, userId, mapId, userId)
+// — mapId+userId for the node CTE pair, then mapId+userId for note_visible.
+
+const std::string NOTE_VISIBILITY_CTE =
+    "WITH RECURSIVE node_resolve AS ("
+    "  SELECT nd.id AS start_id, nd.id AS cur_id, nd.parent_id, "
+    "         nd.visibility_override, 0 AS depth "
+    "  FROM nodes nd WHERE nd.map_id = ? "
+    "  UNION ALL "
+    "  SELECT r.start_id, p.id, p.parent_id, p.visibility_override, r.depth + 1 "
+    "  FROM node_resolve r JOIN nodes p ON p.id = r.parent_id "
+    "  WHERE r.visibility_override = FALSE AND r.depth < " +
+        std::to_string(MAX_NODE_DEPTH) +
+    "), node_visible_starts AS ( "
+    "  SELECT DISTINCT r.start_id FROM node_resolve r "
+    "  JOIN node_visibility nv "
+    "       ON nv.node_id = r.cur_id AND r.visibility_override = TRUE "
+    "  JOIN visibility_group_members vgm "
+    "       ON vgm.visibility_group_id = nv.visibility_group_id "
+    "  WHERE vgm.user_id = ? "
+    "), note_visible AS ( "
+    "  SELECT n.id AS visible_note_id FROM notes n "
+    "  JOIN nodes nd ON nd.id = n.node_id AND nd.map_id = ? "
+    "  WHERE (n.visibility_override = TRUE "
+    "         AND EXISTS (SELECT 1 FROM note_visibility nv2 "
+    "                     JOIN visibility_group_members vgm2 "
+    "                          ON vgm2.visibility_group_id = nv2.visibility_group_id "
+    "                     WHERE nv2.note_id = n.id AND vgm2.user_id = ?)) "
+    "     OR (n.visibility_override = FALSE "
+    "         AND n.node_id IN (SELECT start_id FROM node_visible_starts)) "
+    ") ";
+
+// Predicate to AND into a notes WHERE clause. Aliases assumed:
+//   m → maps, n → notes (the row being filtered).
+// Binds 1 parameter: (userId) for the owner_xray check.
+const std::string NOTE_VISIBILITY_PREDICATE =
+    " AND ((m.owner_id = ? AND m.owner_xray = TRUE) "
+    "      OR n.id IN (SELECT visible_note_id FROM note_visible)) ";
 
 // Build a JSON note from a result row. Shape is consistent across all
 // read endpoints.
@@ -46,38 +109,56 @@ void NoteController::listNotes(
     int tenantId, int mapId, int nodeId) {
 
     int userId = callerUserId(req);
+    bool isAdmin = isTenantAdmin(req);
 
-    const std::string sql = R"(
-        SELECT n.id, n.node_id, nd.map_id, n.created_by, u.username AS creator_username,
-               n.title, n.text, n.pinned, n.color, n.visibility_override,
-               n.created_at, n.updated_at,
-               CASE WHEN m.owner_id = ? OR n.created_by = ? OR mp.level IN ('edit','moderate','admin')
-                    THEN 1 ELSE 0 END AS can_edit
-        FROM notes n
-        JOIN nodes nd ON nd.id = n.node_id
-        JOIN maps m   ON m.id  = nd.map_id
-        JOIN users u  ON u.id  = n.created_by
-        LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ?
-        LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL
-                                        AND mp_pub.level IN ('view','comment','edit','moderate','admin')
-        WHERE n.node_id = ? AND nd.map_id = ? AND m.tenant_id = ?
-          AND (m.owner_id = ? OR mp.level IN ('view','comment','edit','moderate','admin') OR mp_pub.level IN ('view','comment','edit','moderate','admin'))
-        ORDER BY n.pinned DESC, n.created_at ASC
-    )";
+    // Tenant admins bypass the visibility filter; non-admins get the
+    // CTE prefix and the effective-visibility predicate. Order-of-bind
+    // notes preserved inline below.
+    std::string sql;
+    if (!isAdmin) sql = NOTE_VISIBILITY_CTE;
+    sql +=
+        "SELECT n.id, n.node_id, nd.map_id, n.created_by, u.username AS creator_username, "
+        "       n.title, n.text, n.pinned, n.color, n.visibility_override, "
+        "       n.created_at, n.updated_at, "
+        "       CASE WHEN m.owner_id = ? OR n.created_by = ? OR mp.level IN ('edit','moderate','admin') "
+        "            THEN 1 ELSE 0 END AS can_edit "
+        "FROM notes n "
+        "JOIN nodes nd ON nd.id = n.node_id "
+        "JOIN maps m   ON m.id  = nd.map_id "
+        "JOIN users u  ON u.id  = n.created_by "
+        "LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ? "
+        "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
+        "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
+        "WHERE n.node_id = ? AND nd.map_id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? OR mp.level IN ('view','comment','edit','moderate','admin') OR mp_pub.level IN ('view','comment','edit','moderate','admin'))";
+    if (!isAdmin) sql += NOTE_VISIBILITY_PREDICATE;
+    sql += " ORDER BY n.pinned DESC, n.created_at ASC";
 
     auto db = drogon::app().getDbClient();
-    db->execSqlAsync(
-        sql,
-        [callback](const drogon::orm::Result& r) {
-            Json::Value arr(Json::arrayValue);
-            for (const auto& row : r) arr.append(rowToNote(row));
-            callback(drogon::HttpResponse::newHttpJsonResponse(arr));
-        },
-        [callback](const drogon::orm::DrogonDbException&) {
-            callback(errorResponse(drogon::k500InternalServerError,
-                "db_error", "Failed to fetch notes"));
-        },
-        userId, userId, userId, nodeId, mapId, tenantId, userId);
+    auto resultCb = [callback](const drogon::orm::Result& r) {
+        Json::Value arr(Json::arrayValue);
+        for (const auto& row : r) arr.append(rowToNote(row));
+        callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+    };
+    auto errCb = [callback](const drogon::orm::DrogonDbException&) {
+        callback(errorResponse(drogon::k500InternalServerError,
+            "db_error", "Failed to fetch notes"));
+    };
+
+    if (isAdmin) {
+        // Existing param order preserved.
+        db->execSqlAsync(sql, resultCb, errCb,
+            userId, userId, userId, nodeId, mapId, tenantId, userId);
+    } else {
+        // CTE binds (mapId, userId, mapId, userId), then the SELECT
+        // binds the same params as the admin path, then the predicate
+        // binds (userId) for the xray check.
+        db->execSqlAsync(sql, resultCb, errCb,
+            mapId, userId, mapId, userId,           // CTE
+            userId, userId, userId,                  // can_edit + mp join
+            nodeId, mapId, tenantId, userId,         // WHERE map gating
+            userId);                                 // visibility xray
+    }
 }
 
 // ─── POST /api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{nodeId}/notes ───────
@@ -180,8 +261,11 @@ void NoteController::getNote(
     int tenantId, int mapId, int id) {
 
     int userId = callerUserId(req);
-    auto db    = drogon::app().getDbClient();
-    db->execSqlAsync(
+    bool isAdmin = isTenantAdmin(req);
+
+    std::string sql;
+    if (!isAdmin) sql = NOTE_VISIBILITY_CTE;
+    sql +=
         "SELECT n.id, n.node_id, nd.map_id, n.created_by, u.username AS creator_username, "
         "       n.title, n.text, n.pinned, n.color, n.visibility_override, "
         "       n.created_at, n.updated_at, "
@@ -195,20 +279,33 @@ void NoteController::getNote(
         "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
         "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
         "WHERE n.id = ? AND nd.map_id = ? AND m.tenant_id = ? "
-        "  AND (m.owner_id = ? OR mp.level IN ('view','comment','edit','moderate','admin') OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
-        [callback](const drogon::orm::Result& r) {
-            if (r.empty()) {
-                callback(errorResponse(drogon::k404NotFound,
-                    "not_found", "Note not found or no permission"));
-                return;
-            }
-            callback(drogon::HttpResponse::newHttpJsonResponse(rowToNote(r[0])));
-        },
-        [callback](const drogon::orm::DrogonDbException&) {
-            callback(errorResponse(drogon::k500InternalServerError,
-                "db_error", "Database error"));
-        },
-        userId, userId, userId, id, mapId, tenantId, userId);
+        "  AND (m.owner_id = ? OR mp.level IN ('view','comment','edit','moderate','admin') OR mp_pub.level IN ('view','comment','edit','moderate','admin'))";
+    if (!isAdmin) sql += NOTE_VISIBILITY_PREDICATE;
+
+    auto resultCb = [callback](const drogon::orm::Result& r) {
+        if (r.empty()) {
+            callback(errorResponse(drogon::k404NotFound,
+                "not_found", "Note not found or no permission"));
+            return;
+        }
+        callback(drogon::HttpResponse::newHttpJsonResponse(rowToNote(r[0])));
+    };
+    auto errCb = [callback](const drogon::orm::DrogonDbException&) {
+        callback(errorResponse(drogon::k500InternalServerError,
+            "db_error", "Database error"));
+    };
+
+    auto db = drogon::app().getDbClient();
+    if (isAdmin) {
+        db->execSqlAsync(sql, resultCb, errCb,
+            userId, userId, userId, id, mapId, tenantId, userId);
+    } else {
+        db->execSqlAsync(sql, resultCb, errCb,
+            mapId, userId, mapId, userId,           // CTE
+            userId, userId, userId,                  // can_edit + mp join
+            id, mapId, tenantId, userId,             // WHERE
+            userId);                                 // xray
+    }
 }
 
 // ─── PUT /api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id} ──────────────────
@@ -309,4 +406,223 @@ void NoteController::deleteNote(
                 "db_error", "Failed to delete note"));
         },
         userId, id, mapId, tenantId, userId, userId);
+}
+
+// ─── GET /api/v1/tenants/{tid}/maps/{mid}/notes/{id}/visibility ──────────────
+//
+// Raw stored state (no inheritance). Mirror of NodeController::getVisibility:
+// the caller doesn't need read-side visibility on the note itself — managers
+// need to be able to inspect tagging metadata before editing it. Tenant
+// scoping (note must live under a node on a map in this tenant) is the
+// only existence check.
+
+void NoteController::getVisibility(
+    const drogon::HttpRequestPtr& /*req*/,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int id) {
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT n.visibility_override, nv.visibility_group_id "
+        "FROM notes n "
+        "JOIN nodes nd ON nd.id = n.node_id "
+        "JOIN maps m ON m.id = nd.map_id "
+        "LEFT JOIN note_visibility nv ON nv.note_id = n.id "
+        "WHERE n.id = ? AND nd.map_id = ? AND m.tenant_id = ?",
+        [callback, id](const drogon::orm::Result& r) {
+            if (r.empty()) {
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "Note not found"));
+                return;
+            }
+            Json::Value out;
+            out["noteId"]   = id;
+            out["override"] = r[0]["visibility_override"].as<bool>();
+            Json::Value ids(Json::arrayValue);
+            for (const auto& row : r) {
+                if (!row["visibility_group_id"].isNull()) {
+                    ids.append(row["visibility_group_id"].as<int>());
+                }
+            }
+            out["groupIds"] = ids;
+            callback(drogon::HttpResponse::newHttpJsonResponse(out));
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to fetch note visibility"));
+        },
+        id, mapId, tenantId);
+}
+
+// ─── POST /api/v1/tenants/{tid}/maps/{mid}/notes/{id}/visibility ─────────────
+//
+// Body: { override?: bool, groupIds?: number[] }   — same shape as #86 nodes.
+// Auth: requireVisibilityGroupManager (admin OR manages_visibility group
+// member). Validates that all groupIds belong to this tenant; verifies the
+// note lives on this map+tenant.
+
+void NoteController::setVisibility(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int id) {
+
+    int userId = callerUserId(req);
+
+    auto body = req->getJsonObject();
+    if (!body) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "JSON body required"));
+        return;
+    }
+
+    bool hasOverride = body->isMember("override") && (*body)["override"].isBool();
+    bool overrideVal = hasOverride ? (*body)["override"].asBool() : false;
+
+    bool hasGroupIds = body->isMember("groupIds");
+    std::set<int> groupIds;
+    if (hasGroupIds) {
+        const Json::Value& g = (*body)["groupIds"];
+        if (!g.isArray()) {
+            callback(errorResponse(drogon::k400BadRequest,
+                "bad_request", "groupIds must be an array of integers"));
+            return;
+        }
+        for (const auto& v : g) {
+            if (!v.isInt()) {
+                callback(errorResponse(drogon::k400BadRequest,
+                    "bad_request", "groupIds must contain only integers"));
+                return;
+            }
+            groupIds.insert(v.asInt());
+        }
+    }
+
+    if (!hasOverride && !hasGroupIds) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "Body must include override or groupIds"));
+        return;
+    }
+
+    // Same int-set → "1,2,3" join trick used in #86 NodeController. Safe
+    // because the values came from Json::Value::asInt() — bounded ints,
+    // no string content, no SQL injection vector.
+    auto joinIds = [](const std::set<int>& s) {
+        std::string out;
+        bool first = true;
+        for (int v : s) {
+            if (!first) out += ",";
+            out += std::to_string(v);
+            first = false;
+        }
+        return out;
+    };
+
+    requireVisibilityGroupManager(req, tenantId, userId, callback,
+        [callback, req, tenantId, mapId, id, userId,
+         hasOverride, overrideVal, hasGroupIds, groupIds, joinIds]() {
+
+        auto finish = [callback, req, tenantId, mapId, id, userId]() {
+            Json::Value detail;
+            detail["mapId"]  = mapId;
+            detail["noteId"] = id;
+            AuditLog::record("note_visibility_set", req,
+                userId, 0, tenantId, detail);
+            auto resp = drogon::HttpResponse::newHttpResponse();
+            resp->setStatusCode(drogon::k204NoContent);
+            callback(resp);
+        };
+
+        // Step 4: replace tag set if groupIds present.
+        auto applyTags = [callback, id, hasGroupIds, groupIds, finish]() {
+            if (!hasGroupIds) { finish(); return; }
+            auto dbT = drogon::app().getDbClient();
+            dbT->execSqlAsync(
+                "DELETE FROM note_visibility WHERE note_id = ?",
+                [callback, id, groupIds, finish](const drogon::orm::Result&) {
+                    if (groupIds.empty()) { finish(); return; }
+                    std::string vals;
+                    bool first = true;
+                    for (int g : groupIds) {
+                        if (!first) vals += ",";
+                        vals += "(" + std::to_string(id) + "," + std::to_string(g) + ")";
+                        first = false;
+                    }
+                    auto dbI = drogon::app().getDbClient();
+                    dbI->execSqlAsync(
+                        "INSERT INTO note_visibility "
+                        "  (note_id, visibility_group_id) VALUES " + vals,
+                        [finish](const drogon::orm::Result&) { finish(); },
+                        [callback](const drogon::orm::DrogonDbException&) {
+                            callback(errorResponse(drogon::k500InternalServerError,
+                                "db_error", "Failed to insert tags"));
+                        });
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to clear existing tags"));
+                },
+                id);
+        };
+
+        // Step 3: optionally update note.visibility_override.
+        auto applyOverrideThenTags =
+            [callback, id, hasOverride, overrideVal, applyTags]() {
+            if (!hasOverride) { applyTags(); return; }
+            auto dbO = drogon::app().getDbClient();
+            dbO->execSqlAsync(
+                "UPDATE notes SET visibility_override = ? WHERE id = ?",
+                [applyTags](const drogon::orm::Result&) { applyTags(); },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to set override"));
+                },
+                overrideVal, id);
+        };
+
+        // Step 2: verify the note exists on this map+tenant.
+        auto dbN = drogon::app().getDbClient();
+        dbN->execSqlAsync(
+            "SELECT n.id FROM notes n "
+            "JOIN nodes nd ON nd.id = n.node_id "
+            "JOIN maps m ON m.id = nd.map_id "
+            "WHERE n.id = ? AND nd.map_id = ? AND m.tenant_id = ?",
+            [callback, tenantId, hasGroupIds, groupIds, joinIds,
+             applyOverrideThenTags](const drogon::orm::Result& r1) {
+                if (r1.empty()) {
+                    callback(errorResponse(drogon::k404NotFound,
+                        "not_found", "Note not found"));
+                    return;
+                }
+                if (!hasGroupIds || groupIds.empty()) {
+                    applyOverrideThenTags();
+                    return;
+                }
+                std::string sql =
+                    "SELECT COUNT(*) AS c FROM visibility_groups "
+                    "WHERE tenant_id = ? AND id IN (" + joinIds(groupIds) + ")";
+                auto dbV = drogon::app().getDbClient();
+                dbV->execSqlAsync(sql,
+                    [callback, groupIds, applyOverrideThenTags]
+                    (const drogon::orm::Result& r2) {
+                        int count = r2[0]["c"].as<int>();
+                        if (count != static_cast<int>(groupIds.size())) {
+                            callback(errorResponse(drogon::k400BadRequest,
+                                "bad_request",
+                                "One or more groupIds are invalid for this tenant"));
+                            return;
+                        }
+                        applyOverrideThenTags();
+                    },
+                    [callback](const drogon::orm::DrogonDbException&) {
+                        callback(errorResponse(drogon::k500InternalServerError,
+                            "db_error", "Failed to validate group ids"));
+                    },
+                    tenantId);
+            },
+            [callback](const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Failed to verify note"));
+            },
+            id, mapId, tenantId);
+    });
 }

--- a/backend/src/controllers/NoteController.h
+++ b/backend/src/controllers/NoteController.h
@@ -15,9 +15,27 @@
  * PUT    /api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}
  * DELETE /api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}
  *
- * Visibility filtering arrives in Phase 2b.iii (#87). For now, standard
- * map view-access gates list/get; map edit-access (or note creator)
- * gates update/delete.
+ * GET    /api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}/visibility
+ * POST   /api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}/visibility
+ *
+ * Phase 2b.iii (#87) wires up visibility tagging + read-time filtering
+ * for notes. Effective visibility for a note:
+ *   1. If note.visibility_override = TRUE → use note_visibility rows.
+ *   2. Else walk to the attached node and recurse up the node parent
+ *      chain (same as #99) to its first override = TRUE ancestor; use
+ *      that node's node_visibility rows.
+ *   3. If no override anywhere up the chain → admin-only (empty set).
+ *
+ * Tenant admins bypass the filter; map owners with owner_xray = TRUE
+ * see every note. Hidden notes return 404 (don't leak existence).
+ *
+ * POST /visibility body shape (same as nodes in #86):
+ *   { override?: bool, groupIds?: number[] }
+ *   - groupIds OMITTED → leave existing tags untouched.
+ *   - groupIds PRESENT (even []) → replace the entire tag set.
+ *   - All groupIds must belong to {tenantId}.
+ *   - Tags are kept regardless of override flag (lean: keep them so
+ *     they can re-activate when override is flipped back on).
  */
 class NoteController : public drogon::HttpController<NoteController> {
 public:
@@ -37,6 +55,12 @@ public:
         ADD_METHOD_TO(NoteController::deleteNote,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}",
                       drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(NoteController::getVisibility,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}/visibility",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+        ADD_METHOD_TO(NoteController::setVisibility,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/notes/{id}/visibility",
+                      drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
     METHOD_LIST_END
 
     void listNotes(const drogon::HttpRequestPtr&,
@@ -54,4 +78,10 @@ public:
     void deleteNote(const drogon::HttpRequestPtr&,
                     std::function<void(const drogon::HttpResponsePtr&)>&&,
                     int tenantId, int mapId, int id);
+    void getVisibility(const drogon::HttpRequestPtr&,
+                       std::function<void(const drogon::HttpResponsePtr&)>&&,
+                       int tenantId, int mapId, int id);
+    void setVisibility(const drogon::HttpRequestPtr&,
+                       std::function<void(const drogon::HttpResponsePtr&)>&&,
+                       int tenantId, int mapId, int id);
 };

--- a/backend/tests/run-tests.py
+++ b/backend/tests/run-tests.py
@@ -47,6 +47,7 @@ FAST_TESTS = [
     "test_18_visibility_groups.py",
     "test_19_node_visibility.py",
     "test_20_node_visibility_filter.py",
+    "test_21_note_visibility.py",
 ]
 
 # test_14_nodes.py landed in #96 (NodeController CRUD + tree + max-depth).
@@ -56,6 +57,8 @@ FAST_TESTS = [
 # test_19_node_visibility.py landed in #86 (node visibility tagging).
 # test_20_node_visibility_filter.py landed in #99 (effective-visibility CTE
 #   + read-time filtering + owner_xray bypass on GET nodes / GET nodes/{id}).
+# test_21_note_visibility.py landed in #87 (note tagging + filtering;
+#   note → node → parent-chain inheritance).
 # Annotation/note-group tests are gone permanently — those concepts were
 # consolidated into nodes and visibility groups during the rebuild.
 
@@ -79,6 +82,7 @@ TEST_DESCRIPTIONS = {
     18: "Visibility groups (admin-only CRUD; member mgmt in #98)",
     19: "Node visibility tagging (set/get override + groupIds on nodes)",
     20: "Node visibility read filter (admin bypass, inheritance, owner_xray)",
+    21: "Note visibility (tagging + filter; note → node → parent-chain)",
 }
 
 

--- a/backend/tests/test_21_note_visibility.py
+++ b/backend/tests/test_21_note_visibility.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""test_21_note_visibility.py — Phase 2b.iii: Note visibility tagging +
+read-time filtering (note → node → parent chain inheritance).
+
+Two halves:
+  1. Tagging endpoints (mirror of #86 tests for nodes).
+  2. Effective-visibility filter on listNotes + getNote, including
+     admin bypass, owner_xray, and the cross-table (note → node → up
+     parent chain) inheritance walk.
+
+Same SQL fixtures as test_20: B becomes a same-org `viewer` member of
+A's tenant + has explicit map view permission.
+"""
+
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import (
+    reset_counters, report, assert_status, assert_json_field, assert_true,
+    http_post, http_get, http_delete,
+    register_user, json_field, mysql_query,
+)
+
+reset_counters()
+RUN_ID = os.getpid()
+
+print("=== Note Visibility Tests ===")
+
+# ─── Setup ───────────────────────────────────────────────────────────────────
+
+TOKEN_A = register_user(f"t21_a_{RUN_ID}", f"t21_a_{RUN_ID}@test.com", "testpass123")
+_, body_a = http_post("/auth/login",
+    {"email": f"t21_a_{RUN_ID}@test.com", "password": "testpass123"})
+TENANT_A   = json_field(body_a, ["tenantId"])
+USER_A_ID  = json_field(body_a, ["user", "id"])
+
+TOKEN_B = register_user(f"t21_b_{RUN_ID}", f"t21_b_{RUN_ID}@test.com", "testpass123")
+_, body_b = http_post("/auth/login",
+    {"email": f"t21_b_{RUN_ID}@test.com", "password": "testpass123"})
+TENANT_B  = json_field(body_b, ["tenantId"])
+USER_B_ID = json_field(body_b, ["user", "id"])
+
+# Move B into A's org + insert as viewer (same fixture as test_20).
+A_ORG_ID = mysql_query(f"SELECT org_id FROM users WHERE id={USER_A_ID};")
+mysql_query(f"UPDATE users SET org_id={A_ORG_ID} WHERE id={USER_B_ID};")
+mysql_query(
+    f"INSERT INTO tenant_members (tenant_id, user_id, role) "
+    f"VALUES ({TENANT_A}, {USER_B_ID}, 'viewer');")
+
+_, body = http_post(f"/tenants/{TENANT_A}/maps", {
+    "title": "Note Vis Map",
+    "coordinateSystem": {"type": "wgs84", "center": {"lat": 0, "lng": 0}, "zoom": 3},
+}, TOKEN_A)
+MAP_ID = json_field(body, ["id"])
+
+mysql_query(
+    f"INSERT INTO map_permissions (map_id, user_id, level) "
+    f"VALUES ({MAP_ID}, {USER_B_ID}, 'view');")
+
+VG_BASE = f"/tenants/{TENANT_A}/visibility-groups"
+_, body = http_post(VG_BASE, {"name": "Players"}, TOKEN_A)
+G_PLAYERS = json_field(body, ["id"])
+_, body = http_post(VG_BASE, {"name": "GMs"}, TOKEN_A)
+G_GMS = json_field(body, ["id"])
+http_post(f"{VG_BASE}/{G_PLAYERS}/members", {"userId": USER_B_ID}, TOKEN_A)
+
+# Build the node tree:
+#   Root (no override)
+#   ├── Pin (no override)
+#   ├── PlayersBranch (override=TRUE, [Players])
+#   └── GmBranch (override=TRUE, [GMs])
+#       └── DeepChild (no override)            ← inherits GMs
+NODES_BASE = f"/tenants/{TENANT_A}/maps/{MAP_ID}/nodes"
+
+def mknode(name, parent_id=None):
+    body_in = {"name": name}
+    if parent_id is not None:
+        body_in["parentId"] = parent_id
+    _, b = http_post(NODES_BASE, body_in, TOKEN_A)
+    return json_field(b, ["id"])
+
+def settag_node(node_id, override, group_ids):
+    http_post(f"{NODES_BASE}/{node_id}/visibility",
+              {"override": override, "groupIds": group_ids}, TOKEN_A)
+
+ROOT            = mknode("Root")
+PIN             = mknode("Pin", ROOT)
+PLAYERS_BRANCH  = mknode("PlayersBranch", ROOT); settag_node(PLAYERS_BRANCH, True, [G_PLAYERS])
+GM_BRANCH       = mknode("GmBranch", ROOT);      settag_node(GM_BRANCH,      True, [G_GMS])
+DEEP_CHILD      = mknode("DeepChild", GM_BRANCH)
+
+def mknote(node_id, title, text="text"):
+    _, b = http_post(f"{NODES_BASE}/{node_id}/notes",
+                     {"title": title, "text": text}, TOKEN_A)
+    return json_field(b, ["id"])
+
+# Notes attached to various nodes, with various override states:
+NOTE_PIN_INHERIT  = mknote(PIN,            "InheritFromPin")          # → admin-only via Root
+NOTE_PLR_INHERIT  = mknote(PLAYERS_BRANCH, "InheritFromPlayers")      # → Players via node
+NOTE_GM_INHERIT   = mknote(GM_BRANCH,      "InheritFromGm")           # → GMs via node
+NOTE_DEEP_INHERIT = mknote(DEEP_CHILD,     "InheritFromDeep")         # → walks up to GM_BRANCH
+NOTE_PLR_OWN      = mknote(GM_BRANCH,      "OwnPlayersOverride")      # node says GM but…
+NOTE_GM_OWN       = mknote(PLAYERS_BRANCH, "OwnGmOverride")           # node says Players but…
+NOTE_LOCK         = mknote(PLAYERS_BRANCH, "ExplicitLock")            # override TRUE, empty tags
+
+NOTES_VIS_BASE = f"/tenants/{TENANT_A}/maps/{MAP_ID}/notes"
+
+def settag_note(note_id, override, group_ids):
+    return http_post(f"{NOTES_VIS_BASE}/{note_id}/visibility",
+                     {"override": override, "groupIds": group_ids}, TOKEN_A)
+
+# Apply note-level overrides
+settag_note(NOTE_PLR_OWN, True, [G_PLAYERS])
+settag_note(NOTE_GM_OWN,  True, [G_GMS])
+settag_note(NOTE_LOCK,    True, [])
+
+# B should be able to see (after all settings):
+#   NOTE_PLR_INHERIT (inherits Players-tagged node)
+#   NOTE_PLR_OWN     (own override Players)
+B_VISIBLE_NOTES = {NOTE_PLR_INHERIT, NOTE_PLR_OWN}
+ALL_NOTES       = {NOTE_PIN_INHERIT, NOTE_PLR_INHERIT, NOTE_GM_INHERIT,
+                   NOTE_DEEP_INHERIT, NOTE_PLR_OWN, NOTE_GM_OWN, NOTE_LOCK}
+
+# ─── Tagging endpoint: GET ───────────────────────────────────────────────────
+
+print("  --- GET visibility ---")
+
+vis_path = f"{NOTES_VIS_BASE}/{NOTE_PLR_OWN}/visibility"
+status, body = http_get(vis_path, TOKEN_A)
+assert_status("get-vis: returns 200", 200, status)
+assert_json_field("get-vis: noteId", body, ["noteId"], str(NOTE_PLR_OWN))
+assert_json_field("get-vis: override TRUE", body, ["override"], "True")
+assert_true("get-vis: groupIds = [Players]", body["groupIds"] == [G_PLAYERS])
+
+# Unknown note → 404
+status, _ = http_get(f"{NOTES_VIS_BASE}/9999999/visibility", TOKEN_A)
+assert_status("get-vis: unknown note returns 404", 404, status)
+
+# Cross-tenant blocked at TenantFilter
+status, _ = http_get(vis_path, TOKEN_B)  # B is tenant_member viewer
+# Note: B is a member of A's tenant, so TenantFilter allows. The endpoint
+# itself doesn't restrict reads to managers — that mirrors NodeController's
+# getVisibility behavior. So B gets 200 here.
+assert_status("get-vis: tenant member sees raw state", 200, status)
+
+print("  All GET-visibility tests passed.")
+
+# ─── Tagging endpoint: POST ──────────────────────────────────────────────────
+
+print("  --- POST visibility ---")
+
+# Override-only call leaves tags untouched
+status, _ = http_post(vis_path, {"override": False}, TOKEN_A)
+assert_status("set-vis: override-only returns 204", 204, status)
+status, body = http_get(vis_path, TOKEN_A)
+assert_json_field("set-vis: override flipped", body, ["override"], "False")
+assert_true("set-vis: tags survived flip", body["groupIds"] == [G_PLAYERS])
+
+# Restore for the filter tests that follow
+http_post(vis_path, {"override": True, "groupIds": [G_PLAYERS]}, TOKEN_A)
+
+# Empty body
+status, _ = http_post(vis_path, {}, TOKEN_A)
+assert_status("set-vis: empty body 400", 400, status)
+
+# Cross-tenant group rejected
+_, body = http_post(f"/tenants/{TENANT_B}/visibility-groups",
+                    {"name": "OtherTenantGroup"}, TOKEN_B)
+G_OTHER = json_field(body, ["id"])
+status, _ = http_post(vis_path, {"groupIds": [G_OTHER]}, TOKEN_A)
+assert_status("set-vis: cross-tenant groupId 400", 400, status)
+
+# Unknown note id
+status, _ = http_post(f"{NOTES_VIS_BASE}/9999999/visibility",
+                      {"override": True}, TOKEN_A)
+assert_status("set-vis: unknown note 404", 404, status)
+
+print("  All POST-visibility tests passed.")
+
+# ─── Admin bypass on listNotes + getNote ─────────────────────────────────────
+# Admin should see every note attached to every node, regardless of
+# override or tagging state.
+
+print("  --- Admin bypass ---")
+
+for node_id in [PIN, PLAYERS_BRANCH, GM_BRANCH, DEEP_CHILD]:
+    status, body = http_get(f"{NODES_BASE}/{node_id}/notes", TOKEN_A)
+    assert_status(f"admin: listNotes node {node_id} returns 200", 200, status)
+    # Just make sure the list isn't empty if the node has notes attached.
+    expected = sum(1 for nid in [
+        (PIN, NOTE_PIN_INHERIT),
+        (PLAYERS_BRANCH, NOTE_PLR_INHERIT), (PLAYERS_BRANCH, NOTE_GM_OWN),
+        (PLAYERS_BRANCH, NOTE_LOCK),
+        (GM_BRANCH, NOTE_GM_INHERIT), (GM_BRANCH, NOTE_PLR_OWN),
+        (DEEP_CHILD, NOTE_DEEP_INHERIT),
+    ] if nid[0] == node_id)
+    assert_true(f"admin: list under {node_id} contains {expected} notes",
+                len(body) == expected)
+
+for note_id in ALL_NOTES:
+    status, _ = http_get(f"{NOTES_VIS_BASE}/{note_id}", TOKEN_A)
+    assert_status(f"admin: getNote {note_id} returns 200", 200, status)
+
+print("  All admin-bypass tests passed.")
+
+# ─── Non-admin filter on listNotes + getNote ─────────────────────────────────
+
+print("  --- Non-admin filter ---")
+
+# Listing under PIN (a Root-fallback node) — should be empty for B.
+status, body = http_get(f"{NODES_BASE}/{PIN}/notes", TOKEN_B)
+assert_status("B: listNotes under Pin returns 200", 200, status)
+assert_true("B: no notes visible under admin-only node",
+            len(body) == 0)
+
+# Listing under PlayersBranch — B sees the inherit + own-override, but
+# NOT the GM-override note attached to that same node, NOR the lock.
+status, body = http_get(f"{NODES_BASE}/{PLAYERS_BRANCH}/notes", TOKEN_B)
+ids = {n["id"] for n in body}
+assert_true("B: listNotes under PlayersBranch = {InheritFromPlayers}",
+            ids == {NOTE_PLR_INHERIT})
+
+# Listing under GmBranch — B sees only the note that overrides itself
+# back to Players, NOT the inheriting note (which goes to GMs).
+status, body = http_get(f"{NODES_BASE}/{GM_BRANCH}/notes", TOKEN_B)
+ids = {n["id"] for n in body}
+assert_true("B: listNotes under GmBranch = {OwnPlayersOverride}",
+            ids == {NOTE_PLR_OWN})
+
+# Listing under DeepChild — note inherits via DeepChild → GmBranch (GMs).
+# B isn't in GMs, so the list is empty.
+status, body = http_get(f"{NODES_BASE}/{DEEP_CHILD}/notes", TOKEN_B)
+assert_true("B: listNotes under DeepChild empty (inherits GMs)",
+            len(body) == 0)
+
+# getNote: 200 for visible, 404 for hidden.
+for note_id in B_VISIBLE_NOTES:
+    status, _ = http_get(f"{NOTES_VIS_BASE}/{note_id}", TOKEN_B)
+    assert_status(f"B: getNote visible {note_id} returns 200", 200, status)
+for note_id in ALL_NOTES - B_VISIBLE_NOTES:
+    status, _ = http_get(f"{NOTES_VIS_BASE}/{note_id}", TOKEN_B)
+    assert_status(f"B: getNote hidden {note_id} returns 404", 404, status)
+
+print("  All non-admin-filter tests passed.")
+
+# ─── owner_xray bypass for notes ─────────────────────────────────────────────
+
+print("  --- owner_xray ---")
+
+mysql_query(f"UPDATE maps SET owner_id={USER_B_ID}, owner_xray=TRUE WHERE id={MAP_ID};")
+
+status, body = http_get(f"{NODES_BASE}/{GM_BRANCH}/notes", TOKEN_B)
+ids = {n["id"] for n in body}
+assert_true("xray=TRUE owner: sees every note under GmBranch",
+            ids == {NOTE_GM_INHERIT, NOTE_PLR_OWN})
+status, _ = http_get(f"{NOTES_VIS_BASE}/{NOTE_LOCK}", TOKEN_B)
+assert_status("xray=TRUE owner: explicit-lock note 200", 200, status)
+
+mysql_query(f"UPDATE maps SET owner_xray=FALSE WHERE id={MAP_ID};")
+status, _ = http_get(f"{NOTES_VIS_BASE}/{NOTE_LOCK}", TOKEN_B)
+assert_status("xray=FALSE owner: lock note 404 again", 404, status)
+mysql_query(f"UPDATE maps SET owner_id={USER_A_ID} WHERE id={MAP_ID};")
+
+print("  All owner_xray tests passed.")
+
+# ─── Cleanup CASCADE ─────────────────────────────────────────────────────────
+
+print("  --- Cleanup cascade ---")
+
+# Re-tag NOTE_PLR_OWN with both groups
+http_post(f"{NOTES_VIS_BASE}/{NOTE_PLR_OWN}/visibility",
+          {"override": True, "groupIds": [G_PLAYERS, G_GMS]}, TOKEN_A)
+status, body = http_get(f"{NOTES_VIS_BASE}/{NOTE_PLR_OWN}/visibility", TOKEN_A)
+assert_true("cleanup: re-tagged with both",
+            sorted(body["groupIds"]) == sorted([G_PLAYERS, G_GMS]))
+
+# Delete G_PLAYERS — note_visibility row should CASCADE
+http_delete(f"{VG_BASE}/{G_PLAYERS}", TOKEN_A)
+status, body = http_get(f"{NOTES_VIS_BASE}/{NOTE_PLR_OWN}/visibility", TOKEN_A)
+assert_true("cleanup: cascade dropped Players row", body["groupIds"] == [G_GMS])
+
+# Deleting the underlying note should also cascade away its visibility rows
+NOTE_TOMBSTONE = mknote(PLAYERS_BRANCH, "ToCascade")
+http_post(f"{NOTES_VIS_BASE}/{NOTE_TOMBSTONE}/visibility",
+          {"override": True, "groupIds": [G_GMS]}, TOKEN_A)
+http_delete(f"{NOTES_VIS_BASE}/{NOTE_TOMBSTONE}", TOKEN_A)
+remaining = mysql_query(
+    f"SELECT COUNT(*) FROM note_visibility WHERE note_id={NOTE_TOMBSTONE};")
+assert_true("cleanup: note delete cascaded note_visibility",
+            remaining == "0")
+
+print("  All cleanup tests passed.")
+
+sys.exit(0 if report() else 1)


### PR DESCRIPTION
Closes #87 (will close manually after merge — auto-close skips non-default-branch PRs).

## Summary

Closes the visibility loop for the nodes-rebuild branch by extending the same pattern from #86 + #99 to notes. Two parts:

1. **Tagging endpoints** (mirror of #86 for nodes):
   - `GET    /api/v1/tenants/{tid}/maps/{mid}/notes/{id}/visibility` — raw stored state.
   - `POST   /api/v1/tenants/{tid}/maps/{mid}/notes/{id}/visibility` — body `{ override?, groupIds? }`, same independent-fields semantics.

2. **Read-time filter** on `listNotes` and `getNote` — uses an extended CTE that walks the inheritance chain across the note → node table boundary, then up the node parent chain to its first override-TRUE ancestor.

## Note effective-visibility chain

For a note:
1. If `note.visibility_override = TRUE` → use the note's `note_visibility` rows.
2. Else walk to the attached node and recurse up the node parent chain (same as #99) to its first override-TRUE ancestor; use **that node's** `node_visibility` rows.
3. If no override anywhere up the chain → admin-only (empty set).

Visible to a user iff:
- They're a tenant admin (filter bypassed entirely), OR
- They're a member of any visibility group in the effective set, OR
- They're the map owner **and** `maps.owner_xray = TRUE`.

## SQL shape

The `node_resolve` and `node_visible_starts` CTEs are structurally identical to the node version in #99. A new `note_visible` CTE on top combines two cases via UNION-style OR:

```sql
WITH RECURSIVE
  node_resolve AS ( ... same as #99 ... ),
  node_visible_starts AS ( ... same as #99 ... ),
  note_visible AS (
    SELECT n.id AS visible_note_id FROM notes n
    JOIN nodes nd ON nd.id = n.node_id AND nd.map_id = ?
    WHERE (n.visibility_override = TRUE
           AND EXISTS (SELECT 1 FROM note_visibility nv2
                       JOIN visibility_group_members vgm2
                            ON vgm2.visibility_group_id = nv2.visibility_group_id
                       WHERE nv2.note_id = n.id AND vgm2.user_id = ?))
       OR (n.visibility_override = FALSE
           AND n.node_id IN (SELECT start_id FROM node_visible_starts))
  )
SELECT ... FROM notes n JOIN ... maps m ...
WHERE ... AND ((m.owner_id = ? AND m.owner_xray = TRUE)
               OR n.id IN (SELECT visible_note_id FROM note_visible))
```

CTE is bounded against `MAX_NODE_DEPTH` (15) — same chain limit as #99. Tenant admins skip the CTE entirely (no perf cost).

## Behaviour worth flagging

- **Note-level override wins.** A note attached to a GMs-tagged node can override itself back to Players (or vice versa). The note's own override + tags trumps inheritance from the attached node.
- **Empty effective set = admin-only.** A note with `override = TRUE` and zero `note_visibility` rows is explicit-locked — only admins (and xray owners) see it. Same convergence as nodes in #99.
- **Hidden notes return 404, not 403.** Don't leak existence.
- **`getVisibility` doesn't gate on read access to the note itself.** Mirrors `NodeController::getVisibility` from #86 — managers need to be able to inspect tagging metadata before editing it.

## Files changed

- **backend/src/controllers/NoteController.h** — Two new route entries + method declarations; doc-string updated to spell out the inheritance chain.
- **backend/src/controllers/NoteController.cpp** — `NOTE_VISIBILITY_CTE` + `NOTE_VISIBILITY_PREDICATE` constants in the anonymous namespace; `listNotes` and `getNote` rewritten to branch on `isTenantAdmin(req)`; new `getVisibility` and `setVisibility` handlers (use `requireVisibilityGroupManager` from `VisibilityAuth.h`, validate that all groupIds belong to the tenant, idempotent multi-row INSERT with literal int splicing — same pattern as #86).
- **backend/tests/test_21_note_visibility.py** — New 45-assertion suite covering tagging endpoint shapes, admin bypass on list+get, the cross-table inheritance walk (note→node→parent chain), note-level override winning over node inheritance, owner_xray bypass, hidden-note 404, and CASCADE behavior on both group delete and note delete.
- **backend/tests/run-tests.py** — Adds `test_21_note_visibility.py` to `FAST_TESTS`; description.

## Test plan

- [x] `python3 backend/tests/test_21_note_visibility.py` — 45 passed, 0 failed.
- [x] `python3 backend/tests/run-tests.py --tier fast` — all 15 suites pass; existing `test_16_notes.py`, `test_19_node_visibility.py`, `test_20_node_visibility_filter.py` unchanged.
- [ ] CI green on PR (E2E expected red — see below)

## Test expectations (CI on `nodes-rebuild`)

| Job | Expected | Why |
|---|---|---|
| `lint` | ✅ pass | No frontend changes. |
| `security` | ✅ pass | No new dependencies. |
| `compile` | ✅ pass | New CTE constants + handlers compile cleanly. |
| `integration` (db tests) | ✅ pass | Schema unchanged; 179/179. |
| `integration` (backend tests) | ✅ pass | 15/15 suites pass locally including new `test_21_note_visibility.py`. |
| `integration` (E2E) | ❌ **expected fail** | Annotations / cross-tenant E2E specs reference the old annotations frontend that was ripped out for the rebuild. Frontend rebuild lands in the #94 series. |

`integration` will report red overall because of the E2E sub-step. Mid-rebuild informational state — `main` remains the enforced gate.

## Out of scope

- Note media visibility (deferred — media stays accessible if its owner is, per ticket).
- Frontend UI (#94 series).

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)