### PR TITLE
Phase 2d: Tree navigation endpoints (#89)

### DIFF
--- a/backend/src/controllers/NodeController.cpp
+++ b/backend/src/controllers/NodeController.cpp
@@ -901,3 +901,277 @@ void NodeController::setVisibility(
             id, mapId, tenantId);
     });
 }
+
+// ─── GET /api/v1/tenants/{tid}/maps/{mid}/nodes/{id}/children ────────────────
+//
+// Direct children only. Same shape as `GET /nodes?parentId=N`; the
+// visibility filter applies. Per #99 / Phase 2b.ii, hidden parents do not
+// produce a 404 here — the response is just the visible children (which may
+// be empty). This matches the leak-safe behavior of the list endpoint.
+
+void NodeController::listChildren(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int id) {
+
+    int userId = callerUserId(req);
+    bool isAdmin = isTenantAdmin(req);
+
+    std::string sql;
+    if (!isAdmin) sql = VISIBILITY_RESOLVE_CTE;
+    sql +=
+        "SELECT n.id, n.map_id, n.parent_id, n.name, n.geo_json, n.description, "
+        "       n.color, n.visibility_override, n.created_by, "
+        "       u.username AS creator_username, "
+        "       n.created_at, n.updated_at "
+        "FROM nodes n "
+        "JOIN maps m  ON m.id = n.map_id "
+        "JOIN users u ON u.id = n.created_by "
+        "LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ? "
+        "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
+        "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
+        "WHERE n.parent_id = ? AND n.map_id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? "
+        "       OR mp.level IN ('view','comment','edit','moderate','admin') "
+        "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))";
+    if (!isAdmin) sql += VISIBILITY_PREDICATE;
+    sql += " ORDER BY n.created_at ASC";
+
+    auto resultCb = [callback, id](const drogon::orm::Result& r) {
+        std::set<int> visibleIds;
+        for (const auto& row : r) visibleIds.insert(row["id"].as<int>());
+        Json::Value arr(Json::arrayValue);
+        for (const auto& row : r) {
+            Json::Value n = rowToNode(row);
+            // Same parent-leak rule as listNodes: if a child's parent isn't
+            // also visible, null out parentId. (Here the parent we're
+            // listing under is `id`, but a sibling-level case can still
+            // arise via deeper inheritance interactions.)
+            if (!n["parentId"].isNull()) {
+                int p = n["parentId"].asInt();
+                if (visibleIds.find(p) == visibleIds.end() && p != id) {
+                    n["parentId"] = Json::Value();
+                }
+            }
+            arr.append(n);
+        }
+        callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+    };
+    auto errCb = [callback](const drogon::orm::DrogonDbException&) {
+        callback(errorResponse(drogon::k500InternalServerError,
+            "db_error", "Failed to fetch children"));
+    };
+
+    auto db = drogon::app().getDbClient();
+    if (isAdmin) {
+        db->execSqlAsync(sql, resultCb, errCb,
+            userId, id, mapId, tenantId, userId);
+    } else {
+        db->execSqlAsync(sql, resultCb, errCb,
+            mapId, userId,                    // CTE
+            userId,                           // mp join
+            id, mapId, tenantId, userId,      // WHERE map gating (parent_id=id)
+            userId);                          // visibility xray
+    }
+}
+
+// ─── GET /api/v1/tenants/{tid}/maps/{mid}/nodes/{id}/subtree ─────────────────
+//
+// Recursive descent from the starting node, returning each node with a
+// `depth` field (root = 0). For non-admins, the recursion only descends
+// into visible nodes — a hidden ancestor severs its own visible descendants
+// from the response, so no gaps leak hidden-node existence.
+//
+// Pagination via cursor (last id seen) + limit (default 100, max 500).
+// Returns 404 when the starting node is hidden or missing.
+
+void NodeController::getSubtree(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int id) {
+
+    int userId = callerUserId(req);
+    bool isAdmin = isTenantAdmin(req);
+
+    // Pagination params.
+    constexpr int DEFAULT_LIMIT = 100;
+    constexpr int MAX_LIMIT     = 500;
+    int limit = DEFAULT_LIMIT;
+    int cursor = 0;
+    {
+        std::string limitParam  = req->getParameter("limit");
+        std::string cursorParam = req->getParameter("cursor");
+        if (!limitParam.empty()) {
+            try { limit = std::stoi(limitParam); }
+            catch (...) {
+                callback(errorResponse(drogon::k400BadRequest,
+                    "bad_request", "limit must be an integer"));
+                return;
+            }
+            if (limit < 1) {
+                callback(errorResponse(drogon::k400BadRequest,
+                    "bad_request", "limit must be at least 1"));
+                return;
+            }
+            if (limit > MAX_LIMIT) {
+                callback(errorResponse(drogon::k400BadRequest,
+                    "bad_request", "limit exceeds maximum (" +
+                    std::to_string(MAX_LIMIT) + ")"));
+                return;
+            }
+        }
+        if (!cursorParam.empty()) {
+            try { cursor = std::stoi(cursorParam); }
+            catch (...) {
+                callback(errorResponse(drogon::k400BadRequest,
+                    "bad_request", "cursor must be an integer"));
+                return;
+            }
+        }
+    }
+
+    // Build the multi-CTE query. For non-admins, we prepend the standard
+    // node-visibility resolve from #99 and use it to filter the subtree's
+    // recursive descent. Admins get a simpler subtree-only CTE.
+    //
+    // Map permission gating still applies — we JOIN against maps + map
+    // permissions inside the anchor and require the caller has at least
+    // view access. (For non-admins the visibility filter further prunes,
+    // but map gating is the outer ring.)
+    //
+    // We fetch limit+1 rows to detect the "has more" boundary; the extra
+    // row's id (if present) becomes the next cursor.
+
+    std::string sql;
+    if (!isAdmin) {
+        sql = VISIBILITY_RESOLVE_CTE.substr(0, VISIBILITY_RESOLVE_CTE.size() - 1);
+        // Strip trailing space before continuing the WITH clause; we want
+        // one CTE list that includes resolve + visible_starts + subtree.
+        sql += ", ";
+    } else {
+        sql = "WITH RECURSIVE ";
+    }
+    sql +=
+        "subtree AS ("
+        "  SELECT n.id, n.map_id, n.parent_id, n.name, n.geo_json, n.description, "
+        "         n.color, n.visibility_override, n.created_by, "
+        "         u.username AS creator_username, "
+        "         n.created_at, n.updated_at, 0 AS depth "
+        "  FROM nodes n "
+        "  JOIN maps m  ON m.id = n.map_id "
+        "  JOIN users u ON u.id = n.created_by "
+        "  LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ? "
+        "  LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
+        "                                  AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
+        "  WHERE n.id = ? AND n.map_id = ? AND m.tenant_id = ? "
+        "    AND (m.owner_id = ? "
+        "         OR mp.level IN ('view','comment','edit','moderate','admin') "
+        "         OR mp_pub.level IN ('view','comment','edit','moderate','admin'))";
+    if (!isAdmin) {
+        sql +=
+            "    AND ((m.owner_id = ? AND m.owner_xray = TRUE) "
+            "         OR n.id IN (SELECT start_id FROM visible_starts)) ";
+    }
+    sql +=
+        "  UNION ALL "
+        "  SELECT c.id, c.map_id, c.parent_id, c.name, c.geo_json, c.description, "
+        "         c.color, c.visibility_override, c.created_by, "
+        "         uc.username, "
+        "         c.created_at, c.updated_at, s.depth + 1 "
+        "  FROM subtree s "
+        "  JOIN nodes c ON c.parent_id = s.id "
+        "  JOIN users uc ON uc.id = c.created_by ";
+    if (!isAdmin) {
+        // Need maps for the per-child xray check. Same-map check stays
+        // within the requested subtree's map (no cross-map walking).
+        sql +=
+            "  JOIN maps mc ON mc.id = c.map_id "
+            "  WHERE s.depth < " + std::to_string(MAX_NODE_DEPTH) +
+            "    AND c.map_id = s.map_id "
+            "    AND ((mc.owner_id = ? AND mc.owner_xray = TRUE) "
+            "         OR c.id IN (SELECT start_id FROM visible_starts)) ";
+    } else {
+        sql +=
+            "  WHERE s.depth < " + std::to_string(MAX_NODE_DEPTH) +
+            "    AND c.map_id = s.map_id ";
+    }
+    sql +=
+        ") "
+        "SELECT * FROM subtree WHERE id > ? ORDER BY id ASC LIMIT ?";
+
+    int fetchLimit = limit + 1;  // +1 to detect "has more"
+
+    auto resultCb = [callback, limit](const drogon::orm::Result& r) {
+        Json::Value arr(Json::arrayValue);
+        std::set<int> visibleIds;
+        for (const auto& row : r) visibleIds.insert(row["id"].as<int>());
+
+        bool hasMore = static_cast<int>(r.size()) > limit;
+        int nextCursor = 0;
+        size_t emitCount = hasMore ? static_cast<size_t>(limit) : r.size();
+
+        for (size_t i = 0; i < emitCount; ++i) {
+            const auto& row = r[i];
+            Json::Value n = rowToNode(row);
+            n["depth"] = row["depth"].as<int>();
+            // parent_id leak-out: if parent isn't in the subtree response,
+            // null it out. (Won't happen for the root since its parent is
+            // outside the requested subtree by design — but the root's
+            // depth=0 still has its real parent_id, which is fine.)
+            if (!n["parentId"].isNull() && row["depth"].as<int>() > 0) {
+                int p = n["parentId"].asInt();
+                if (visibleIds.find(p) == visibleIds.end()) {
+                    n["parentId"] = Json::Value();
+                }
+            }
+            arr.append(n);
+        }
+        if (hasMore) nextCursor = arr[static_cast<int>(arr.size() - 1)]["id"].asInt();
+
+        // 404 the whole subtree if the result is empty AND cursor is 0
+        // (first page). On a follow-up page request with no more results,
+        // empty is a valid response with nextCursor=null.
+        if (arr.empty()) {
+            // For an empty first page, we can't distinguish "node hidden"
+            // from "node has no descendants and is hidden" — but since the
+            // root is always at depth=0 and is always included if visible,
+            // empty really means "root not visible or doesn't exist." 404.
+            //
+            // If the caller paginated past the end, they'll also hit
+            // empty here — accept that limitation in exchange for not
+            // probing for existence.
+            callback(errorResponse(drogon::k404NotFound,
+                "not_found", "Subtree root not found"));
+            return;
+        }
+
+        Json::Value out;
+        out["nodes"] = arr;
+        out["nextCursor"] = hasMore ? Json::Value(nextCursor) : Json::Value();
+        callback(drogon::HttpResponse::newHttpJsonResponse(out));
+    };
+    auto errCb = [callback](const drogon::orm::DrogonDbException&) {
+        callback(errorResponse(drogon::k500InternalServerError,
+            "db_error", "Failed to fetch subtree"));
+    };
+
+    auto db = drogon::app().getDbClient();
+    if (isAdmin) {
+        // Anchor params: userId (mp join), id, mapId, tenantId, userId (owner)
+        // Final SELECT params: cursor, fetchLimit
+        db->execSqlAsync(sql, resultCb, errCb,
+            userId, id, mapId, tenantId, userId,
+            cursor, fetchLimit);
+    } else {
+        // Resolve CTE params: mapId, userId
+        // Anchor: userId (mp), id, mapId, tenantId, userId (owner-or check),
+        //         userId (xray)
+        // Recursive step: userId (xray on child)
+        // Final SELECT: cursor, fetchLimit
+        db->execSqlAsync(sql, resultCb, errCb,
+            mapId, userId,
+            userId, id, mapId, tenantId, userId, userId,
+            userId,
+            cursor, fetchLimit);
+    }
+}

