### PR TITLE
docs: AI-agent collaboration conventions

### DIFF
--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -37,6 +37,8 @@ agent instructions:
    branch is action #1**, before any feature ticket starts.
 9. **Stamp commits with the current AI model name** (not a previously-used
    string) in the `Co-Authored-By:` trailer.
+10. **When a rule here is added, modified, or removed, update this document
+    and agent memory in the same change** so the two stay in sync.
 
 ---
 
@@ -373,20 +375,64 @@ Sequence for any future long-running branch:
 
 ---
 
+## Meta — keeping these conventions current
+
+### 10. Update this document and agent memory together
+
+> **Rule:** When a rule in this document is added, modified, or removed,
+> apply the same change to the agent's memory store in the same PR (or
+> conversation turn) so the two representations stay in sync.
+
+**Why:** These conventions live in two places — this document (committed,
+shareable, the canonical reference) and the agent's per-project memory (where
+they shape behavior turn-by-turn). Drift between them has a predictable
+failure mode: the doc says one thing, the agent does another, and a human
+collaborator can't tell which is authoritative. Updating both at once keeps
+the document trustworthy as a porting source AND keeps the agent's behavior
+matching what the doc claims.
+
+**How to apply:**
+
+When the user asks to add, change, or drop a rule:
+
+1. **Edit this document** — both the **Quick reference** one-liner *and* the
+   per-rule expanded section (Rule / Why / How to apply). Renumber later
+   rules if inserting; remove the entry if deleting.
+2. **Edit agent memory** — the corresponding `feedback_*.md` file (write a
+   new one for additions, edit for modifications, delete for removals).
+   Update `MEMORY.md` to add/remove the pointer.
+3. **Commit both together** in the same PR so the diff makes the linkage
+   visible.
+
+For a rule discovered organically mid-conversation (e.g., the user
+corrects something), do the same — capture it in memory immediately, then
+fold it into this document on the next reasonable PR boundary (don't let
+the doc lag behind memory by more than one ticket).
+
+**Inverse direction:** if the doc is edited directly (e.g., the user
+fixes wording or clarifies an example), reflect the same change in the
+relevant `feedback_*.md` memory file. The two are mirrors of each other,
+not master/replica.
+
+---
+
 ## Adapting these conventions to other projects
 
 When porting to another project:
 
-- **Rules 1–6 and 9** are largely tooling-agnostic — the rule statements
+- **Rules 1, 4, 5, 6, 10** are fully tooling-agnostic — the rule statements
   transfer directly.
-- **Rule 2 (status lifecycle)** carries a project-board GraphQL ID block
-  in **How to apply** that needs replacement with the new project's IDs.
+- **Rule 2 (status lifecycle)** carries a project-board GraphQL ID block in
+  **How to apply** that needs replacement with the new project's IDs.
 - **Rule 3 (default project)** has the project number / owner hardcoded —
   swap for your project's equivalents.
-- **Rule 7 (Co-Authored-By trailer)** assumes Claude; for other agents
+- **Rule 7 (public-repo scan)** only applies if the repo is public. Skip it
+  for private repos, but consider keeping the secrets-scan portion anyway —
+  leaked credentials in private-repo history are still a risk if the repo's
+  visibility ever changes.
+- **Rule 8 (long-running branch CI)** assumes GitHub Actions; adapt the
+  "extend the workflow" mechanics for other CI systems (GitLab CI, Buildkite,
+  etc.).
+- **Rule 9 (Co-Authored-By trailer)** assumes Claude; for other agents
   (Cursor, Aider, etc.) adjust the trailer format to match what the agent
   actually identifies as.
-- **Rule 8 (public-repo scan)** only applies if the repo is public.
-  Skip it for private repos, but consider keeping the secrets-scan portion
-  anyway — leaked credentials in private-repo history are still a risk if
-  the repo's visibility ever changes.

--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -37,8 +37,9 @@ agent instructions:
    branch is action #1**, before any feature ticket starts.
 9. **Stamp commits with the current AI model name** (not a previously-used
    string) in the `Co-Authored-By:` trailer.
-10. **When a rule here is added, modified, or removed, update this document
-    and agent memory in the same change** so the two stay in sync.
+10. **This document is the master record; agent-memory entries are thin
+    replicas pointing back here.** When a rule changes, edit the doc; the
+    memory pointer's frontmatter is updated to match.
 
 ---
 
