### PR TITLE
Phase 2c: Plots + plot membership (#88)

### DIFF
--- a/backend/src/controllers/PlotController.cpp
+++ b/backend/src/controllers/PlotController.cpp
@@ -1,0 +1,716 @@
+#include "PlotController.h"
+#include "AuditLog.h"
+#include "ErrorResponse.h"
+#include "NodeController.h"  // MAX_NODE_DEPTH for the resolve CTE
+#include <drogon/drogon.h>
+
+// Phase 2c (#88): plots are tenant-scoped narrative groupings that tie
+// together places (nodes) and content (notes) across one or more maps.
+// Two parallel junction tables (plot_nodes, plot_notes) hold the
+// membership; CASCADE on either side handles cleanup.
+//
+// Read endpoints are open to any tenant member (TenantFilter enforces).
+// Write endpoints (CRUD + membership add/remove) require tenantRole IN
+// ('admin', 'editor'). The membership listing applies the same node and
+// note effective-visibility filters from #99 / #87, so plot members the
+// caller can't otherwise see don't leak through this endpoint.
+
+static int callerUserId(const drogon::HttpRequestPtr& req) {
+    try { return req->getAttributes()->get<int>("userId"); }
+    catch (...) { return 0; }
+}
+
+namespace {
+
+bool isTenantAdmin(const drogon::HttpRequestPtr& req) {
+    try {
+        return req->getAttributes()->get<std::string>("tenantRole") == "admin";
+    } catch (...) { return false; }
+}
+
+bool isTenantEditorOrAdmin(const drogon::HttpRequestPtr& req) {
+    try {
+        const auto role = req->getAttributes()->get<std::string>("tenantRole");
+        return role == "admin" || role == "editor";
+    } catch (...) { return false; }
+}
+
+Json::Value rowToPlot(const drogon::orm::Row& row) {
+    Json::Value p;
+    p["id"]          = row["id"].as<int>();
+    p["tenantId"]    = row["tenant_id"].as<int>();
+    p["name"]        = row["name"].as<std::string>();
+    p["description"] = row["description"].isNull()
+                         ? "" : row["description"].as<std::string>();
+    p["createdBy"]   = row["created_by"].as<int>();
+    p["createdAt"]   = row["created_at"].as<std::string>();
+    p["updatedAt"]   = row["updated_at"].as<std::string>();
+    return p;
+}
+
+Json::Value rowToNodeMember(const drogon::orm::Row& row) {
+    Json::Value n;
+    n["id"]                 = row["id"].as<int>();
+    n["mapId"]              = row["map_id"].as<int>();
+    n["parentId"]           = row["parent_id"].isNull()
+                                ? Json::Value()
+                                : Json::Value(row["parent_id"].as<int>());
+    n["name"]               = row["name"].as<std::string>();
+    n["color"]              = row["color"].isNull()
+                                ? Json::Value()
+                                : Json::Value(row["color"].as<std::string>());
+    n["visibilityOverride"] = row["visibility_override"].as<bool>();
+    return n;
+}
+
+Json::Value rowToNoteMember(const drogon::orm::Row& row) {
+    Json::Value n;
+    n["id"]                 = row["id"].as<int>();
+    n["nodeId"]             = row["node_id"].as<int>();
+    n["mapId"]              = row["map_id"].as<int>();
+    n["title"]              = row["title"].isNull() ? "" : row["title"].as<std::string>();
+    n["pinned"]             = row["pinned"].as<bool>();
+    n["color"]              = row["color"].isNull()
+                                ? Json::Value()
+                                : Json::Value(row["color"].as<std::string>());
+    n["visibilityOverride"] = row["visibility_override"].as<bool>();
+    return n;
+}
+
+// ─── Plot-member visibility CTEs ─────────────────────────────────────────────
+// Adapted from #99 (NodeController) and #87 (NoteController). The shape is:
+// the recursive walk's anchor is restricted to the *plot's members*
+// (instead of all nodes on a map), then `node_visible_starts` and
+// `note_visible` are computed exactly as in those controllers. This keeps
+// the work proportional to plot membership, not whole maps.
+
+const std::string PLOT_NODE_VISIBILITY_CTE =
+    "WITH RECURSIVE node_resolve AS ("
+    "  SELECT nd.id AS start_id, nd.id AS cur_id, nd.parent_id, "
+    "         nd.visibility_override, 0 AS depth "
+    "  FROM nodes nd JOIN plot_nodes pn ON pn.node_id = nd.id AND pn.plot_id = ? "
+    "  UNION ALL "
+    "  SELECT r.start_id, p.id, p.parent_id, p.visibility_override, r.depth + 1 "
+    "  FROM node_resolve r JOIN nodes p ON p.id = r.parent_id "
+    "  WHERE r.visibility_override = FALSE AND r.depth < " +
+        std::to_string(MAX_NODE_DEPTH) +
+    "), node_visible_starts AS ( "
+    "  SELECT DISTINCT r.start_id FROM node_resolve r "
+    "  JOIN node_visibility nv "
+    "       ON nv.node_id = r.cur_id AND r.visibility_override = TRUE "
+    "  JOIN visibility_group_members vgm "
+    "       ON vgm.visibility_group_id = nv.visibility_group_id "
+    "  WHERE vgm.user_id = ? "
+    ") ";
+
+// For notes, the resolve walks: (note's attached node) → its parent chain.
+// Anchor = nodes attached to a note that's a member of this plot.
+const std::string PLOT_NOTE_VISIBILITY_CTE =
+    "WITH RECURSIVE node_resolve AS ("
+    "  SELECT nd.id AS start_id, nd.id AS cur_id, nd.parent_id, "
+    "         nd.visibility_override, 0 AS depth "
+    "  FROM nodes nd "
+    "  JOIN notes n ON n.node_id = nd.id "
+    "  JOIN plot_notes pnn ON pnn.note_id = n.id AND pnn.plot_id = ? "
+    "  UNION ALL "
+    "  SELECT r.start_id, p.id, p.parent_id, p.visibility_override, r.depth + 1 "
+    "  FROM node_resolve r JOIN nodes p ON p.id = r.parent_id "
+    "  WHERE r.visibility_override = FALSE AND r.depth < " +
+        std::to_string(MAX_NODE_DEPTH) +
+    "), node_visible_starts AS ( "
+    "  SELECT DISTINCT r.start_id FROM node_resolve r "
+    "  JOIN node_visibility nv "
+    "       ON nv.node_id = r.cur_id AND r.visibility_override = TRUE "
+    "  JOIN visibility_group_members vgm "
+    "       ON vgm.visibility_group_id = nv.visibility_group_id "
+    "  WHERE vgm.user_id = ? "
+    "), note_visible AS ( "
+    "  SELECT n.id AS visible_note_id FROM notes n "
+    "  JOIN plot_notes pnn ON pnn.note_id = n.id AND pnn.plot_id = ? "
+    "  WHERE (n.visibility_override = TRUE "
+    "         AND EXISTS (SELECT 1 FROM note_visibility nv2 "
+    "                     JOIN visibility_group_members vgm2 "
+    "                          ON vgm2.visibility_group_id = nv2.visibility_group_id "
+    "                     WHERE nv2.note_id = n.id AND vgm2.user_id = ?)) "
+    "     OR (n.visibility_override = FALSE "
+    "         AND n.node_id IN (SELECT start_id FROM node_visible_starts)) "
+    ") ";
+
+}  // anonymous namespace
+
+// ─── GET /api/v1/tenants/{tid}/plots ─────────────────────────────────────────
+
+void PlotController::listPlots(
+    const drogon::HttpRequestPtr& /*req*/,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId) {
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT id, tenant_id, name, description, created_by, created_at, updated_at "
+        "FROM plots WHERE tenant_id = ? ORDER BY name ASC",
+        [callback](const drogon::orm::Result& r) {
+            Json::Value arr(Json::arrayValue);
+            for (const auto& row : r) arr.append(rowToPlot(row));
+            callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to fetch plots"));
+        },
+        tenantId);
+}
+
+// ─── POST /api/v1/tenants/{tid}/plots ────────────────────────────────────────
+
+void PlotController::createPlot(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId) {
+
+    if (!isTenantEditorOrAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Plot management requires editor or admin role"));
+        return;
+    }
+
+    int userId = callerUserId(req);
+    auto body  = req->getJsonObject();
+    if (!body || !(*body)["name"]) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "name is required"));
+        return;
+    }
+
+    std::string name        = (*body)["name"].asString();
+    std::string description = (*body).get("description", "").asString();
+
+    if (name.empty()) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "name must not be empty"));
+        return;
+    }
+    if (!checkMaxLen("name", name, MAX_NAME_LEN, callback)) return;
+    if (!checkMaxLen("description", description, MAX_DESCRIPTION_LEN, callback)) return;
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "INSERT INTO plots (tenant_id, name, description, created_by) "
+        "VALUES (?, ?, NULLIF(?, ''), ?)",
+        [callback, req, tenantId, userId, name, description]
+        (const drogon::orm::Result& r) {
+            int newId = static_cast<int>(r.insertId());
+            Json::Value p;
+            p["id"]          = newId;
+            p["tenantId"]    = tenantId;
+            p["name"]        = name;
+            p["description"] = description;
+            p["createdBy"]   = userId;
+            Json::Value detail;
+            detail["plotId"] = newId;
+            AuditLog::record("plot_create", req, userId, 0, tenantId, detail);
+            auto resp = drogon::HttpResponse::newHttpJsonResponse(p);
+            resp->setStatusCode(drogon::k201Created);
+            callback(resp);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to create plot"));
+        },
+        tenantId, name, description, userId);
+}
+
+// ─── GET /api/v1/tenants/{tid}/plots/{id} ────────────────────────────────────
+
+void PlotController::getPlot(
+    const drogon::HttpRequestPtr& /*req*/,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id) {
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT id, tenant_id, name, description, created_by, created_at, updated_at "
+        "FROM plots WHERE id = ? AND tenant_id = ?",
+        [callback](const drogon::orm::Result& r) {
+            if (r.empty()) {
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "Plot not found"));
+                return;
+            }
+            callback(drogon::HttpResponse::newHttpJsonResponse(rowToPlot(r[0])));
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to fetch plot"));
+        },
+        id, tenantId);
+}
+
+// ─── PUT /api/v1/tenants/{tid}/plots/{id} ────────────────────────────────────
+
+void PlotController::updatePlot(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id) {
+
+    if (!isTenantEditorOrAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Plot management requires editor or admin role"));
+        return;
+    }
+
+    int userId = callerUserId(req);
+    auto body  = req->getJsonObject();
+    if (!body) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "Request body required"));
+        return;
+    }
+
+    std::string name        = (*body).get("name", "").asString();
+    std::string description = (*body).get("description", "").asString();
+    bool hasDescription     = body->isMember("description");
+
+    if (!checkMaxLen("name", name, MAX_NAME_LEN, callback)) return;
+    if (!checkMaxLen("description", description, MAX_DESCRIPTION_LEN, callback)) return;
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "UPDATE plots SET "
+        "  name        = IF(?='', name, ?), "
+        "  description = IF(?, NULLIF(?, ''), description) "
+        "WHERE id = ? AND tenant_id = ?",
+        [callback, req, userId, tenantId, id]
+        (const drogon::orm::Result& r) {
+            if (r.affectedRows() == 0) {
+                // Either the plot doesn't exist in this tenant, or the
+                // submitted body matched current values exactly. The
+                // latter still represents a no-op success; do an
+                // existence check to disambiguate.
+                auto db2 = drogon::app().getDbClient();
+                db2->execSqlAsync(
+                    "SELECT 1 FROM plots WHERE id = ? AND tenant_id = ?",
+                    [callback, req, userId, tenantId, id]
+                    (const drogon::orm::Result& r2) {
+                        if (r2.empty()) {
+                            callback(errorResponse(drogon::k404NotFound,
+                                "not_found", "Plot not found"));
+                            return;
+                        }
+                        Json::Value detail; detail["plotId"] = id;
+                        AuditLog::record("plot_update", req, userId, 0, tenantId, detail);
+                        Json::Value v; v["id"] = id; v["updated"] = true;
+                        callback(drogon::HttpResponse::newHttpJsonResponse(v));
+                    },
+                    [callback](const drogon::orm::DrogonDbException&) {
+                        callback(errorResponse(drogon::k500InternalServerError,
+                            "db_error", "Failed to verify plot"));
+                    },
+                    id, tenantId);
+                return;
+            }
+            Json::Value detail; detail["plotId"] = id;
+            AuditLog::record("plot_update", req, userId, 0, tenantId, detail);
+            Json::Value v; v["id"] = id; v["updated"] = true;
+            callback(drogon::HttpResponse::newHttpJsonResponse(v));
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to update plot"));
+        },
+        name, name,
+        hasDescription, description,
+        id, tenantId);
+}
+
+// ─── DELETE /api/v1/tenants/{tid}/plots/{id} ─────────────────────────────────
+
+void PlotController::deletePlot(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id) {
+
+    if (!isTenantEditorOrAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Plot management requires editor or admin role"));
+        return;
+    }
+
+    int userId = callerUserId(req);
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "DELETE FROM plots WHERE id = ? AND tenant_id = ?",
+        [callback, req, userId, tenantId, id](const drogon::orm::Result& r) {
+            if (r.affectedRows() == 0) {
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "Plot not found"));
+                return;
+            }
+            Json::Value detail; detail["plotId"] = id;
+            AuditLog::record("plot_delete", req, userId, 0, tenantId, detail);
+            auto resp = drogon::HttpResponse::newHttpResponse();
+            resp->setStatusCode(drogon::k204NoContent);
+            callback(resp);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to delete plot"));
+        },
+        id, tenantId);
+}
+
+// ─── GET /api/v1/tenants/{tid}/plots/{id}/members ────────────────────────────
+//
+// Combined response: { nodes: [...], notes: [...] }
+// Visibility-filtered for non-admins using the plot-scoped CTEs above.
+// Map-owner xray bypass is honored per-member (a member's owning map's
+// owner_xray flag short-circuits the visibility predicate for that member).
+
+void PlotController::listMembers(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id) {
+
+    int userId = callerUserId(req);
+    bool isAdmin = isTenantAdmin(req);
+
+    auto db = drogon::app().getDbClient();
+
+    // Step 1: verify the plot exists in this tenant.
+    db->execSqlAsync(
+        "SELECT 1 FROM plots WHERE id = ? AND tenant_id = ?",
+        [callback, req, tenantId, id, userId, isAdmin]
+        (const drogon::orm::Result& r1) {
+            if (r1.empty()) {
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "Plot not found"));
+                return;
+            }
+
+            // Step 2: fetch visible node members. Admins skip the CTE.
+            std::string nodeSql;
+            if (!isAdmin) nodeSql = PLOT_NODE_VISIBILITY_CTE;
+            nodeSql +=
+                "SELECT n.id, n.map_id, n.parent_id, n.name, n.color, n.visibility_override "
+                "FROM nodes n "
+                "JOIN plot_nodes pn ON pn.node_id = n.id AND pn.plot_id = ? "
+                "JOIN maps m ON m.id = n.map_id AND m.tenant_id = ? ";
+            if (!isAdmin) {
+                nodeSql +=
+                    "WHERE ((m.owner_id = ? AND m.owner_xray = TRUE) "
+                    "       OR n.id IN (SELECT start_id FROM node_visible_starts)) ";
+            }
+            nodeSql += "ORDER BY n.created_at ASC";
+
+            // Step 3: fetch visible note members. Admins skip the CTE.
+            std::string noteSql;
+            if (!isAdmin) noteSql = PLOT_NOTE_VISIBILITY_CTE;
+            noteSql +=
+                "SELECT nt.id, nt.node_id, nd.map_id, nt.title, nt.pinned, "
+                "       nt.color, nt.visibility_override "
+                "FROM notes nt "
+                "JOIN plot_notes pnn ON pnn.note_id = nt.id AND pnn.plot_id = ? "
+                "JOIN nodes nd ON nd.id = nt.node_id "
+                "JOIN maps m ON m.id = nd.map_id AND m.tenant_id = ? ";
+            if (!isAdmin) {
+                noteSql +=
+                    "WHERE ((m.owner_id = ? AND m.owner_xray = TRUE) "
+                    "       OR nt.id IN (SELECT visible_note_id FROM note_visible)) ";
+            }
+            noteSql += "ORDER BY nt.pinned DESC, nt.created_at ASC";
+
+            // Sequence: nodes query → notes query → combined response.
+            auto dbN = drogon::app().getDbClient();
+            auto noteFetch = [callback, noteSql, id, tenantId, userId, isAdmin]
+                (Json::Value nodesArr) {
+                auto dbT = drogon::app().getDbClient();
+                auto onNotes = [callback, nodesArr]
+                    (const drogon::orm::Result& rN) mutable {
+                    Json::Value notesArr(Json::arrayValue);
+                    for (const auto& row : rN) notesArr.append(rowToNoteMember(row));
+                    Json::Value out;
+                    out["nodes"] = nodesArr;
+                    out["notes"] = notesArr;
+                    callback(drogon::HttpResponse::newHttpJsonResponse(out));
+                };
+                auto onNotesErr = [callback]
+                    (const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to fetch plot note members"));
+                };
+                if (isAdmin) {
+                    dbT->execSqlAsync(noteSql, onNotes, onNotesErr,
+                        id, tenantId);
+                } else {
+                    // CTE binds: (plotId, userId, plotId, userId, plotId)
+                    // — anchor uses plotId, node_visible_starts uses userId,
+                    // note_visible's outer JOIN uses plotId, override-TRUE
+                    // EXISTS uses userId, then SELECT JOIN uses plotId.
+                    dbT->execSqlAsync(noteSql, onNotes, onNotesErr,
+                        id, userId, id, userId,   // CTE
+                        id, tenantId, userId);    // SELECT WHERE + xray
+                }
+            };
+
+            auto onNodes = [callback, noteFetch]
+                (const drogon::orm::Result& rN) mutable {
+                Json::Value nodesArr(Json::arrayValue);
+                for (const auto& row : rN) nodesArr.append(rowToNodeMember(row));
+                noteFetch(nodesArr);
+            };
+            auto onNodesErr = [callback]
+                (const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Failed to fetch plot node members"));
+            };
+
+            if (isAdmin) {
+                dbN->execSqlAsync(nodeSql, onNodes, onNodesErr, id, tenantId);
+            } else {
+                dbN->execSqlAsync(nodeSql, onNodes, onNodesErr,
+                    id, userId,             // CTE (plotId, userId)
+                    id, tenantId, userId);  // SELECT WHERE + xray
+            }
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to verify plot"));
+        },
+        id, tenantId);
+}
+
+// ─── POST /api/v1/tenants/{tid}/plots/{id}/nodes ─────────────────────────────
+//
+// Body: { nodeId: number }
+// Idempotent: re-attaching an already-attached node returns 201 with no
+// duplicate row (INSERT IGNORE). Cross-tenant defense: the node's owning
+// map must live in this tenant.
+
+void PlotController::addNode(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id) {
+
+    if (!isTenantEditorOrAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Plot management requires editor or admin role"));
+        return;
+    }
+
+    int userId = callerUserId(req);
+    auto body  = req->getJsonObject();
+    if (!body || !body->isMember("nodeId") || !(*body)["nodeId"].isInt()) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "nodeId (integer) is required"));
+        return;
+    }
+    int nodeId = (*body)["nodeId"].asInt();
+
+    // Verify both the plot AND the node live in this tenant before
+    // inserting. Single existence query joins through the appropriate
+    // tenant scopes.
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT (SELECT COUNT(*) FROM plots WHERE id = ? AND tenant_id = ?) AS plot_ok, "
+        "       (SELECT COUNT(*) FROM nodes nd JOIN maps m ON m.id = nd.map_id "
+        "        WHERE nd.id = ? AND m.tenant_id = ?) AS node_ok",
+        [callback, req, tenantId, id, nodeId, userId]
+        (const drogon::orm::Result& r1) {
+            int plotOk = r1[0]["plot_ok"].as<int>();
+            int nodeOk = r1[0]["node_ok"].as<int>();
+            if (plotOk == 0) {
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "Plot not found"));
+                return;
+            }
+            if (nodeOk == 0) {
+                callback(errorResponse(drogon::k400BadRequest,
+                    "bad_request", "Node not found in this tenant"));
+                return;
+            }
+
+            auto dbI = drogon::app().getDbClient();
+            dbI->execSqlAsync(
+                "INSERT IGNORE INTO plot_nodes (plot_id, node_id) VALUES (?, ?)",
+                [callback, req, tenantId, id, nodeId, userId]
+                (const drogon::orm::Result&) {
+                    Json::Value detail;
+                    detail["plotId"] = id;
+                    detail["nodeId"] = nodeId;
+                    AuditLog::record("plot_node_add", req, userId, 0, tenantId, detail);
+                    Json::Value v;
+                    v["plotId"] = id;
+                    v["nodeId"] = nodeId;
+                    auto resp = drogon::HttpResponse::newHttpJsonResponse(v);
+                    resp->setStatusCode(drogon::k201Created);
+                    callback(resp);
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to attach node"));
+                },
+                id, nodeId);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to verify plot or node"));
+        },
+        id, tenantId, nodeId, tenantId);
+}
+
+// ─── DELETE /api/v1/tenants/{tid}/plots/{id}/nodes/{nodeId} ──────────────────
+
+void PlotController::removeNode(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id, int nodeId) {
+
+    if (!isTenantEditorOrAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Plot management requires editor or admin role"));
+        return;
+    }
+
+    int userId = callerUserId(req);
+    auto db = drogon::app().getDbClient();
+    // DELETE only if the plot is in this tenant. The plot_nodes row's
+    // existence is the success signal — no row → 404.
+    db->execSqlAsync(
+        "DELETE pn FROM plot_nodes pn "
+        "JOIN plots p ON p.id = pn.plot_id "
+        "WHERE pn.plot_id = ? AND pn.node_id = ? AND p.tenant_id = ?",
+        [callback, req, userId, tenantId, id, nodeId]
+        (const drogon::orm::Result& r) {
+            if (r.affectedRows() == 0) {
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "Plot or node membership not found"));
+                return;
+            }
+            Json::Value detail;
+            detail["plotId"] = id;
+            detail["nodeId"] = nodeId;
+            AuditLog::record("plot_node_remove", req, userId, 0, tenantId, detail);
+            auto resp = drogon::HttpResponse::newHttpResponse();
+            resp->setStatusCode(drogon::k204NoContent);
+            callback(resp);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to detach node"));
+        },
+        id, nodeId, tenantId);
+}
+
+// ─── POST /api/v1/tenants/{tid}/plots/{id}/notes ─────────────────────────────
+
+void PlotController::addNote(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id) {
+
+    if (!isTenantEditorOrAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Plot management requires editor or admin role"));
+        return;
+    }
+
+    int userId = callerUserId(req);
+    auto body  = req->getJsonObject();
+    if (!body || !body->isMember("noteId") || !(*body)["noteId"].isInt()) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "noteId (integer) is required"));
+        return;
+    }
+    int noteId = (*body)["noteId"].asInt();
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT (SELECT COUNT(*) FROM plots WHERE id = ? AND tenant_id = ?) AS plot_ok, "
+        "       (SELECT COUNT(*) FROM notes n "
+        "        JOIN nodes nd ON nd.id = n.node_id "
+        "        JOIN maps m ON m.id = nd.map_id "
+        "        WHERE n.id = ? AND m.tenant_id = ?) AS note_ok",
+        [callback, req, tenantId, id, noteId, userId]
+        (const drogon::orm::Result& r1) {
+            int plotOk = r1[0]["plot_ok"].as<int>();
+            int noteOk = r1[0]["note_ok"].as<int>();
+            if (plotOk == 0) {
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "Plot not found"));
+                return;
+            }
+            if (noteOk == 0) {
+                callback(errorResponse(drogon::k400BadRequest,
+                    "bad_request", "Note not found in this tenant"));
+                return;
+            }
+
+            auto dbI = drogon::app().getDbClient();
+            dbI->execSqlAsync(
+                "INSERT IGNORE INTO plot_notes (plot_id, note_id) VALUES (?, ?)",
+                [callback, req, tenantId, id, noteId, userId]
+                (const drogon::orm::Result&) {
+                    Json::Value detail;
+                    detail["plotId"] = id;
+                    detail["noteId"] = noteId;
+                    AuditLog::record("plot_note_add", req, userId, 0, tenantId, detail);
+                    Json::Value v;
+                    v["plotId"] = id;
+                    v["noteId"] = noteId;
+                    auto resp = drogon::HttpResponse::newHttpJsonResponse(v);
+                    resp->setStatusCode(drogon::k201Created);
+                    callback(resp);
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to attach note"));
+                },
+                id, noteId);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to verify plot or note"));
+        },
+        id, tenantId, noteId, tenantId);
+}
+
+// ─── DELETE /api/v1/tenants/{tid}/plots/{id}/notes/{noteId} ──────────────────
+
+void PlotController::removeNote(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int id, int noteId) {
+
+    if (!isTenantEditorOrAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Plot management requires editor or admin role"));
+        return;
+    }
+
+    int userId = callerUserId(req);
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "DELETE pnn FROM plot_notes pnn "
+        "JOIN plots p ON p.id = pnn.plot_id "
+        "WHERE pnn.plot_id = ? AND pnn.note_id = ? AND p.tenant_id = ?",
+        [callback, req, userId, tenantId, id, noteId]
+        (const drogon::orm::Result& r) {
+            if (r.affectedRows() == 0) {
+                callback(errorResponse(drogon::k404NotFound,
+                    "not_found", "Plot or note membership not found"));
+                return;
+            }
+            Json::Value detail;
+            detail["plotId"] = id;
+            detail["noteId"] = noteId;
+            AuditLog::record("plot_note_remove", req, userId, 0, tenantId, detail);
+            auto resp = drogon::HttpResponse::newHttpResponse();
+            resp->setStatusCode(drogon::k204NoContent);
+            callback(resp);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Failed to detach note"));
+        },
+        id, noteId, tenantId);
+}