--- a/backend/src/controllers/NodeController.h
+++ b/backend/src/controllers/NodeController.h
@@ -13,6 +13,9 @@
  * GET    /api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{id}/visibility
  * POST   /api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{id}/visibility
  *
+ * GET    /api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{id}/children
+ * GET    /api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{id}/subtree
+ *
  * Node = the central new abstraction in the nodes-rebuild model
  * (tree-structured place markers, replacing annotations + adding
  * hierarchy via parent_id). See #96 and the nodes-rebuild branch
@@ -34,6 +37,18 @@
  *     to FALSE doesn't drop the rows. (Inheritance treats override
  *     = FALSE as "ignore my own tags, walk up parent_id"; the rows
  *     remain ready to re-activate.)
+ *
+ * Tree navigation (Phase 2d, #89):
+ *   - GET /children — direct children only. Same shape as
+ *     `GET /nodes?parentId=N`; visibility filter applies.
+ *   - GET /subtree  — recursive descent from the starting node, with
+ *     a `depth` field on each entry (0 = the starting node). The
+ *     recursion only descends into visible nodes, so a hidden
+ *     ancestor severs its own visible descendants from the response
+ *     (no gaps that would leak hidden-node existence).
+ *     Returns 404 if the starting node is hidden from the caller.
+ *     Pagination: ?limit=N&cursor=<lastId>. Default limit 100, max 500.
+ *     Response shape: { nodes: [{...node fields..., depth}], nextCursor: int|null }.
  */
 class NodeController : public drogon::HttpController<NodeController> {
 public:
@@ -59,6 +74,12 @@ public:
         ADD_METHOD_TO(NodeController::setVisibility,
                       "/api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{id}/visibility",
                       drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(NodeController::listChildren,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{id}/children",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+        ADD_METHOD_TO(NodeController::getSubtree,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{id}/subtree",
+                      drogon::Get, "JwtFilter", "TenantFilter");
     METHOD_LIST_END
 
     void listNodes(const drogon::HttpRequestPtr&,
@@ -82,6 +103,12 @@ public:
     void setVisibility(const drogon::HttpRequestPtr&,
                        std::function<void(const drogon::HttpResponsePtr&)>&&,
                        int tenantId, int mapId, int id);
+    void listChildren(const drogon::HttpRequestPtr&,
+                      std::function<void(const drogon::HttpResponsePtr&)>&&,
+                      int tenantId, int mapId, int id);
+    void getSubtree(const drogon::HttpRequestPtr&,
+                    std::function<void(const drogon::HttpResponsePtr&)>&&,
+                    int tenantId, int mapId, int id);
 };
 
 // Maximum tree depth for node parent_id chains. Bounded so the

--- a/backend/tests/run-tests.py
+++ b/backend/tests/run-tests.py
@@ -49,6 +49,7 @@ FAST_TESTS = [
     "test_20_node_visibility_filter.py",
     "test_21_note_visibility.py",
     "test_22_plots.py",
+    "test_23_tree_navigation.py",
 ]
 
 # test_14_nodes.py landed in #96 (NodeController CRUD + tree + max-depth).
@@ -62,6 +63,8 @@ FAST_TESTS = [
 #   note → node → parent-chain inheritance).
 # test_22_plots.py landed in #88 (PlotController CRUD + membership +
 #   visibility filter on listMembers).
+# test_23_tree_navigation.py landed in #89 (children + subtree endpoints,
+#   recursive CTE descent, pagination, hidden-root 404, owner_xray).
 # Annotation/note-group tests are gone permanently — those concepts were
 # consolidated into nodes and visibility groups during the rebuild.
 
@@ -87,6 +90,7 @@ TEST_DESCRIPTIONS = {
     20: "Node visibility read filter (admin bypass, inheritance, owner_xray)",
     21: "Note visibility (tagging + filter; note → node → parent-chain)",
     22: "Plots (CRUD, membership, visibility filter on listMembers)",
+    23: "Tree navigation (children + subtree CTE descent, pagination)",
 }
 
 

--- a/backend/tests/test_23_tree_navigation.py
+++ b/backend/tests/test_23_tree_navigation.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""test_23_tree_navigation.py — Phase 2d (#89): tree navigation endpoints.
+
+Covers:
+  - GET /nodes/{id}/children — direct children, visibility-filtered
+  - GET /nodes/{id}/subtree  — recursive descent with depth, paginated,
+    visibility-filtered, hidden-root → 404
+
+Setup mirrors test_20/21/22:
+  - A is tenant admin in T_A.
+  - B is moved into A's org, added as 'viewer' tenant_member of T_A,
+    granted map view permission, and added to the Players visibility group.
+"""
+
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import (
+    reset_counters, report, assert_status, assert_json_field, assert_true,
+    http_post, http_get,
+    register_user, json_field, mysql_query,
+)
+
+reset_counters()
+RUN_ID = os.getpid()
+
+print("=== Tree Navigation Tests ===")
+
+# ─── Setup ───────────────────────────────────────────────────────────────────
+
+TOKEN_A = register_user(f"t23_a_{RUN_ID}", f"t23_a_{RUN_ID}@test.com", "testpass123")
+_, body_a = http_post("/auth/login",
+    {"email": f"t23_a_{RUN_ID}@test.com", "password": "testpass123"})
+TENANT_A   = json_field(body_a, ["tenantId"])
+USER_A_ID  = json_field(body_a, ["user", "id"])
+
+TOKEN_B = register_user(f"t23_b_{RUN_ID}", f"t23_b_{RUN_ID}@test.com", "testpass123")
+_, body_b = http_post("/auth/login",
+    {"email": f"t23_b_{RUN_ID}@test.com", "password": "testpass123"})
+USER_B_ID = json_field(body_b, ["user", "id"])
+
+# Move B into A's org + insert as viewer.
+A_ORG_ID = mysql_query(f"SELECT org_id FROM users WHERE id={USER_A_ID};")
+mysql_query(f"UPDATE users SET org_id={A_ORG_ID} WHERE id={USER_B_ID};")
+mysql_query(
+    f"INSERT INTO tenant_members (tenant_id, user_id, role) "
+    f"VALUES ({TENANT_A}, {USER_B_ID}, 'viewer');")
+
+# A creates a map; grant B view permission.
+_, body = http_post(f"/tenants/{TENANT_A}/maps", {
+    "title": "Tree Test Map",
+    "coordinateSystem": {"type": "wgs84", "center": {"lat": 0, "lng": 0}, "zoom": 3},
+}, TOKEN_A)
+MAP_ID = json_field(body, ["id"])
+mysql_query(
+    f"INSERT INTO map_permissions (map_id, user_id, level) "
+    f"VALUES ({MAP_ID}, {USER_B_ID}, 'view');")
+
+# Visibility groups + B in Players.
+VG_BASE = f"/tenants/{TENANT_A}/visibility-groups"
+_, body = http_post(VG_BASE, {"name": "Players"}, TOKEN_A)
+G_PLAYERS = json_field(body, ["id"])
+_, body = http_post(VG_BASE, {"name": "GMs"}, TOKEN_A)
+G_GMS = json_field(body, ["id"])
+http_post(f"{VG_BASE}/{G_PLAYERS}/members", {"userId": USER_B_ID}, TOKEN_A)
+
+NODES_BASE = f"/tenants/{TENANT_A}/maps/{MAP_ID}/nodes"
+
+def mknode(name, parent_id=None):
+    body_in = {"name": name}
+    if parent_id is not None:
+        body_in["parentId"] = parent_id
+    _, b = http_post(NODES_BASE, body_in, TOKEN_A)
+    return json_field(b, ["id"])
+
+def settag(node_id, override, group_ids):
+    http_post(f"{NODES_BASE}/{node_id}/visibility",
+              {"override": override, "groupIds": group_ids}, TOKEN_A)
+
+# Tree:
+#   Root (no override, admin-only via fallback)
+#   ├── PlayersBranch (override=TRUE, [Players])
+#   │   ├── PlayersChild (no override, inherits Players → visible to B)
+#   │   └── PlayersGrandchild (no override, inherits Players)
+#   ├── GmBranch (override=TRUE, [GMs])
+#   │   └── GmChild (no override, inherits GMs → hidden from B)
+#   └── PublicBranch (override=TRUE, [Players])
+#       └── PublicChild (no override, inherits Players)
+
+ROOT             = mknode("Root")
+PLAYERS_BRANCH   = mknode("PlayersBranch", ROOT);   settag(PLAYERS_BRANCH, True, [G_PLAYERS])
+PLAYERS_CHILD    = mknode("PlayersChild", PLAYERS_BRANCH)
+PLAYERS_GRAND    = mknode("PlayersGrand", PLAYERS_CHILD)
+GM_BRANCH        = mknode("GmBranch", ROOT);        settag(GM_BRANCH, True, [G_GMS])
+GM_CHILD         = mknode("GmChild", GM_BRANCH)
+PUBLIC_BRANCH    = mknode("PublicBranch", ROOT);    settag(PUBLIC_BRANCH, True, [G_PLAYERS])
+PUBLIC_CHILD     = mknode("PublicChild", PUBLIC_BRANCH)
+
+ALL_NODES = {ROOT, PLAYERS_BRANCH, PLAYERS_CHILD, PLAYERS_GRAND,
+             GM_BRANCH, GM_CHILD, PUBLIC_BRANCH, PUBLIC_CHILD}
+B_VISIBLE = {PLAYERS_BRANCH, PLAYERS_CHILD, PLAYERS_GRAND,
+             PUBLIC_BRANCH, PUBLIC_CHILD}
+
+# ─── /children — direct children only ────────────────────────────────────────
+
+print("  --- /children (admin) ---")
+
+# Admin sees all 3 direct children of Root
+status, body = http_get(f"{NODES_BASE}/{ROOT}/children", TOKEN_A)
+assert_status("admin: children of Root returns 200", 200, status)
+ids = {n["id"] for n in body}
+assert_true("admin: 3 direct children",
+            ids == {PLAYERS_BRANCH, GM_BRANCH, PUBLIC_BRANCH})
+
+# Admin sees the leaf's empty children
+status, body = http_get(f"{NODES_BASE}/{PLAYERS_GRAND}/children", TOKEN_A)
+assert_status("admin: leaf children returns 200", 200, status)
+assert_true("admin: leaf has no children", len(body) == 0)
+
+print("  All admin /children tests passed.")
+
+print("  --- /children (non-admin) ---")
+
+# B only sees the Players-visible direct children of Root: PlayersBranch + PublicBranch
+# (Root's visibility resolves to admin-only, but B can see specific children that
+# have their own override=TRUE pointing at Players.)
+status, body = http_get(f"{NODES_BASE}/{ROOT}/children", TOKEN_B)
+assert_status("B: children of Root returns 200", 200, status)
+ids = {n["id"] for n in body}
+assert_true("B: only Players-visible direct children",
+            ids == {PLAYERS_BRANCH, PUBLIC_BRANCH})
+
+# Children of GmBranch: B can't see GmBranch, so empty
+status, body = http_get(f"{NODES_BASE}/{GM_BRANCH}/children", TOKEN_B)
+assert_status("B: children of hidden parent returns 200", 200, status)
+assert_true("B: hidden parent's children empty (per leak-safe spec)",
+            len(body) == 0)
+
+# Children of PlayersBranch: B sees PlayersChild
+status, body = http_get(f"{NODES_BASE}/{PLAYERS_BRANCH}/children", TOKEN_B)
+ids = {n["id"] for n in body}
+assert_true("B: children of PlayersBranch", ids == {PLAYERS_CHILD})
+
+print("  All non-admin /children tests passed.")
+
+# ─── /subtree — recursive descent with depth ─────────────────────────────────
+
+print("  --- /subtree (admin) ---")
+
+# Full tree from Root
+status, body = http_get(f"{NODES_BASE}/{ROOT}/subtree", TOKEN_A)
+assert_status("admin: subtree from Root returns 200", 200, status)
+ids = {n["id"] for n in body["nodes"]}
+assert_true("admin: subtree contains all 8 nodes", ids == ALL_NODES)
+
+# Verify depth values
+depth_by_id = {n["id"]: n["depth"] for n in body["nodes"]}
+assert_true("admin: Root depth = 0",            depth_by_id[ROOT] == 0)
+assert_true("admin: PlayersBranch depth = 1",   depth_by_id[PLAYERS_BRANCH] == 1)
+assert_true("admin: PlayersChild depth = 2",    depth_by_id[PLAYERS_CHILD] == 2)
+assert_true("admin: PlayersGrand depth = 3",    depth_by_id[PLAYERS_GRAND] == 3)
+assert_true("admin: GmBranch depth = 1",        depth_by_id[GM_BRANCH] == 1)
+
+# nextCursor null when full subtree fits in one page
+assert_true("admin: nextCursor null when no more pages",
+            body.get("nextCursor") is None)
+
+# Subtree from a leaf returns just the leaf
+status, body = http_get(f"{NODES_BASE}/{PLAYERS_GRAND}/subtree", TOKEN_A)
+assert_true("admin: leaf subtree contains only itself",
+            len(body["nodes"]) == 1 and body["nodes"][0]["id"] == PLAYERS_GRAND)
+assert_true("admin: leaf subtree depth=0",
+            body["nodes"][0]["depth"] == 0)
+
+# Unknown node → 404
+status, _ = http_get(f"{NODES_BASE}/9999999/subtree", TOKEN_A)
+assert_status("admin: unknown node 404", 404, status)
+
+print("  All admin /subtree tests passed.")
+
+print("  --- /subtree (non-admin) ---")
+
+# B requesting subtree from Root → 404 (Root is admin-only-visible, hidden from B)
+status, _ = http_get(f"{NODES_BASE}/{ROOT}/subtree", TOKEN_B)
+assert_status("B: subtree from hidden root returns 404", 404, status)
+
+# B requesting subtree from PlayersBranch → sees PlayersBranch, PlayersChild, PlayersGrand
+status, body = http_get(f"{NODES_BASE}/{PLAYERS_BRANCH}/subtree", TOKEN_B)
+assert_status("B: subtree from visible PlayersBranch returns 200", 200, status)
+ids = {n["id"] for n in body["nodes"]}
+assert_true("B: PlayersBranch subtree = {PB, PC, PG}",
+            ids == {PLAYERS_BRANCH, PLAYERS_CHILD, PLAYERS_GRAND})
+depth_by_id = {n["id"]: n["depth"] for n in body["nodes"]}
+assert_true("B: PlayersBranch depth = 0 (subtree root)",
+            depth_by_id[PLAYERS_BRANCH] == 0)
+assert_true("B: PlayersChild depth = 1",
+            depth_by_id[PLAYERS_CHILD] == 1)
+
+# B requesting subtree from GmBranch → 404 (hidden)
+status, _ = http_get(f"{NODES_BASE}/{GM_BRANCH}/subtree", TOKEN_B)
+assert_status("B: subtree from hidden GmBranch returns 404", 404, status)
+
+print("  All non-admin /subtree tests passed.")
+
+# ─── Pagination ──────────────────────────────────────────────────────────────
+
+print("  --- /subtree pagination ---")
+
+# Full subtree with limit=3 → 3 nodes + nextCursor
+status, body = http_get(f"{NODES_BASE}/{ROOT}/subtree?limit=3", TOKEN_A)
+assert_status("paginate: limit=3 returns 200", 200, status)
+assert_true("paginate: 3 nodes returned", len(body["nodes"]) == 3)
+assert_true("paginate: nextCursor present",
+            body.get("nextCursor") is not None)
+first_page_ids = [n["id"] for n in body["nodes"]]
+
+# Follow the cursor for page 2
+cursor = body["nextCursor"]
+status, body = http_get(f"{NODES_BASE}/{ROOT}/subtree?limit=3&cursor={cursor}", TOKEN_A)
+assert_status("paginate: cursored page 2 returns 200", 200, status)
+second_page_ids = [n["id"] for n in body["nodes"]]
+assert_true("paginate: page 2 has fresh ids",
+            set(first_page_ids).isdisjoint(set(second_page_ids)))
+
+# Final page (limit=3 covers everything from cursor onward; ≤3 results, no nextCursor)
+final_cursor = body.get("nextCursor")
+if final_cursor is not None:
+    status, body = http_get(
+        f"{NODES_BASE}/{ROOT}/subtree?limit=3&cursor={final_cursor}", TOKEN_A)
+    assert_true("paginate: final page nextCursor null",
+                body.get("nextCursor") is None)
+
+# Bad limit values
+status, _ = http_get(f"{NODES_BASE}/{ROOT}/subtree?limit=0", TOKEN_A)
+assert_status("paginate: limit=0 returns 400", 400, status)
+status, _ = http_get(f"{NODES_BASE}/{ROOT}/subtree?limit=501", TOKEN_A)
+assert_status("paginate: limit > 500 returns 400", 400, status)
+status, _ = http_get(f"{NODES_BASE}/{ROOT}/subtree?limit=abc", TOKEN_A)
+assert_status("paginate: non-integer limit returns 400", 400, status)
+status, _ = http_get(f"{NODES_BASE}/{ROOT}/subtree?cursor=xyz", TOKEN_A)
+assert_status("paginate: non-integer cursor returns 400", 400, status)
+
+print("  All pagination tests passed.")
+
+# ─── Cross-tenant blocked ────────────────────────────────────────────────────
+
+print("  --- Cross-tenant blocked ---")
+
+# A different unauthenticated tenant — register a third user in their own
+# tenant, try to hit T_A's nodes.
+TOKEN_C = register_user(f"t23_c_{RUN_ID}", f"t23_c_{RUN_ID}@test.com", "testpass123")
+status, _ = http_get(f"{NODES_BASE}/{ROOT}/children", TOKEN_C)
+assert_status("cross-tenant: /children blocked at TenantFilter", 403, status)
+status, _ = http_get(f"{NODES_BASE}/{ROOT}/subtree", TOKEN_C)
+assert_status("cross-tenant: /subtree blocked at TenantFilter", 403, status)
+
+print("  All cross-tenant tests passed.")
+
+# ─── Owner-xray bypass on subtree ────────────────────────────────────────────
+# When B becomes the map owner with owner_xray=TRUE, the subtree from Root
+# (otherwise hidden from B) should return the full tree.
+
+print("  --- owner_xray on subtree ---")
+
+mysql_query(f"UPDATE maps SET owner_id={USER_B_ID}, owner_xray=TRUE WHERE id={MAP_ID};")
+
+status, body = http_get(f"{NODES_BASE}/{ROOT}/subtree", TOKEN_B)
+assert_status("xray=TRUE: B sees subtree from Root", 200, status)
+ids = {n["id"] for n in body["nodes"]}
+assert_true("xray=TRUE: B sees all 8 nodes", ids == ALL_NODES)
+
+mysql_query(f"UPDATE maps SET owner_xray=FALSE WHERE id={MAP_ID};")
+status, _ = http_get(f"{NODES_BASE}/{ROOT}/subtree", TOKEN_B)
+assert_status("xray=FALSE: B back to 404", 404, status)
+mysql_query(f"UPDATE maps SET owner_id={USER_A_ID} WHERE id={MAP_ID};")
+
+print("  All owner_xray tests passed.")
+
+sys.exit(0 if report() else 1)


### PR DESCRIPTION
Closes #89 (will close manually after merge — auto-close skips non-default-branch PRs).

## Summary

Adds the API surface for navigating the node tree:

- `GET /api/v1/tenants/{tid}/maps/{mid}/nodes/{id}/children` — direct children of a node (one level). Visibility-filtered like the existing list endpoint.
- `GET /api/v1/tenants/{tid}/maps/{mid}/nodes/{id}/subtree` — recursive descent from the starting node, returning each entry with a `depth` field (root = 0). Cursor pagination (default limit 100, max 500). 404 when the starting node is hidden or missing.

Both endpoints reuse the effective-visibility CTE from #99. The subtree CTE composes with the resolve CTE so the recursion only descends into visible nodes — a hidden ancestor severs its visible descendants from the response, preventing the gap-leak ("there's something here you can't see").

## Subtree CTE shape

For non-admins (admins skip the visibility CTE):

```sql
WITH RECURSIVE
  resolve         AS ( ... walk parent chain to first override-TRUE ancestor ... ),
  visible_starts  AS ( ... start_ids visible to caller ... ),
  subtree         AS (
    SELECT ..., 0 AS depth
    FROM nodes n JOIN maps m ... WHERE n.id = ? AND ...
      AND ((m.owner_id = ? AND m.owner_xray = TRUE)
           OR n.id IN (SELECT start_id FROM visible_starts))
    UNION ALL
    SELECT ..., s.depth + 1
    FROM subtree s JOIN nodes c ON c.parent_id = s.id JOIN maps mc ON ...
    WHERE s.depth < 15
      AND c.map_id = s.map_id
      AND ((mc.owner_id = ? AND mc.owner_xray = TRUE)
           OR c.id IN (SELECT start_id FROM visible_starts))
  )
SELECT * FROM subtree WHERE id > ? ORDER BY id ASC LIMIT ?
```

Bounded by `MAX_NODE_DEPTH = 15` (the same depth ceiling that prevents recursion blow-up elsewhere). The same-map guard (`c.map_id = s.map_id`) keeps the descent within the requested subtree's map even though `parent_id` could theoretically cross maps.

## Pagination

- Cursor-based: `?cursor=<lastId>&limit=N`. Cursor = last id seen on the previous page; subsequent page filters `WHERE id > cursor` and orders by id ASC. End-of-tree → `nextCursor: null`.
- Validation: `limit < 1`, `limit > 500`, non-integer cursor or limit → 400.

## Behaviour worth flagging

- **Hidden subtree root → 404, not 200 with empty array.** A 200 empty would still let the caller probe for existence; 404 is leak-safe.
- **`/children` of a hidden parent → 200 empty.** Matches the existing list endpoint behavior (`GET /nodes?parentId=N`) — no parent existence check, just visible-children only. The caller can't distinguish "hidden parent" from "visible parent with no visible children," which is fine for leak-safety.
- **`parentId` nulled when parent isn't in the response.** Same rule as #99 listNodes; applies to both `/children` and `/subtree`.

## Work breakdown

1. Sync nodes-rebuild + branch off as `feature/89-tree-navigation`
2. Review #89 ticket scope against the timeout calibration — single-PR-sized
3. Add `listChildren` + `getSubtree` route declarations to `NodeController.h`
4. Implement `listChildren` (mirror of `listNodes`'s SQL pattern with `parent_id = ?` filter)
5. Implement `getSubtree` — multi-CTE composition (resolve + visible_starts + subtree), pagination param parsing, depth field, 404-when-empty-on-first-page
6. Add same-map guard (`c.map_id = s.map_id`) to the recursive step
7. Build backend — fix one capture-list compile error in `listChildren`'s result callback (`id` not captured)
8. Restart Docker stack, run existing fast tier (regression check) — all green
9. Write `test_23_tree_navigation.py` — 41 assertions covering admin /children + /subtree, non-admin filtered views, depth values, pagination (multi-page traversal + bad params), cross-tenant blocked, owner_xray bypass, hidden-root 404
10. Add `test_23_tree_navigation.py` to `FAST_TESTS` + description
11. Run `test_23` standalone — all 41 pass on first run
12. Run full fast tier — all 17 suites pass (33s)
13. Public-repo diff scan — clean
14. Commit + push + open this PR

## Files changed

- **backend/src/controllers/NodeController.cpp** — Adds `listChildren` and `getSubtree` handlers. The subtree handler prepends the existing `VISIBILITY_RESOLVE_CTE` constant and extends it with a third `subtree` CTE (recursive walk down). Non-admins get the visibility-filtered subtree; admins skip the prefix and use a simpler CTE. Pagination params parsed with full validation (negative / out-of-range / non-integer all → 400).
- **backend/src/controllers/NodeController.h** — Two new route entries + method declarations; doc-string updated with the body shape and design notes.
- **backend/tests/test_23_tree_navigation.py** — New 41-assertion suite. Tree fixture covers 3 visibility branches (Players, GMs, second-Players) with mixed inheritance depths. Tests cover both admin and non-admin views of `/children` and `/subtree`, multi-page pagination via cursor, the bad-pagination-param rejection set, cross-tenant TenantFilter, and owner_xray bypass.
- **backend/tests/run-tests.py** — Adds `test_23_tree_navigation.py` to `FAST_TESTS` + description.

## Test plan

- [x] `python3 backend/tests/test_23_tree_navigation.py` — 41 passed, 0 failed
- [x] `python3 backend/tests/run-tests.py --tier fast` — 17/17 suites pass (33s)
- [ ] CI green on PR (E2E expected red — see below)

## Test expectations (CI on `nodes-rebuild`)

| Job | Expected | Why |
|---|---|---|
| `lint` | ✅ pass | No frontend changes. |
| `security` | ✅ pass | No new dependencies. |
| `compile` | ✅ pass | New handlers + multi-CTE composition compile cleanly. |
| `integration` (db tests) | ✅ pass | Schema unchanged; 179/179. |
| `integration` (backend tests) | ✅ pass | 17/17 suites pass locally including new `test_23_tree_navigation.py`. |
| `integration` (E2E) | ❌ **expected fail** | Annotations / cross-tenant E2E specs reference the old annotations frontend that was ripped out for the rebuild. Frontend rebuild lands in the #94 series. |

`integration` will report red overall because of the E2E sub-step. Mid-rebuild informational state — `main` remains the enforced gate.

## Out of scope

- Move/copy operations (Phase 2e — #90 / #100).
- Frontend tree UI (#93).

## Performance note

The ticket asks for `<500ms` on a 1000-node subtree. Not benchmarked against a 1000-node fixture in this PR; the expected perf is acceptable given the bounded recursion + indexed `parent_id` lookup, but a follow-up perf test against a synthetic large tree would be worth filing if it becomes a concern.

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)