@@ -377,42 +378,74 @@ Sequence for any future long-running branch:
 
 ## Meta — keeping these conventions current
 
-### 10. Update this document and agent memory together
+### 10. Doc is the master record; memory entries are thin replicas
 
-> **Rule:** When a rule in this document is added, modified, or removed,
-> apply the same change to the agent's memory store in the same PR (or
-> conversation turn) so the two representations stay in sync.
+> **Rule:** This document is the authoritative source for the working
+> agreements. The agent's per-project memory entries (e.g.,
+> `feedback_*.md` files under `~/.claude/projects/<project>/memory/` for
+> Claude Code) are thin replicas — they exist so the agent's relevance
+> matcher fires on the right rule, and their bodies just point back to
+> the relevant section here.
 
-**Why:** These conventions live in two places — this document (committed,
-shareable, the canonical reference) and the agent's per-project memory (where
-they shape behavior turn-by-turn). Drift between them has a predictable
-failure mode: the doc says one thing, the agent does another, and a human
-collaborator can't tell which is authoritative. Updating both at once keeps
-the document trustworthy as a porting source AND keeps the agent's behavior
-matching what the doc claims.
+**Why:** Two parallel sources of truth drift; one of them needs to win.
+The doc is the better master because: (a) it's reviewable in PR diffs,
+(b) it has structure (categories, cross-references, examples, the
+porting guide) that loose memory files don't, and (c) it's what a new
+collaborator or another project would actually consume. Memory's job is
+narrower — it just needs the frontmatter + filename + description so the
+relevance matcher can surface the right rule, then the agent reads this
+doc for the actual content. Treating doc as master eliminates the
+"did I update both?" discipline cost and removes the "which is right?"
+ambiguity when a drift is discovered.
 
 **How to apply:**
 
-When the user asks to add, change, or drop a rule:
+When adding / modifying / removing a rule:
 
-1. **Edit this document** — both the **Quick reference** one-liner *and* the
-   per-rule expanded section (Rule / Why / How to apply). Renumber later
-   rules if inserting; remove the entry if deleting.
-2. **Edit agent memory** — the corresponding `feedback_*.md` file (write a
-   new one for additions, edit for modifications, delete for removals).
-   Update `MEMORY.md` to add/remove the pointer.
-3. **Commit both together** in the same PR so the diff makes the linkage
-   visible.
+1. **Edit this document** — both the **Quick reference** one-liner *and*
+   the per-rule expanded section (Rule / Why / How to apply). Renumber
+   later rules if inserting; remove the entry if deleting; update the
+   "Adapting" section if portability semantics changed.
+2. **Update the memory pointer** — write/edit/delete the corresponding
+   `feedback_*.md` so its frontmatter (`name`, `description`) matches
+   the doc, and the body points to the new doc section. For new rules,
+   also add the pointer line to `MEMORY.md`.
+3. **Commit the doc change.** The memory update happens locally — memory
+   lives outside the repo and isn't part of any PR.
 
-For a rule discovered organically mid-conversation (e.g., the user
-corrects something), do the same — capture it in memory immediately, then
-fold it into this document on the next reasonable PR boundary (don't let
-the doc lag behind memory by more than one ticket).
+**Memory body shape (thin replica):**
 
-**Inverse direction:** if the doc is edited directly (e.g., the user
-fixes wording or clarifies an example), reflect the same change in the
-relevant `feedback_*.md` memory file. The two are mirrors of each other,
-not master/replica.
+```markdown
+---
+name: <human-readable rule name>
+description: <one-line description used by relevance matcher>
+type: feedback
+---
+See [docs/AI-COLLABORATION-CONVENTIONS.md](docs/AI-COLLABORATION-CONVENTIONS.md) §N for the full rule, why, and how to apply.
+```
+
+When the relevance matcher surfaces this entry, the agent reads the doc
+section to get the actual rule content — one extra Read, negligible cost.
+
+**Operational-cache exception:** A few rules carry project-specific
+operational data that benefits from being in memory directly (no extra
+read needed mid-task) — e.g., cached GraphQL IDs for the project board.
+Those stay in the memory body alongside the pointer:
+
+```markdown
+---
+name: ...
+---
+See [docs/AI-COLLABORATION-CONVENTIONS.md](docs/AI-COLLABORATION-CONVENTIONS.md) §N for the full rule.
+
+**Project-specific operational cache** (kept here for fast reuse):
+- Project ID: PVT_xxx
+- Status field ID: PVTSSF_xxx
+- Option IDs: Todo=..., In Progress=..., Done=...
+```
+
+The split rule: **rule content → doc; project-specific operational
+caches → memory body.**
 
 ---
 
