### PR TITLE
ci: skip PR-comment step on push events (no PR number to comment on)

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -262,7 +262,12 @@ jobs:
           retention-days: 7
 
       - name: Post test summary to PR
-        if: always() && steps.db_tests.outcome != 'skipped'
+        # Only fires for pull_request events. The workflow also runs on
+        # push to nodes-rebuild (post-merge verification), which has no
+        # PR number to comment on — without this gate the step constructs
+        # `…/issues//comments` and the API call 404s, marking the run red
+        # for what's actually just incidental noise.
+        if: always() && steps.db_tests.outcome != 'skipped' && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary

Adds a `github.event_name == 'pull_request'` guard to the "Post test summary to PR" step in `pr-tests.yml`. Without it, that step fires on push-event runs (post-merge verification on `nodes-rebuild`, per the CI extension in #109), where there's no originating PR number — the API URL gets constructed as `.../issues//comments` (note the empty path segment), GitHub returns 404, and the whole run gets marked red.

Concrete trigger: [run 25128254899](https://github.com/dcltdw/annotated-maps/actions/runs/25128254899) on `nodes-rebuild`. Substance steps (db tests, backend tests, E2E) all passed; the only red mark was the post-summary step trying to comment on PR `<empty>`. Without this fix every post-merge push to `nodes-rebuild` produces the same noisy red.

## Work breakdown

1. Read run 25128254899's logs — confirm the failure is in "Post test summary to PR" with `…/issues//comments` 404, and that all preceding test steps passed
2. Locate the failing step in `.github/workflows/pr-tests.yml` (line 264)
3. Add `&& github.event_name == 'pull_request'` to the existing `if:` guard
4. Add a comment explaining why the gate exists, so a future reader doesn't drop it on a clean-up pass
5. Commit + push + open this PR

## Files changed

- **.github/workflows/pr-tests.yml** — Three-line addition (gate + explanatory comment).

## Test plan

- [x] YAML edit verified by reading; only the targeted `if:` line plus a comment block changed.
- [ ] Verify by observation: this PR's own CI run *should* exercise the post-summary step (since this PR is itself a `pull_request` event into `main`), and a future post-merge push to `main` should run the workflow without firing the post-summary step.

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)