### PR TITLE
Phase 2f follow-up: frontend rendering for pixel + blank coordinate systems (#128)

### DIFF
--- a/frontend/src/components/Map/MapView.tsx
+++ b/frontend/src/components/Map/MapView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { MapContainer, TileLayer, Marker, Polyline, Polygon, Popup } from 'react-leaflet';
+import { MapContainer, TileLayer, ImageOverlay, Marker, Polyline, Polygon, Popup } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
 import iconUrl from 'leaflet/dist/images/marker-icon.png';
@@ -194,22 +194,78 @@ export function MapView({ map, onNodeClick }: MapViewProps) {
     onNodeClick?.(nodeId);
   };
 
-  if (map.coordinateSystem.type !== 'wgs84') {
-    // Pixel and blank renderers land with #91's frontend follow-up. Stub
-    // here so the page is intelligible until then.
+  // All three renderers share the same node-layer rendering; the only
+  // difference is the MapContainer's CRS + base layer (or lack thereof).
+  // The GeoJSON [lng, lat] → Leaflet [lat, lng] swap in `pointLatLng` /
+  // `lineLatLngs` / `polygonLatLngs` is purely about GeoJSON's axis
+  // convention and applies regardless of CRS — for pixel maps the
+  // numbers mean (x, y) but the swap is still correct.
+
+  const cs = map.coordinateSystem;
+  const renderNodeLayers = () =>
+    nodes.map((n) => (
+      <NodeLayer
+        key={n.id}
+        node={n}
+        media={mediaByNode[n.id] ?? []}
+        onClick={handleClick}
+      />
+    ));
+
+  if (cs.type === 'pixel') {
+    // CRS.Simple maps coordinate (0, 0) to the top-left. The image
+    // overlay spans from (0, 0) to (height, width) — Leaflet expects
+    // bounds as [[y, x], [y, x]]. Viewport's (x, y) center maps the
+    // same way: pass [viewport.y, viewport.x].
+    const bounds: L.LatLngBoundsExpression = [
+      [0, 0],
+      [cs.height, cs.width],
+    ];
+    const center: [number, number] = [cs.viewport.y, cs.viewport.x];
     return (
-      <div className="map-view-stub">
-        <p>
-          <strong>Coordinate system <code>{map.coordinateSystem.type}</code>: rendering coming in #91.</strong>
-        </p>
-        <p>This map has {nodes.length} node(s); the renderer for non-WGS84 backdrops isn't wired yet.</p>
+      <div className="map-view">
+        {loadError && <div className="alert alert-error">{loadError}</div>}
+        <MapContainer
+          crs={L.CRS.Simple}
+          center={center}
+          zoom={cs.viewport.zoom}
+          minZoom={-5}
+          className="map-view-leaflet"
+        >
+          <ImageOverlay url={cs.image_url} bounds={bounds} />
+          {renderNodeLayers()}
+        </MapContainer>
       </div>
     );
   }
 
-  const cs = map.coordinateSystem;
-  const center: [number, number] = [cs.center.lat, cs.center.lng];
+  if (cs.type === 'blank') {
+    // No base layer — just the canvas + nodes. Center on the middle of
+    // the extent so the user sees something at default zoom.
+    const center: [number, number] = [cs.extent.y / 2, cs.extent.x / 2];
+    const maxBounds: L.LatLngBoundsExpression = [
+      [0, 0],
+      [cs.extent.y, cs.extent.x],
+    ];
+    return (
+      <div className="map-view">
+        {loadError && <div className="alert alert-error">{loadError}</div>}
+        <MapContainer
+          crs={L.CRS.Simple}
+          center={center}
+          zoom={0}
+          minZoom={-5}
+          maxBounds={maxBounds}
+          className="map-view-leaflet map-view-blank"
+        >
+          {renderNodeLayers()}
+        </MapContainer>
+      </div>
+    );
+  }
 
+  // wgs84 — standard OSM tile layer
+  const center: [number, number] = [cs.center.lat, cs.center.lng];
   return (
     <div className="map-view">
       {loadError && <div className="alert alert-error">{loadError}</div>}
@@ -218,14 +274,7 @@ export function MapView({ map, onNodeClick }: MapViewProps) {
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         />
-        {nodes.map((n) => (
-          <NodeLayer
-            key={n.id}
-            node={n}
-            media={mediaByNode[n.id] ?? []}
-            onClick={handleClick}
-          />
-        ))}
+        {renderNodeLayers()}
       </MapContainer>
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -334,6 +334,7 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
   text-align: center;
   color: var(--color-text-muted, #555);
 }
+.map-view-blank .leaflet-container { background: #f5f5f5; }
 .node-popup h3 { margin: 0 0 .5rem 0; font-size: 1rem; }
 .node-popup p  { margin: .25rem 0; }
 .node-popup-media { margin-top: .5rem; }

--- a/frontend/tests/e2e/coordinate-systems.spec.ts
+++ b/frontend/tests/e2e/coordinate-systems.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect, Page, APIRequestContext } from '@playwright/test';
+import { makeUser } from './helpers';
+
+/**
+ * E2E coverage for #128 (Phase 2f follow-up): pixel + blank map renderers.
+ *
+ * The new-map UI in MapListPage hardcodes `wgs84` defaults — there's no
+ * UI yet for editing `coordinateSystem` to `pixel` or `blank`. To exercise
+ * the renderers, this spec uses the backend API directly to register a
+ * user, create a map with the desired coordinate system, attach a node,
+ * then seeds `localStorage` so the browser session is authenticated and
+ * navigates to the map detail page. The MapView renderer is what's
+ * actually under test.
+ *
+ * Verification per type:
+ *  - `pixel` → `<img class="leaflet-image-layer">` with the right src,
+ *    plus a `.leaflet-marker-icon` for the placed node.
+ *  - `blank` → no image layer, MapContainer carries `map-view-blank`
+ *    class, marker is rendered.
+ */
+
+// The Playwright `request` fixture inherits the spec's baseURL (5173), but
+// the backend runs on a different port. Hit it directly so we don't bounce
+// through Vite's dev server.
+const API = process.env.PLAYWRIGHT_API_URL ?? 'http://localhost:8080/api/v1';
+
+interface ApiUser {
+  token: string;
+  tenantId: number;
+  user: { id: number; username: string; email: string };
+}
+
+async function registerViaApi(request: APIRequestContext, tag: string): Promise<ApiUser> {
+  const u = makeUser(tag);
+  const res = await request.post(`${API}/auth/register`, {
+    data: { username: u.username, email: u.email, password: u.password },
+  });
+  expect(res.ok()).toBeTruthy();
+  const body = await res.json();
+  return { token: body.token, tenantId: body.tenantId, user: body.user };
+}
+
+async function createMapViaApi(
+  request: APIRequestContext,
+  api: ApiUser,
+  title: string,
+  coordinateSystem: unknown,
+): Promise<{ id: number }> {
+  const res = await request.post(`${API}/tenants/${api.tenantId}/maps`, {
+    headers: { Authorization: `Bearer ${api.token}` },
+    data: { title, coordinateSystem },
+  });
+  if (!res.ok()) {
+    throw new Error(`createMap failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function createNodeViaApi(
+  request: APIRequestContext,
+  api: ApiUser,
+  mapId: number,
+  body: { name: string; geoJson: unknown },
+): Promise<{ id: number }> {
+  const res = await request.post(`${API}/tenants/${api.tenantId}/maps/${mapId}/nodes`, {
+    headers: { Authorization: `Bearer ${api.token}` },
+    data: body,
+  });
+  if (!res.ok()) {
+    throw new Error(`createNode failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+/** Seed the zustand-persisted auth storage so the SPA boots authenticated. */
+async function seedAuthInBrowser(page: Page, api: ApiUser): Promise<void> {
+  // First navigate so localStorage is scoped to the right origin.
+  await page.goto('/login');
+  await page.evaluate((api) => {
+    const persisted = {
+      state: {
+        token: api.token,
+        user: api.user,
+        orgId: null,
+        tenantId: api.tenantId,
+        tenants: [
+          { id: api.tenantId, name: '', slug: '', role: 'admin' as const },
+        ],
+        branding: {},
+      },
+      version: 0,
+    };
+    localStorage.setItem('auth-storage', JSON.stringify(persisted));
+  }, api);
+}
+
+test.describe('Pixel coordinate system', () => {
+  test('renders an image overlay and a marker for a placed node', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'cs_pixel');
+
+    const map = await createMapViaApi(request, api, 'Pixel Test Map', {
+      type: 'pixel',
+      // Use a stable host that returns *something* (200/404 doesn't matter
+      // — Leaflet still mounts the <img> with this src either way).
+      image_url: 'https://example.com/test-map.png',
+      width: 1024,
+      height: 768,
+      viewport: { x: 512, y: 384, zoom: 0 },
+    });
+
+    // Place a Point node in the middle of the image.
+    await createNodeViaApi(request, api, map.id, {
+      name: 'Pixel Pin',
+      geoJson: { type: 'Point', coordinates: [512, 384] },
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // Image overlay is present with our URL.
+    const imgLayer = page.locator('img.leaflet-image-layer');
+    await expect(imgLayer).toBeVisible();
+    await expect(imgLayer).toHaveAttribute('src', /test-map\.png$/);
+
+    // Marker for the node renders.
+    await expect(page.locator('.leaflet-marker-icon').first()).toBeVisible();
+
+    // The "coming in #91" stub banner should NOT be on the page — that
+    // would mean the dispatch fell through to the default branch.
+    await expect(page.getByText(/rendering coming in #91/i)).toHaveCount(0);
+  });
+});
+
+test.describe('Blank coordinate system', () => {
+  test('renders a blank canvas with a marker, no tile layer', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'cs_blank');
+
+    const map = await createMapViaApi(request, api, 'Blank Test Map', {
+      type: 'blank',
+      extent: { x: 1000, y: 800 },
+    });
+
+    await createNodeViaApi(request, api, map.id, {
+      name: 'Blank Pin',
+      geoJson: { type: 'Point', coordinates: [500, 400] },
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // Container has the blank-class marker that scopes the off-white bg.
+    await expect(page.locator('.map-view-blank')).toBeVisible();
+
+    // No image overlay (it's a blank canvas).
+    await expect(page.locator('img.leaflet-image-layer')).toHaveCount(0);
+
+    // No tile layer either.
+    await expect(page.locator('.leaflet-tile-pane img')).toHaveCount(0);
+
+    // Marker for the node renders.
+    await expect(page.locator('.leaflet-marker-icon').first()).toBeVisible();
+
+    // Stub banner absent.
+    await expect(page.getByText(/rendering coming in #91/i)).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Closes #128. Also closes **#91** — this PR is the home for the last bit of #91's work that wasn't shipped via #124 (backend validation) or #126 (#101 wgs84 + stub banners).

## Summary

Replaces the "coming in #91" stub branches in `MapView.tsx` with the actual renderers for the two non-WGS84 coordinate systems:

| Type | Container CRS | Base layer | Center | Bounds |
|---|---|---|---|---|
| `pixel` | `L.CRS.Simple` | `<ImageOverlay url={image_url} bounds={[[0,0],[height,width]]} />` | `[viewport.y, viewport.x]` | implicit (image extent) |
| `blank` | `L.CRS.Simple` | _none_ | `[extent.y/2, extent.x/2]` | `maxBounds={[[0,0],[extent.y,extent.x]]}` |

Node rendering is unchanged — Marker / Polyline / Polygon per geometry, the `[lng, lat]` → `[lat, lng]` swap already in place is correct for `CRS.Simple` too (it's about GeoJSON's axis convention, not the CRS).

E2E coverage added (see "Test plan").

## Why this isn't bundled inside #101 / #126

Two related reasons:

1. **#101's ticket explicitly excluded pixel/blank rendering** (out-of-scope: "pixel/blank rendering (#91)"). My earlier comment on #91 incorrectly claimed otherwise — fixed in [the corrected status comment on #91](https://github.com/dcltdw/annotated-maps/issues/91#issuecomment-4346707598).
2. **Splitting kept the #126 PR focused** on the wgs84 path + dispatch infrastructure, with stub banners as the explicit user-visible "this is coming" affordance for the other types.

## E2E test approach

The new-map UI in `MapListPage` hardcodes `wgs84` defaults — there's no UI yet to create or edit a `pixel`/`blank` map. To exercise the renderers, the spec uses the backend API directly:

1. `registerViaApi` → POST `/auth/register` → captures `{ token, tenantId, user }`.
2. `createMapViaApi` → POST `/tenants/N/maps` with the desired `coordinateSystem`.
3. `createNodeViaApi` → POST `/tenants/N/maps/M/nodes` with a Point geometry.
4. `seedAuthInBrowser` → writes the captured auth state into `localStorage['auth-storage']` so the SPA boots authenticated.
5. `page.goto(...)` to the map detail URL.
6. Assert against the rendered Leaflet DOM:
   - **pixel**: `<img class="leaflet-image-layer">` exists with `src` matching the supplied `image_url`; `.leaflet-marker-icon` for the placed node is visible; the "rendering coming in #91" stub copy is absent.
   - **blank**: `.map-view-blank` class is present (so the off-white canvas styling applies); zero `img.leaflet-image-layer`; zero `.leaflet-tile-pane img`; `.leaflet-marker-icon` visible; stub copy absent.

The `request` fixture's baseURL points at Vite (`localhost:5173`); the backend lives on `localhost:8080`, so the spec uses `process.env.PLAYWRIGHT_API_URL ?? 'http://localhost:8080/api/v1'` for direct API calls. (One iteration: first run failed at `register` because I'd used the relative path — fixed by switching to the absolute backend URL.)

## Work breakdown

1. Sync nodes-rebuild + branch off as `feature/128-pixel-blank-rendering`
2. Read the existing MapView dispatch (post-#101) — the `coordinateSystem.type !== 'wgs84'` branch is the stub I'm replacing
3. Add `ImageOverlay` to the react-leaflet import
4. Replace the stub branch with two early-return blocks: one for `pixel` (CRS.Simple + ImageOverlay), one for `blank` (CRS.Simple, no base layer, maxBounds). Both reuse the shared `renderNodeLayers()` factory so node rendering is identical across the three CRS types.
5. Add `.map-view-blank .leaflet-container { background: #f5f5f5; }` to give the otherwise-empty blank canvas a visible color
6. Run `tsc --noEmit` + `npm run lint` — clean
7. Write `coordinate-systems.spec.ts` with two tests (one per non-WGS84 type)
8. Run the new spec — both fail at `register` (relative path → Vite, not backend)
9. Fix: switch to absolute backend URL via `process.env.PLAYWRIGHT_API_URL ?? 'http://localhost:8080/api/v1'`
10. Re-run the new spec — both pass (3.0s)
11. Re-run full E2E suite — 18 passed, 5 fixme'd, 0 failed (16.1s)
12. Public-repo diff scan — clean
13. Commit + push + open this PR

## Files changed

- **frontend/src/components/Map/MapView.tsx** — Pixel + blank renderers replace the stub branch. Adds `ImageOverlay` import. Extracts a `renderNodeLayers()` factory shared across all three CRS types.
- **frontend/src/index.css** — One line: `.map-view-blank .leaflet-container { background: #f5f5f5; }`.
- **frontend/tests/e2e/coordinate-systems.spec.ts** *(new)* — 2 tests, ~135 lines including helpers for API-driven setup + `localStorage` seeding.

## Test plan

- [x] `docker compose exec frontend npx tsc --noEmit` — clean
- [x] `docker compose exec frontend npm run lint` — clean
- [x] `npx playwright test tests/e2e/coordinate-systems.spec.ts` — 2 passed (3.0s)
- [x] `npx playwright test` (full suite) — 18 passed, 5 fixme, 0 failed (16.1s)
- [ ] CI green on PR

## Out of scope

- File upload for `image_url` (URLs only — same constraint as #91).
- UI for editing `coordinateSystem` on existing maps (admin can change via API).
- Custom projections / GeoTIFF / other CRSes (extend later if needed).

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none** (test uses `https://example.com/test-map.png`, intentionally; backend URL `http://localhost:8080/api/v1` is dev-stack-local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)