--- a/backend/src/controllers/PlotController.h
+++ b/backend/src/controllers/PlotController.h
@@ -1,0 +1,110 @@
+#pragma once
+#include <drogon/HttpController.h>
+
+/**
+ * PlotController — tenant-scoped narrative grouping (Phase 2c, #88).
+ *
+ * A plot is a story-arc grouping: it ties together places (nodes) and
+ * content (notes) across one or more maps within a single tenant. Two
+ * parallel junction tables (`plot_nodes`, `plot_notes`) hold the
+ * membership; CASCADE works naturally on either side.
+ *
+ * Plot CRUD:
+ *   GET    /api/v1/tenants/{tenantId}/plots
+ *   POST   /api/v1/tenants/{tenantId}/plots
+ *   GET    /api/v1/tenants/{tenantId}/plots/{id}
+ *   PUT    /api/v1/tenants/{tenantId}/plots/{id}
+ *   DELETE /api/v1/tenants/{tenantId}/plots/{id}
+ *
+ * Membership:
+ *   GET    /api/v1/tenants/{tenantId}/plots/{id}/members
+ *   POST   /api/v1/tenants/{tenantId}/plots/{id}/nodes
+ *   DELETE /api/v1/tenants/{tenantId}/plots/{id}/nodes/{nodeId}
+ *   POST   /api/v1/tenants/{tenantId}/plots/{id}/notes
+ *   DELETE /api/v1/tenants/{tenantId}/plots/{id}/notes/{noteId}
+ *
+ * Authorization:
+ *   - Read endpoints: any tenant member (TenantFilter enforces).
+ *   - Write endpoints (create/update/delete plot, attach/detach members):
+ *     tenant role must be admin or editor.
+ *
+ * Plot membership respects node/note visibility: GET /members filters out
+ * members the caller can't see, using the same effective-visibility CTEs
+ * from #99 (nodes) and #87 (notes), adapted to walk only the plot's
+ * members rather than every node on a map.
+ *
+ * Body shapes:
+ *   POST /plots         — { name, description? }
+ *   PUT  /plots/{id}    — { name?, description? } (all optional)
+ *   POST /nodes         — { nodeId }
+ *   POST /notes         — { noteId }
+ *
+ * Idempotency: POST /nodes and POST /notes use INSERT IGNORE — re-attaching
+ * an already-attached member is a no-op (returns 201 either way).
+ */
+class PlotController : public drogon::HttpController<PlotController> {
+public:
+    METHOD_LIST_BEGIN
+        ADD_METHOD_TO(PlotController::listPlots,
+                      "/api/v1/tenants/{tenantId}/plots",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+        ADD_METHOD_TO(PlotController::createPlot,
+                      "/api/v1/tenants/{tenantId}/plots",
+                      drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(PlotController::getPlot,
+                      "/api/v1/tenants/{tenantId}/plots/{id}",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+        ADD_METHOD_TO(PlotController::updatePlot,
+                      "/api/v1/tenants/{tenantId}/plots/{id}",
+                      drogon::Put, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(PlotController::deletePlot,
+                      "/api/v1/tenants/{tenantId}/plots/{id}",
+                      drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(PlotController::listMembers,
+                      "/api/v1/tenants/{tenantId}/plots/{id}/members",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+        ADD_METHOD_TO(PlotController::addNode,
+                      "/api/v1/tenants/{tenantId}/plots/{id}/nodes",
+                      drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(PlotController::removeNode,
+                      "/api/v1/tenants/{tenantId}/plots/{id}/nodes/{nodeId}",
+                      drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(PlotController::addNote,
+                      "/api/v1/tenants/{tenantId}/plots/{id}/notes",
+                      drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(PlotController::removeNote,
+                      "/api/v1/tenants/{tenantId}/plots/{id}/notes/{noteId}",
+                      drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
+    METHOD_LIST_END
+
+    void listPlots(const drogon::HttpRequestPtr&,
+                   std::function<void(const drogon::HttpResponsePtr&)>&&,
+                   int tenantId);
+    void createPlot(const drogon::HttpRequestPtr&,
+                    std::function<void(const drogon::HttpResponsePtr&)>&&,
+                    int tenantId);
+    void getPlot(const drogon::HttpRequestPtr&,
+                 std::function<void(const drogon::HttpResponsePtr&)>&&,
+                 int tenantId, int id);
+    void updatePlot(const drogon::HttpRequestPtr&,
+                    std::function<void(const drogon::HttpResponsePtr&)>&&,
+                    int tenantId, int id);
+    void deletePlot(const drogon::HttpRequestPtr&,
+                    std::function<void(const drogon::HttpResponsePtr&)>&&,
+                    int tenantId, int id);
+    void listMembers(const drogon::HttpRequestPtr&,
+                     std::function<void(const drogon::HttpResponsePtr&)>&&,
+                     int tenantId, int id);
+    void addNode(const drogon::HttpRequestPtr&,
+                 std::function<void(const drogon::HttpResponsePtr&)>&&,
+                 int tenantId, int id);
+    void removeNode(const drogon::HttpRequestPtr&,
+                    std::function<void(const drogon::HttpResponsePtr&)>&&,
+                    int tenantId, int id, int nodeId);
+    void addNote(const drogon::HttpRequestPtr&,
+                 std::function<void(const drogon::HttpResponsePtr&)>&&,
+                 int tenantId, int id);
+    void removeNote(const drogon::HttpRequestPtr&,
+                    std::function<void(const drogon::HttpResponsePtr&)>&&,
+                    int tenantId, int id, int noteId);
+};

--- a/backend/tests/run-tests.py
+++ b/backend/tests/run-tests.py
@@ -48,6 +48,7 @@ FAST_TESTS = [
     "test_19_node_visibility.py",
     "test_20_node_visibility_filter.py",
     "test_21_note_visibility.py",
+    "test_22_plots.py",
 ]
 
 # test_14_nodes.py landed in #96 (NodeController CRUD + tree + max-depth).
@@ -59,6 +60,8 @@ FAST_TESTS = [
 #   + read-time filtering + owner_xray bypass on GET nodes / GET nodes/{id}).
 # test_21_note_visibility.py landed in #87 (note tagging + filtering;
 #   note → node → parent-chain inheritance).
+# test_22_plots.py landed in #88 (PlotController CRUD + membership +
+#   visibility filter on listMembers).
 # Annotation/note-group tests are gone permanently — those concepts were
 # consolidated into nodes and visibility groups during the rebuild.
 
@@ -83,6 +86,7 @@ TEST_DESCRIPTIONS = {
     19: "Node visibility tagging (set/get override + groupIds on nodes)",
     20: "Node visibility read filter (admin bypass, inheritance, owner_xray)",
     21: "Note visibility (tagging + filter; note → node → parent-chain)",
+    22: "Plots (CRUD, membership, visibility filter on listMembers)",
 }
 
 

--- a/backend/tests/test_22_plots.py
+++ b/backend/tests/test_22_plots.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""test_22_plots.py — Phase 2c (#88): Plots + plot membership.
+
+Covers:
+  - Plot CRUD (list, create, get, update, delete)
+  - Membership (add/remove nodes, add/remove notes; idempotent; cross-tenant rejected)
+  - Combined GET .../members response shape and ordering
+  - Visibility filter on listMembers (admin bypass, non-admin filtering,
+    owner_xray bypass)
+  - Auth: editor/admin can write; viewer can only read
+  - Cross-tenant blocked at TenantFilter
+
+Same SQL fixtures as test_20/test_21:
+  - Move B's user.org_id into A's org so visibility-group membership is allowed
+  - Insert B as 'viewer' in A's tenant_members (non-admin tenant member)
+  - Grant B map view permission so map gating doesn't reject the read
+"""
+
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import (
+    reset_counters, report, assert_status, assert_json_field, assert_true,
+    http_post, http_get, http_put, http_delete,
+    register_user, json_field, mysql_query,
+)
+
+reset_counters()
+RUN_ID = os.getpid()
+
+print("=== Plot Tests ===")
+
+# ─── Setup ───────────────────────────────────────────────────────────────────
+
+TOKEN_A = register_user(f"t22_a_{RUN_ID}", f"t22_a_{RUN_ID}@test.com", "testpass123")
+_, body_a = http_post("/auth/login",
+    {"email": f"t22_a_{RUN_ID}@test.com", "password": "testpass123"})
+TENANT_A   = json_field(body_a, ["tenantId"])
+USER_A_ID  = json_field(body_a, ["user", "id"])
+
+TOKEN_B = register_user(f"t22_b_{RUN_ID}", f"t22_b_{RUN_ID}@test.com", "testpass123")
+_, body_b = http_post("/auth/login",
+    {"email": f"t22_b_{RUN_ID}@test.com", "password": "testpass123"})
+TENANT_B  = json_field(body_b, ["tenantId"])
+USER_B_ID = json_field(body_b, ["user", "id"])
+
+# Move B into A's org so visibility-group membership is allowed; insert as
+# viewer in A's tenant_members so B exercises the non-admin paths.
+A_ORG_ID = mysql_query(f"SELECT org_id FROM users WHERE id={USER_A_ID};")
+mysql_query(f"UPDATE users SET org_id={A_ORG_ID} WHERE id={USER_B_ID};")
+mysql_query(
+    f"INSERT INTO tenant_members (tenant_id, user_id, role) "
+    f"VALUES ({TENANT_A}, {USER_B_ID}, 'viewer');")
+
+# A creates a map.
+_, body = http_post(f"/tenants/{TENANT_A}/maps", {
+    "title": "Plot Test Map",
+    "coordinateSystem": {"type": "wgs84", "center": {"lat": 0, "lng": 0}, "zoom": 3},
+}, TOKEN_A)
+MAP_ID = json_field(body, ["id"])
+mysql_query(
+    f"INSERT INTO map_permissions (map_id, user_id, level) "
+    f"VALUES ({MAP_ID}, {USER_B_ID}, 'view');")
+
+# Two visibility groups; add B to Players.
+VG_BASE = f"/tenants/{TENANT_A}/visibility-groups"
+_, body = http_post(VG_BASE, {"name": "Players"}, TOKEN_A)
+G_PLAYERS = json_field(body, ["id"])
+_, body = http_post(VG_BASE, {"name": "GMs"}, TOKEN_A)
+G_GMS = json_field(body, ["id"])
+http_post(f"{VG_BASE}/{G_PLAYERS}/members", {"userId": USER_B_ID}, TOKEN_A)
+
+# Tree with mixed visibility:
+#   Root (no override)
+#   ├── PlayersNode  (override=TRUE, [Players])
+#   └── GmNode       (override=TRUE, [GMs])
+NODES_BASE = f"/tenants/{TENANT_A}/maps/{MAP_ID}/nodes"
+
+def mknode(name, parent_id=None):
+    body_in = {"name": name}
+    if parent_id is not None:
+        body_in["parentId"] = parent_id
+    _, b = http_post(NODES_BASE, body_in, TOKEN_A)
+    return json_field(b, ["id"])
+
+def settag_node(node_id, override, group_ids):
+    http_post(f"{NODES_BASE}/{node_id}/visibility",
+              {"override": override, "groupIds": group_ids}, TOKEN_A)
+
+ROOT          = mknode("Root")
+PLAYERS_NODE  = mknode("PlayersNode", ROOT); settag_node(PLAYERS_NODE, True, [G_PLAYERS])
+GM_NODE       = mknode("GmNode",      ROOT); settag_node(GM_NODE,      True, [G_GMS])
+
+def mknote(node_id, title):
+    _, b = http_post(f"{NODES_BASE}/{node_id}/notes",
+                     {"title": title, "text": "..."}, TOKEN_A)
+    return json_field(b, ["id"])
+
+# Notes: one inheriting Players (visible to B), one inheriting GMs (hidden from B)
+NOTE_PLAYERS = mknote(PLAYERS_NODE, "PlayersNote")  # inherits Players
+NOTE_GM      = mknote(GM_NODE,      "GmNote")       # inherits GMs
+
+PLOTS_BASE = f"/tenants/{TENANT_A}/plots"
+
+# ─── CRUD ────────────────────────────────────────────────────────────────────
+
+print("  --- CRUD ---")
+
+# Empty list initially
+status, body = http_get(PLOTS_BASE, TOKEN_A)
+assert_status("list: empty returns 200", 200, status)
+assert_true("list: array initially empty",
+            isinstance(body, list) and len(body) == 0)
+
+# Create
+status, body = http_post(PLOTS_BASE,
+    {"name": "Story Arc 1", "description": "The opening"}, TOKEN_A)
+assert_status("create: returns 201", 201, status)
+PLOT_1 = json_field(body, ["id"])
+assert_json_field("create: name set",        body, ["name"], "Story Arc 1")
+assert_json_field("create: description set", body, ["description"], "The opening")
+assert_json_field("create: tenantId set",    body, ["tenantId"], str(TENANT_A))
+
+# Validation: missing name
+status, _ = http_post(PLOTS_BASE, {}, TOKEN_A)
+assert_status("create: missing name 400", 400, status)
+
+# Validation: empty name
+status, _ = http_post(PLOTS_BASE, {"name": ""}, TOKEN_A)
+assert_status("create: empty name 400", 400, status)
+
+# Multiple plots can share names (intentional — no UNIQUE)
+status, body = http_post(PLOTS_BASE, {"name": "Story Arc 1"}, TOKEN_A)
+assert_status("create: duplicate name allowed", 201, status)
+PLOT_DUP = json_field(body, ["id"])
+
+# Cross-tenant create blocked at TenantFilter
+status, _ = http_post(PLOTS_BASE, {"name": "X"}, TOKEN_B)
+# B is a member of TENANT_A but role=viewer — should be 403 not 'forbidden role'
+assert_status("create: viewer rejected", 403, status)
+
+# Create another for variety
+status, body = http_post(PLOTS_BASE, {"name": "Sidequest"}, TOKEN_A)
+PLOT_2 = json_field(body, ["id"])
+
+# Get
+status, body = http_get(f"{PLOTS_BASE}/{PLOT_1}", TOKEN_A)
+assert_status("get: returns 200", 200, status)
+assert_json_field("get: name", body, ["name"], "Story Arc 1")
+
+# Get unknown
+status, _ = http_get(f"{PLOTS_BASE}/9999999", TOKEN_A)
+assert_status("get: unknown returns 404", 404, status)
+
+# List shows multiple plots, alphabetical
+status, body = http_get(PLOTS_BASE, TOKEN_A)
+names = [p["name"] for p in body]
+assert_true("list: alphabetical",
+            names == sorted(names))
+assert_true("list: contains all 3 plots", len(body) == 3)
+
+# Update name + description
+status, _ = http_put(f"{PLOTS_BASE}/{PLOT_1}",
+    {"name": "Story Arc One", "description": "Revised"}, TOKEN_A)
+assert_status("update: returns 200", 200, status)
+status, body = http_get(f"{PLOTS_BASE}/{PLOT_1}", TOKEN_A)
+assert_json_field("update: name persisted",        body, ["name"], "Story Arc One")
+assert_json_field("update: description persisted", body, ["description"], "Revised")
+
+# Partial update — name only
+status, _ = http_put(f"{PLOTS_BASE}/{PLOT_1}", {"name": "Renamed"}, TOKEN_A)
+status, body = http_get(f"{PLOTS_BASE}/{PLOT_1}", TOKEN_A)
+assert_json_field("update: partial name change",  body, ["name"], "Renamed")
+assert_json_field("update: description preserved", body, ["description"], "Revised")
+
+# Update unknown
+status, _ = http_put(f"{PLOTS_BASE}/9999999", {"name": "X"}, TOKEN_A)
+assert_status("update: unknown returns 404", 404, status)
+
+# Cross-tenant update blocked
+status, _ = http_put(f"{PLOTS_BASE}/{PLOT_1}", {"name": "X"}, TOKEN_B)
+assert_status("update: viewer rejected", 403, status)
+
+# Delete
+status, _ = http_delete(f"{PLOTS_BASE}/{PLOT_DUP}", TOKEN_A)
+assert_status("delete: returns 204", 204, status)
+status, _ = http_get(f"{PLOTS_BASE}/{PLOT_DUP}", TOKEN_A)
+assert_status("delete: gone", 404, status)
+
+# Delete unknown
+status, _ = http_delete(f"{PLOTS_BASE}/9999999", TOKEN_A)
+assert_status("delete: unknown returns 404", 404, status)
+
+# Viewer can read but not write
+status, _ = http_get(PLOTS_BASE, TOKEN_B)
+assert_status("read: viewer can list", 200, status)
+status, _ = http_get(f"{PLOTS_BASE}/{PLOT_1}", TOKEN_B)
+assert_status("read: viewer can get", 200, status)
+status, _ = http_delete(f"{PLOTS_BASE}/{PLOT_1}", TOKEN_B)
+assert_status("delete: viewer rejected", 403, status)
+
+print("  All CRUD tests passed.")
+
+# ─── Membership ──────────────────────────────────────────────────────────────
+
+print("  --- Membership ---")
+
+# Initially empty members
+status, body = http_get(f"{PLOTS_BASE}/{PLOT_1}/members", TOKEN_A)
+assert_status("members: returns 200", 200, status)
+assert_true("members: nodes empty initially",  body["nodes"] == [])
+assert_true("members: notes empty initially",  body["notes"] == [])
+
+# Attach a node
+status, body = http_post(f"{PLOTS_BASE}/{PLOT_1}/nodes",
+                         {"nodeId": ROOT}, TOKEN_A)
+assert_status("attach: node returns 201", 201, status)
+assert_json_field("attach: plotId in response", body, ["plotId"], str(PLOT_1))
+assert_json_field("attach: nodeId in response", body, ["nodeId"], str(ROOT))
+
+# Idempotent dup-attach (INSERT IGNORE) — still 201, no duplicate row
+status, _ = http_post(f"{PLOTS_BASE}/{PLOT_1}/nodes",
+                      {"nodeId": ROOT}, TOKEN_A)
+assert_status("attach: dup returns 201 (idempotent)", 201, status)
+status, body = http_get(f"{PLOTS_BASE}/{PLOT_1}/members", TOKEN_A)
+assert_true("attach: still 1 node member", len(body["nodes"]) == 1)
+
+# Attach more nodes
+http_post(f"{PLOTS_BASE}/{PLOT_1}/nodes", {"nodeId": PLAYERS_NODE}, TOKEN_A)
+http_post(f"{PLOTS_BASE}/{PLOT_1}/nodes", {"nodeId": GM_NODE}, TOKEN_A)
+
+# Attach notes
+http_post(f"{PLOTS_BASE}/{PLOT_1}/notes", {"noteId": NOTE_PLAYERS}, TOKEN_A)
+http_post(f"{PLOTS_BASE}/{PLOT_1}/notes", {"noteId": NOTE_GM}, TOKEN_A)
+
+# Validation: missing nodeId / noteId
+status, _ = http_post(f"{PLOTS_BASE}/{PLOT_1}/nodes", {}, TOKEN_A)
+assert_status("attach: missing nodeId 400", 400, status)
+status, _ = http_post(f"{PLOTS_BASE}/{PLOT_1}/notes", {}, TOKEN_A)
+assert_status("attach: missing noteId 400", 400, status)
+
+# Cross-tenant defense: B's tenant has no nodes/notes; trying to attach
+# id 9999999 should fail with 400 "not found in this tenant"
+status, _ = http_post(f"{PLOTS_BASE}/{PLOT_1}/nodes",
+                      {"nodeId": 9999999}, TOKEN_A)
+assert_status("attach: unknown nodeId 400", 400, status)
+
+# Unknown plot
+status, _ = http_post(f"{PLOTS_BASE}/9999999/nodes",
+                      {"nodeId": ROOT}, TOKEN_A)
+assert_status("attach: unknown plot 404", 404, status)
+
+# Viewer can't attach
+status, _ = http_post(f"{PLOTS_BASE}/{PLOT_1}/nodes",
+                      {"nodeId": ROOT}, TOKEN_B)
+assert_status("attach: viewer rejected", 403, status)
+
+# Detach
+status, _ = http_delete(f"{PLOTS_BASE}/{PLOT_1}/nodes/{ROOT}", TOKEN_A)
+assert_status("detach: node returns 204", 204, status)
+
+# Detach unknown / non-member
+status, _ = http_delete(f"{PLOTS_BASE}/{PLOT_1}/nodes/{ROOT}", TOKEN_A)
+assert_status("detach: non-member returns 404", 404, status)
+status, _ = http_delete(f"{PLOTS_BASE}/9999999/nodes/{PLAYERS_NODE}", TOKEN_A)
+assert_status("detach: unknown plot 404", 404, status)
+
+# Viewer can't detach
+status, _ = http_delete(f"{PLOTS_BASE}/{PLOT_1}/nodes/{PLAYERS_NODE}", TOKEN_B)
+assert_status("detach: viewer rejected", 403, status)
+
+# Detach a note
+status, _ = http_delete(f"{PLOTS_BASE}/{PLOT_1}/notes/{NOTE_GM}", TOKEN_A)
+assert_status("detach: note returns 204", 204, status)
+http_post(f"{PLOTS_BASE}/{PLOT_1}/notes", {"noteId": NOTE_GM}, TOKEN_A)  # re-attach for filter tests
+
+print("  All membership tests passed.")
+
+# ─── Visibility filter on listMembers ────────────────────────────────────────
+
+print("  --- Visibility filter on listMembers ---")
+
+# Plot now contains: nodes={PlayersNode, GmNode}, notes={NotePlayers, NoteGm}.
+# (ROOT was detached above.)
+
+# Admin sees everything
+status, body = http_get(f"{PLOTS_BASE}/{PLOT_1}/members", TOKEN_A)
+node_ids = {n["id"] for n in body["nodes"]}
+note_ids = {n["id"] for n in body["notes"]}
+assert_true("admin: all node members visible",
+            node_ids == {PLAYERS_NODE, GM_NODE})
+assert_true("admin: all note members visible",
+            note_ids == {NOTE_PLAYERS, NOTE_GM})
+
+# Non-admin (B, in Players) sees only Players-resolved members
+status, body = http_get(f"{PLOTS_BASE}/{PLOT_1}/members", TOKEN_B)
+node_ids = {n["id"] for n in body["nodes"]}
+note_ids = {n["id"] for n in body["notes"]}
+assert_true("B: only PlayersNode visible",
+            node_ids == {PLAYERS_NODE})
+assert_true("B: only PlayersNote visible",
+            note_ids == {NOTE_PLAYERS})
+
+# Owner-xray bypass: B as map owner with xray TRUE sees everything in the plot
+mysql_query(f"UPDATE maps SET owner_id={USER_B_ID}, owner_xray=TRUE WHERE id={MAP_ID};")
+status, body = http_get(f"{PLOTS_BASE}/{PLOT_1}/members", TOKEN_B)
+node_ids = {n["id"] for n in body["nodes"]}
+note_ids = {n["id"] for n in body["notes"]}
+assert_true("xray=TRUE: B sees all node members",
+            node_ids == {PLAYERS_NODE, GM_NODE})
+assert_true("xray=TRUE: B sees all note members",
+            note_ids == {NOTE_PLAYERS, NOTE_GM})
+
+# Without xray, B is back to filtered
+mysql_query(f"UPDATE maps SET owner_xray=FALSE WHERE id={MAP_ID};")
+status, body = http_get(f"{PLOTS_BASE}/{PLOT_1}/members", TOKEN_B)
+node_ids = {n["id"] for n in body["nodes"]}
+assert_true("xray=FALSE: B back to filtered set",
+            node_ids == {PLAYERS_NODE})
+
+# Restore ownership
+mysql_query(f"UPDATE maps SET owner_id={USER_A_ID} WHERE id={MAP_ID};")
+
+print("  All visibility-filter tests passed.")
+
+# ─── Cleanup CASCADE ─────────────────────────────────────────────────────────
+# Deleting the plot should cascade away both junction tables.
+
+print("  --- Cleanup cascade ---")
+
+remaining_pn = mysql_query(
+    f"SELECT COUNT(*) FROM plot_nodes WHERE plot_id={PLOT_1};")
+remaining_pnn = mysql_query(
+    f"SELECT COUNT(*) FROM plot_notes WHERE plot_id={PLOT_1};")
+assert_true("cleanup: plot_nodes populated before delete",  int(remaining_pn) > 0)
+assert_true("cleanup: plot_notes populated before delete",  int(remaining_pnn) > 0)
+
+http_delete(f"{PLOTS_BASE}/{PLOT_1}", TOKEN_A)
+
+remaining_pn = mysql_query(
+    f"SELECT COUNT(*) FROM plot_nodes WHERE plot_id={PLOT_1};")
+remaining_pnn = mysql_query(
+    f"SELECT COUNT(*) FROM plot_notes WHERE plot_id={PLOT_1};")
+assert_true("cleanup: plot_nodes cascaded",  remaining_pn == "0")
+assert_true("cleanup: plot_notes cascaded",  remaining_pnn == "0")
+
+# Deleting a node (in NodeController) should also cascade plot_nodes membership
+TOMB_NODE = mknode("Tombstone")
+http_post(f"{PLOTS_BASE}/{PLOT_2}/nodes", {"nodeId": TOMB_NODE}, TOKEN_A)
+http_delete(f"{NODES_BASE}/{TOMB_NODE}", TOKEN_A)
+remaining = mysql_query(
+    f"SELECT COUNT(*) FROM plot_nodes WHERE node_id={TOMB_NODE};")
+assert_true("cleanup: node delete cascaded plot_nodes", remaining == "0")
+
+print("  All cleanup tests passed.")
+
+sys.exit(0 if report() else 1)


### PR DESCRIPTION
Closes #88 (will close manually after merge — auto-close skips non-default-branch PRs).

## Summary

Adds `PlotController` — tenant-scoped narrative groupings that tie together places (nodes) and content (notes) across one or more maps, via two parallel junction tables (`plot_nodes`, `plot_notes`).

- **Plot CRUD** at `/api/v1/tenants/{tid}/plots` (5 endpoints).
- **Combined membership** at `/api/v1/tenants/{tid}/plots/{id}/members` returning `{ nodes: [...], notes: [...] }`.
- **Membership add/remove** via `/nodes` and `/notes` sub-routes — idempotent on add (INSERT IGNORE), rejects cross-tenant ids before inserting.
- **Visibility filter on listMembers** reuses the effective-visibility CTEs from #99 (nodes) and #87 (notes), adapted so the recursive walk anchors on the plot's members rather than every node on a map.

## Work breakdown

1. Read schema for `plots` / `plot_nodes` / `plot_notes` (already stubbed in 2a.i)
2. Write `PlotController.h` (10 routes)
3. Write `PlotController.cpp` — CRUD (list, create, get, update, delete)
4. Write membership endpoints (addNode, removeNode, addNote, removeNote) with idempotent INSERT IGNORE + cross-tenant defense
5. Write `listMembers` with two visibility-filtered queries (nodes + notes), tenant-admin bypass, owner_xray bypass
6. Build backend
7. Refresh local main + merge into nodes-rebuild + fast-forward feature branch (mid-PR, to pick up the `docs/AI-COLLABORATION-CONVENTIONS.md` from #118 / #119)
8. Restart Docker stack with fresh DB; verify existing fast tier is green (regression check)
9. Write `test_22_plots.py` — CRUD, membership (idempotent + cross-tenant rejected), visibility filter (admin bypass + non-admin filtered + owner_xray), CASCADE cleanup; 58 assertions
10. Add `test_22_plots.py` to `FAST_TESTS` in `run-tests.py`
11. Run full fast tier — all 16 suites pass
12. Restore an inadvertently-removed `docs/AI-COLLABORATION-CONVENTIONS.md` (working-tree only; HEAD was intact) — small unexpected wrinkle, fixed via `git checkout HEAD --`
13. Public-repo diff scan
14. Commit + push + open PR

## Permission model

| Operation | Required role |
|---|---|
| GET /plots, /plots/{id}, /plots/{id}/members | Any tenant member (TenantFilter) |
| POST /plots, PUT /plots/{id}, DELETE /plots/{id} | `admin` or `editor` |
| POST/DELETE membership endpoints | `admin` or `editor` |

The visibility filter on `GET /members` runs only for non-admins; admins see every member. Map owners with `owner_xray = TRUE` get the same admin-style bypass per-member (a member living on an xray-owner map is visible regardless of group membership).

## Files changed

- **backend/src/controllers/PlotController.h** — New controller header. 10 routes (5 CRUD + 5 membership), method declarations, doc-string with body shapes and authorization rules.
- **backend/src/controllers/PlotController.cpp** — Full implementation. Two CTE constants in the anonymous namespace (`PLOT_NODE_VISIBILITY_CTE`, `PLOT_NOTE_VISIBILITY_CTE`) walk only the plot's members. CRUD handlers gate writes on `tenantRole IN ('admin','editor')`. Membership add does an existence-check pair (plot exists, member exists in tenant) before INSERT IGNORE; remove uses a JOIN-WHERE pattern so the plot's tenant scope is enforced in the same query.
- **backend/tests/test_22_plots.py** — New 58-assertion suite. Covers CRUD (incl. duplicate names allowed, viewer-rejected writes), membership (idempotent dup-attach, cross-tenant rejected with 400, missing fields, viewer-rejected writes), visibility filter on listMembers (admin sees all, non-admin sees Players-only set, owner_xray TRUE/FALSE), and CASCADE behavior on plot delete and node delete.
- **backend/tests/run-tests.py** — Adds `test_22_plots.py` to `FAST_TESTS` + description.

## Test plan

- [x] `python3 backend/tests/test_22_plots.py` — 58 passed, 0 failed
- [x] `python3 backend/tests/run-tests.py --tier fast` — all 16 suites pass; existing tests unchanged
- [ ] CI green on PR (E2E expected red — see below)

## Test expectations (CI on `nodes-rebuild`)

| Job | Expected | Why |
|---|---|---|
| `lint` | ✅ pass | No frontend changes. |
| `security` | ✅ pass | No new dependencies. |
| `compile` | ✅ pass | New controller + test compile cleanly. |
| `integration` (db tests) | ✅ pass | Schema unchanged; 179/179. |
| `integration` (backend tests) | ✅ pass | 16/16 suites pass locally including new `test_22_plots.py`. |
| `integration` (E2E) | ❌ **expected fail** | Annotations / cross-tenant E2E specs reference the old annotations frontend that was ripped out for the rebuild. Frontend rebuild lands in the #94 series. |

`integration` will report red overall because of the E2E sub-step. Mid-rebuild informational state — `main` remains the enforced gate.

## Out of scope

- Plot visibility (plots themselves are tenant-scoped; visibility tagging on plots could come later if needed — not in this round per ticket).
- Plot media (not in scope per ticket).
- Frontend UI (#94 series).

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)