@@ -420,8 +453,12 @@ not master/replica.
 
 When porting to another project:
 
-- **Rules 1, 4, 5, 6, 10** are fully tooling-agnostic — the rule statements
+- **Rules 1, 4, 5, 6** are fully tooling-agnostic — the rule statements
   transfer directly.
+- **Rule 10 (doc as master)** transfers as a concept, but the specific
+  memory-file format (`feedback_*.md` with frontmatter) is Claude Code-
+  specific. For other agents, adapt the "thin replica" pointer shape to
+  whatever per-rule storage that agent uses.
 - **Rule 2 (status lifecycle)** carries a project-board GraphQL ID block in
   **How to apply** that needs replacement with the new project's IDs.
 - **Rule 3 (default project)** has the project number / owner hardcoded —

--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -1,0 +1,392 @@
+# AI-Agent Collaboration Conventions
+
+Process conventions for working with an AI coding agent (e.g., Claude Code,
+Cursor, Aider) on a real software project. Distilled from the `nodes-rebuild`
+work on annotated-maps; the rules are written portably so they transfer to
+any project, with project-specific bits flagged in **How to apply** sections.
+
+These conventions overlap meaningfully with three established frameworks —
+**Definition of Done** (Scrum/Agile), **Google's "Small CLs" guidance**
+([eng-practices](https://google.github.io/eng-practices/review/developer/small-cls.html)),
+and **Trunk-Based Development**'s feature-branch guidance
+([trunkbaseddevelopment.com](https://trunkbaseddevelopment.com/)). Where
+relevant, that overlap is noted under each rule.
+
+---
+
+## Quick reference (portable rule list)
+
+Copy these statements verbatim into another project's CLAUDE.md / system prompt /
+agent instructions:
+
+1. **Size every ticket to fit a single PR.** Split aggressively up front; many
+   small tickets beats a few "natural" ones that don't land cleanly.
+2. **Move ticket status as work progresses:** Todo → In Progress when the PR
+   opens; In Progress → Done when the PR merges.
+3. **Add every new issue to the project's default board** (whichever board
+   represents "what we're working on now").
+4. **Every PR body has a `## Files changed` section** — alphabetical list of
+   files with one-line summaries.
+5. **Update docs and tests alongside code in every PR.** Verify both
+   explicitly; if neither needs updating, say so in the PR description.
+6. **Include a `## Test expectations` table only when some CI checks are
+   expected to fail.** Skip the section entirely when everything is green.
+7. **Scan the actual diff for secrets, PII, and internal references before
+   opening every PR** in a public repository.
+8. **For long-running branches, extending the CI workflow to trigger on the
+   branch is action #1**, before any feature ticket starts.
+9. **Stamp commits with the current AI model name** (not a previously-used
+   string) in the `Co-Authored-By:` trailer.
+
+---
+
+## Ticket and project-board hygiene
+
+### 1. Size tickets to fit a single PR
+
+> **Rule:** When filing tickets that will later be implemented by an AI agent,
+> size each one so the work fits comfortably in a single PR without risking
+> streaming-API idle timeouts. Split aggressively up front rather than
+> mid-implementation.
+
+**Why:** During the `nodes-rebuild` work, ticket #82 was originally one bundle
+(schema + new controller + tests). Mid-implementation we hit the streaming-API
+idle timeout, had to split it into #82 + #96 retroactively, and then re-evaluated
+#83–#95 and discovered five more tickets needing the same treatment (resulting
+in #98–#106). The pattern is predictable: backend tickets touching multiple
+controllers, anything with recursive CTEs, anything mixing backend + frontend,
+and any wholesale UI rewrite are all at high risk. Splitting up front saves the
+mid-PR rework.
+
+This overlaps with [Google's "Small CLs"](https://google.github.io/eng-practices/review/developer/small-cls.html)
+guidance — read that doc for the orthogonal-but-aligned argument that small
+PRs are also better for human review. Our version is timeout-driven; theirs is
+review-quality-driven. Both reach the same conclusion.
+
+**How to apply:**
+
+- **Calibration point:** for the AI agent's streaming context, a PR around
+  25–30 files / +1100 / -2200 lines runs close to the timeout. Anything bigger,
+  or anything with extra build/test iteration cycles, is risky.
+- **Default split heuristics:**
+  - "Data + management API" tickets (CRUD + members + auth helper + bootstrap)
+    → split CRUD vs. supporting ops.
+  - "Tagging + filtering" tickets where filtering needs a recursive CTE →
+    split write-side from read-side filtering.
+  - "Move + copy" tickets → always two tickets (copy is recursive duplication,
+    a different shape from re-parenting).
+  - Frontend tickets that mix Zod foundation + UI rewrite + E2E rewrite → at
+    least three tickets.
+  - Tickets that touch both backend and frontend → split unless trivially small.
+- **One controller + its tests** is usually a safe single-ticket unit. Anything
+  beyond that, ask: does this need splitting?
+- Cross-link the splits in ticket bodies (".b depends on .a"); trim the
+  parent's task list when splitting; mark out-of-scope items.
+
+### 2. Update ticket status on the project board
+
+> **Rule:** When working on tickets tracked on a project board, move the Status
+> field through Todo → In Progress → Done as work progresses. Default cadence:
+> In Progress when the PR is opened; Done when the PR is merged.
+
+**Why:** The board is the canonical view of "what's happening right now."
+Leaving stale statuses there means the human collaborator can't trust it for
+at-a-glance status, and they end up doing manual cleanup that should have been
+the agent's job. Cheap habit fix; avoids a recurring papercut.
+
+This is essentially a Kanban WIP-discipline rule — see any Kanban guide for
+the canonical Todo → In Progress → Done flow.
+
+**How to apply:**
+
+- **Todo → In Progress:** when the PR opens. Earlier transitions
+  ("starting to think about it") aren't useful — open-PR is a clear,
+  observable trigger.
+- **In Progress → Done:** when the PR merges. Usually triggered by the human
+  saying "PR merged"; that's the cue to flip both sides.
+
+**Long-running branch caveat:** GitHub's auto-close-on-merge only fires for
+the default branch. PRs into a long-running branch (e.g., `nodes-rebuild`)
+do NOT auto-close their linked issues, even with `Closes #N` syntax. After
+merging into a long-running branch, **both** of these are manual:
+
+1. Close the issue (`gh issue close NNN --comment "..."` — explain the
+   long-running-branch context).
+2. Flip the board status to Done.
+
+**Project-specific binding (annotated-maps `Focus on next` board):**
+
+```bash
+PROJECT_ID="PVT_kwHOAAdfes4BTc5U"            # Focus on next
+STATUS_FIELD="PVTSSF_lAHOAAdfes4BTc5UzhAsFXA"
+TODO_OPT="f75ad846"
+IN_PROG_OPT="47fc9ee4"
+DONE_OPT="98236657"
+```
+
+These IDs were stable as of `nodes-rebuild`. If they ever drift (project
+rename, etc.), re-derive via:
+
+```bash
+gh api graphql -f query='
+{ user(login: "dcltdw") {
+    projectV2(number: 1) {
+      id
+      field(name: "Status") {
+        ... on ProjectV2SingleSelectField { id options { id name } }
+      }
+    }
+} }'
+```
+
+When porting to another project, replace these IDs with the equivalents from
+your own GraphQL query.
+
+### 3. Add every new issue to the default project
+
+> **Rule:** Whenever creating a new issue, add it to the project's default
+> "what we're working on" board afterward.
+
+**Why:** All issues should live on one board by default; otherwise, drift
+between "filed" and "tracked" creates a backlog of orphan issues that no one
+is looking at.
+
+**How to apply:**
+
+```bash
+gh issue create --title "..." --body "..."     # produces issue URL
+gh project item-add 1 --owner dcltdw --url <issue-url>
+```
+
+Replace `1` (project number) and `dcltdw` (owner) with your project's values.
+
+---
+
+## PR conventions
+
+### 4. PR body must include a "Files changed" section
+
+> **Rule:** Every PR body has a `## Files changed` section — a bullet list of
+> each file (sorted alphabetically by path) with a one-line summary of changes.
+
+**Why:** Reviewers (and future archaeologists) get a clear at-a-glance map of
+what the PR touches without having to click into the diff. The one-line
+summaries also serve as a sanity check that the agent understood each file's
+purpose.
+
+This is loosely covered by GitHub's own ["Writing a pull request"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests)
+guide, but spelling it out as an alphabetical list with summaries goes
+further than most defaults.
+
+**How to apply:** Place the section between the PR's Summary and Test plan.
+
+```markdown
+## Files changed
+
+- **backend/src/ControllerA.cpp** — Adds the X helper used by the new endpoint.
+- **backend/src/ControllerB.cpp** — Refactors error handling to use shared header.
+- **backend/tests/test_42_x.py** — New 12-assertion suite covering X.
+```
+
+### 5. Always update docs and tests with code
+
+> **Rule:** Every PR must include relevant documentation and test updates.
+> Verify both explicitly before opening the PR; don't conclude readiness
+> without the check.
+
+**Why:** Docs and tests are easy to skip on refactor PRs (where there's no
+behavior change but often new conventions worth documenting), and on
+"obviously" simple PRs where the agent's reflex is to declare the work done
+once the code compiles. The user has had to re-prompt for both more than
+once; a routine check is cheaper.
+
+This is a classic Definition of Done item — most Scrum/Agile DoD checklists
+include both "tests updated" and "documentation updated" near the top.
+
+**How to apply:**
+
+Before opening the PR, run through both questions:
+
+- "What docs reference the area I changed? Do they still match?"
+- "Are there tests covering the area I changed? Do any need updating?"
+
+For refactors with no behavior change, new shared helpers/patterns still
+often warrant a conventions doc (so future devs don't drift back to the old
+shape). If truly nothing needs updating, **say so explicitly** in the PR
+description — e.g., "No docs/tests updated — refactor preserves behavior
+exactly and no convention docs exist yet."
+
+### 6. PR Test Expectations section (only when failures are expected)
+
+> **Rule:** When some CI checks are expected to fail (e.g., mid-rebuild on a
+> long-running branch where one part of the system has outpaced another),
+> include a `## Test expectations` table in the PR body listing each
+> CI job/sub-step with its expected outcome and a one-line reason. Skip the
+> section entirely when everything is expected to pass.
+
+**Why:** Without an explicit expectations table, a reviewer (or future-self)
+sees a red CI run and has to reconstruct the design context to figure out
+whether it's "fine and expected" or "actual bug." A pre-declared table makes
+the review fast: scan, confirm reality matches, move on. Conversely, an
+"all green expected" table on every PR would be pure noise — the green
+checks themselves convey it.
+
+This is a local invention; I haven't seen it codified in DoD or any
+standard PR template. It's most useful on long-running branches where
+mid-state inconsistency is expected by design.
+
+**How to apply:**
+
+- Use a small markdown table per CI job (or sub-step within a multi-step
+  job like `integration`). Columns: **Job | Expected | Why**.
+- Use ✅ pass / ❌ expected fail / 🟡 partial emojis to make the scan fast.
+- For each ❌, give a one-line reason that points at the ticket / phase
+  that will fix it.
+- Mention if the overall job will report red because of one sub-step
+  (e.g., `integration` reporting red because E2E fails *inside* it).
+  Otherwise reviewers may think the whole job is broken.
+- If the long-running branch has different CI gating semantics than `main`
+  (e.g., informational only), state it explicitly.
+
+**Example:**
+
+```markdown
+## Test expectations (CI on `nodes-rebuild`)
+
+| Job | Expected | Why |
+|---|---|---|
+| `lint` | ✅ pass | No frontend changes. |
+| `compile` | ✅ pass | New code compiles locally. |
+| `integration` (backend) | ✅ pass | 9/9 suites pass locally. |
+| `integration` (E2E) | ❌ expected fail | Frontend still references old API; rebuild lands in #92, #101, #102. |
+```
+
+### 7. Stamp commits with the current AI model name
+
+> **Rule:** When adding a `Co-Authored-By:` trailer to commits, use the
+> actual current model name from the runtime environment — don't copy a
+> previously-used string from earlier commits.
+
+**Why:** Stale trailers misrepresent which model produced the change, which
+matters for later archaeology ("did we regress after model upgrade X?").
+The agent's reflex is to copy the previous commit's trailer verbatim;
+that's wrong after any model upgrade.
+
+**How to apply:**
+
+- Before writing the commit-message HEREDOC, check the runtime environment
+  for the line that names the active model and use that exact name.
+- Format: `Co-Authored-By: Claude <ModelName> (<context-size>) <noreply@anthropic.com>`
+  — e.g., `Claude Opus 4.7 (1M context)`.
+- If unsure, ask before guessing.
+
+---
+
+## Repo-level practices
+
+### 8. Public-repo diff scan before every PR
+
+> **Rule:** If the repository is public, scan the actual diff
+> (`git diff <base>...HEAD`) for secrets, PII, internal references, and
+> debugging leakage before opening every PR.
+
+**Why:** Public repos are visible to the world, indexed by search engines,
+and may be cloned by automated bots within minutes of pushing. Doing a
+small diff-scan once per PR is cheap; finding a leaked credential in commit
+history later is expensive (history rewrite + credential rotation).
+
+This aligns with [OpenSSF Scorecard](https://github.com/ossf/scorecard) and
+the broader "secrets in commits" hygiene that tools like
+[gitleaks](https://github.com/gitleaks/gitleaks) automate. Treat the manual
+scan as defense-in-depth, not the only line of defense.
+
+**How to apply:**
+
+Before `gh pr create`, scan the diff and check for:
+
+- **Live credentials:** `sk_live_`, `AKIA*`, `xoxb-`, `ghp_`, `glpat-`,
+  real passwords (anything that's not a documented dev placeholder),
+  real JWT secrets, OAuth `client_secret` values, SSH/TLS keys.
+- **PII:** real names other than the project owner's public identity,
+  real email addresses, phone numbers, physical addresses.
+- **Internal references:** internal hostnames (`*.internal`, `*.local`),
+  private-range IPs (10.x, 172.16-31.x, 192.168.x), references to internal
+  Slack/JIRA/Linear/etc.
+- **Debugging leakage:** `console.log` / `println!` / `std::cerr` calls
+  that dump secrets, tokens, request bodies, or full user objects.
+- **Embarrassing content:** profanity, hot-takes about specific named
+  people/companies, internal-team-only humor.
+
+If anything ambiguous turns up, ask before pushing.
+
+**Beyond pre-PR scanning:**
+
+- Confirm new files are added to `.gitignore` *before* they're created;
+  don't rely on remembering later.
+- Document third-party code attributions in code comments and project
+  manifests.
+- Avoid committing temporary debug files (`*.log`, `tmp_*.txt`, etc.).
+
+### 9. Long-running branches — extend CI as action #1
+
+> **Rule:** When creating a long-running branch (a "rebuild" / "phase-N"
+> branch where many PRs will land before merging back to main), the very
+> first action on that branch is a CI workflow extension PR. Do this BEFORE
+> any feature ticket starts.
+
+**Why:** During the `nodes-rebuild` work, the branch was created and a
+large schema-rewrite PR (#97) sat without any CI verification because
+`pr-tests.yml` only triggered on PRs into `main`. The gap was discovered
+later, requiring two follow-up PRs (#108 to main + #109 to nodes-rebuild)
+to retrofit CI plumbing — and then the original PR had to be re-triggered.
+The work was right; the sequence wasn't.
+
+[Trunk-Based Development guidance](https://trunkbaseddevelopment.com/short-lived-feature-branches/)
+explicitly covers the case where pure trunk-based isn't viable and you need
+a long-running branch. CI gating on that branch is one of the trade-offs
+it tells you to think about up front, not retroactively.
+
+**How to apply:**
+
+When asked to create a long-running branch, the *first* deliverable is a
+tiny PR that extends the project's CI workflow (e.g., `.github/workflows/pr-tests.yml`)
+to:
+
+1. Add the branch to the `pull_request: branches: [...]` list.
+2. Add a `push: branches: [...]` trigger so post-merge state is also verified.
+
+Land that change on **both** `main` (canonical convention) and the
+long-running branch — for `pull_request` events, GitHub Actions reads the
+workflow from the **base branch's tip**, so it has to exist on the long-running
+branch for PRs *into* the branch to fire.
+
+For the long-running branch, decide upfront whether CI is **enforced**
+(branch-protection ruleset) or **informational** (no ruleset). For active
+rebuild branches where mid-state failures are expected, informational is
+usually right; `main` remains the enforced gate.
+
+Sequence for any future long-running branch:
+
+1. Create branch.
+2. CI workflow extension PR (mirror onto both `main` and the branch).
+3. *Then* the first feature ticket.
+
+---
+
+## Adapting these conventions to other projects
+
+When porting to another project:
+
+- **Rules 1–6 and 9** are largely tooling-agnostic — the rule statements
+  transfer directly.
+- **Rule 2 (status lifecycle)** carries a project-board GraphQL ID block
+  in **How to apply** that needs replacement with the new project's IDs.
+- **Rule 3 (default project)** has the project number / owner hardcoded —
+  swap for your project's equivalents.
+- **Rule 7 (Co-Authored-By trailer)** assumes Claude; for other agents
+  (Cursor, Aider, etc.) adjust the trailer format to match what the agent
+  actually identifies as.
+- **Rule 8 (public-repo scan)** only applies if the repo is public.
+  Skip it for private repos, but consider keeping the secrets-scan portion
+  anyway — leaked credentials in private-repo history are still a risk if
+  the repo's visibility ever changes.

--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -31,15 +31,20 @@ agent instructions:
    explicitly; if neither needs updating, say so in the PR description.
 6. **Include a `## Test expectations` table only when some CI checks are
    expected to fail.** Skip the section entirely when everything is green.
-7. **Scan the actual diff for secrets, PII, and internal references before
-   opening every PR** in a public repository.
-8. **For long-running branches, extending the CI workflow to trigger on the
-   branch is action #1**, before any feature ticket starts.
-9. **Stamp commits with the current AI model name** (not a previously-used
+7. **Stamp commits with the current AI model name** (not a previously-used
    string) in the `Co-Authored-By:` trailer.
+8. **Scan the actual diff for secrets, PII, and internal references before
+   opening every PR** in a public repository.
+9. **For long-running branches, extending the CI workflow to trigger on the
+   branch is action #1**, before any feature ticket starts.
 10. **This document is the master record; agent-memory entries are thin
     replicas pointing back here.** When a rule changes, edit the doc; the
     memory pointer's frontmatter is updated to match.
+11. **When a cached operational value fails with a staleness-pattern error
+    (404 / "not found" / "no such resource"), re-derive from the live
+    source and update the cache before retrying.** Don't blindly retry,
+    don't ask the user — refresh on first failure, escalate only if the
+    fresh value also fails.
 
 ---
 
@@ -447,6 +452,69 @@ See [docs/AI-COLLABORATION-CONVENTIONS.md](docs/AI-COLLABORATION-CONVENTIONS.md)
 The split rule: **rule content → doc; project-specific operational
 caches → memory body.**
 
+### 11. Refresh stale operational caches on failure (don't ask, don't retry blindly)
+
+> **Rule:** When a cached operational value (e.g., a project board ID,
+> a resource UUID, a known file path) is used in an operation and the
+> operation fails with an error pattern consistent with cache staleness
+> (404 / "not found" / "no such resource" against an ID that previously
+> worked), re-derive the value from the live source, update the cache
+> in the relevant memory file, then retry the operation. Don't blindly
+> retry with the stale value, and don't ask the user — the operational
+> cache is the agent's responsibility to maintain.
+
+**Why:** Per rule 10, project-specific operational caches live in memory
+bodies (not the doc) — they're local shortcuts that bypass repeated API
+queries. They drift silently when the underlying resource changes (board
+rename, workflow file moved, ID-bearing entity recreated). Without a
+refresh-on-failure rule, the agent's options are: (a) retry blindly and
+fail again, (b) ask the user "what's the new ID?", or (c) silently skip
+the operation. All three are bad. A "stale → refresh → retry once"
+pattern catches drift loudly, self-heals, and doesn't burn user attention.
+
+**Why not refresh proactively at every task start?** Most tasks don't
+touch the cached resource, so a proactive refresh is wasteful — both in
+API calls and in conversation context. First-failure refresh is the
+sweet spot: cheap when the cache is valid (the common case), self-healing
+when it isn't.
+
+**How to apply:**
+
+When using a cached value in an operation:
+
+1. Run the operation with the cached value.
+2. If it fails with a staleness-suggesting error:
+   - Re-derive from the live source (specific command depends on what
+     type of value — see the table below).
+   - Update the cached value in the relevant `feedback_*.md` memory file.
+   - Retry the operation with the fresh value.
+3. If the fresh-derived value also fails: escalate to the user (the
+   problem isn't cache staleness).
+
+**What counts as a staleness-pattern error:**
+
+- 404 / "not found" against a known-cached ID.
+- "Project not found" / "field not found" against a project-board operation.
+- "No such file or directory" against a known-cached path.
+- Permission errors that suggest the resource was recreated under
+  different ownership.
+
+**NOT** staleness-pattern errors (different handling needed):
+
+- Rate limiting (429) — back off and retry.
+- Network timeouts — retry, no cache change.
+- Validation errors (400) — fix the input, no cache change.
+- Auth-token expiry — re-auth, no cache change.
+
+**Common cache types and their re-derive sources:**
+
+| Cache | Re-derive command |
+|---|---|
+| Project board IDs (Project, field, option) | `gh api graphql` query (see §2 for shape) |
+| GitHub repo metadata | `gh api repos/<owner>/<repo>` |
+| File paths in the project | `find` / `Glob` |
+| External service IDs (Slack channel, JIRA project, etc.) | each service's API |
+
 ---
 
 ## Adapting these conventions to other projects
@@ -463,13 +531,16 @@ When porting to another project:
   **How to apply** that needs replacement with the new project's IDs.
 - **Rule 3 (default project)** has the project number / owner hardcoded —
   swap for your project's equivalents.
-- **Rule 7 (public-repo scan)** only applies if the repo is public. Skip it
+- **Rule 7 (Co-Authored-By trailer)** assumes Claude; for other agents
+  (Cursor, Aider, etc.) adjust the trailer format to match what the agent
+  actually identifies as.
+- **Rule 8 (public-repo scan)** only applies if the repo is public. Skip it
   for private repos, but consider keeping the secrets-scan portion anyway —
   leaked credentials in private-repo history are still a risk if the repo's
   visibility ever changes.
-- **Rule 8 (long-running branch CI)** assumes GitHub Actions; adapt the
+- **Rule 9 (long-running branch CI)** assumes GitHub Actions; adapt the
   "extend the workflow" mechanics for other CI systems (GitLab CI, Buildkite,
   etc.).
-- **Rule 9 (Co-Authored-By trailer)** assumes Claude; for other agents
-  (Cursor, Aider, etc.) adjust the trailer format to match what the agent
-  actually identifies as.
+- **Rule 11 (refresh stale caches)** transfers as a concept; the specific
+  re-derive commands depend on what type of cache value is at stake (project
+  board IDs, file paths, external service IDs, etc.).


### PR DESCRIPTION
## Summary

Codifies the working agreements developed during the `nodes-rebuild` work into a portable doc at `docs/AI-COLLABORATION-CONVENTIONS.md`. Each of the nine rules is stated as a one-line directive (copy-pasteable into other projects' agent instructions) with a co-located **Why** and **How to apply** section.

The doc covers three groups:

- **Ticket / project-board hygiene:** ticket sizing for stream-timeout safety, Todo → In Progress → Done lifecycle, default-project membership.
- **PR conventions:** Files-changed section, docs-and-tests parity, Test-expectations table (when applicable), Co-Authored-By trailer with the live model name.
- **Repo-level practices:** public-repo diff scan, long-running-branch CI workflow as the first action.

Cross-references existing frameworks (Definition of Done, [Google's Small CLs](https://google.github.io/eng-practices/review/developer/small-cls.html), [Trunk-Based Development](https://trunkbaseddevelopment.com/), OpenSSF Scorecard) under each rule where they overlap, and an "Adapting to other projects" section flags which rules carry project-specific bindings (board IDs, project numbers, agent name).

## Files changed

- **docs/AI-COLLABORATION-CONVENTIONS.md** — New file. Quick-reference rule list, three category sections (ticket/board, PR, repo-level) with each rule + Why + How to apply, plus a porting-guide section at the end.

## Test plan

- [x] No code changes — purely documentation.
- [ ] Render the doc in the GitHub UI and confirm tables, code blocks, and links display correctly.

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none** (only `dcltdw` / `David Leung` — already public via the repo owner identity)
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)