### PR TITLE
Phase 2g.d: NodeTreePanel — tree of nodes, expand/collapse, click-to-pan (#93)

### DIFF
--- a/frontend/src/components/Map/MapView.tsx
+++ b/frontend/src/components/Map/MapView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { MapContainer, TileLayer, ImageOverlay, Marker, Polyline, Polygon, Popup } from 'react-leaflet';
+import { MapContainer, TileLayer, ImageOverlay, Marker, Polyline, Polygon, Popup, useMap as useLeafletMap } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
 import iconUrl from 'leaflet/dist/images/marker-icon.png';
@@ -150,11 +150,29 @@ function NodeLayer({ node, media, onClick }: NodeLayerProps) {
 
 interface MapViewProps {
   map: MapRecord;
-  /** Fired when a node is clicked. The detail panel that listens lands in #93. */
+  /** Fired when a node layer is clicked on the map. */
   onNodeClick?: (nodeId: number) => void;
+  /**
+   * When set, fly the map to these coordinates. Setting it again with the
+   * same values (new tuple identity) re-pans — clicking the same node
+   * twice in the tree should re-center the map both times.
+   */
+  panTarget?: [number, number] | null;
 }
 
-export function MapView({ map, onNodeClick }: MapViewProps) {
+// Mounted inside MapContainer so it has access to the leaflet map instance.
+// Reacts to panTarget changes by flying the view to the requested coords.
+function PanController({ target }: { target: [number, number] | null | undefined }) {
+  const leafletMap = useLeafletMap();
+  useEffect(() => {
+    if (target) {
+      leafletMap.flyTo(target, leafletMap.getZoom(), { duration: 0.4 });
+    }
+  }, [target, leafletMap]);
+  return null;
+}
+
+export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
   const [nodes, setNodes] = useState<NodeRecord[]>([]);
   const [mediaByNode, setMediaByNode] = useState<Record<number, NodeMediaRecord[]>>({});
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -234,6 +252,7 @@ export function MapView({ map, onNodeClick }: MapViewProps) {
         >
           <ImageOverlay url={cs.image_url} bounds={bounds} />
           {renderNodeLayers()}
+          <PanController target={panTarget} />
         </MapContainer>
       </div>
     );
@@ -259,6 +278,7 @@ export function MapView({ map, onNodeClick }: MapViewProps) {
           className="map-view-leaflet map-view-blank"
         >
           {renderNodeLayers()}
+          <PanController target={panTarget} />
         </MapContainer>
       </div>
     );
@@ -275,6 +295,7 @@ export function MapView({ map, onNodeClick }: MapViewProps) {
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         />
         {renderNodeLayers()}
+        <PanController target={panTarget} />
       </MapContainer>
     </div>
   );

--- a/frontend/src/components/Tree/NodeTreePanel.tsx
+++ b/frontend/src/components/Tree/NodeTreePanel.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useState } from 'react';
+import { nodesService } from '@/services/maps';
+import type { NodeRecord, GeoJsonGeometry } from '@/types';
+
+// NodeTreePanel — Phase 2g.d (#93). Replaces the deleted flat NotesPanel
+// from before the rebuild with the tree-of-nodes UI.
+//
+// Top-level rows are loaded eagerly (parentId=null filter); each row
+// fetches its children lazily on first expand. Selecting a row emits
+// the node id upward; clicking a row with geometry also pans the map
+// to a derived location (Point: itself, LineString/Polygon: first
+// vertex). Detail view + inline note CRUD lands in #103; this PR
+// exposes the selectedNodeId state for that ticket to consume.
+
+interface NodeTreePanelProps {
+  mapId: number;
+  selectedNodeId: number | null;
+  onSelectNode: (nodeId: number) => void;
+  onPanToNode: (coords: [number, number]) => void;
+}
+
+export function NodeTreePanel({
+  mapId,
+  selectedNodeId,
+  onSelectNode,
+  onPanToNode,
+}: NodeTreePanelProps) {
+  const [rootNodes, setRootNodes] = useState<NodeRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    nodesService
+      .listNodes(mapId, null)
+      .then((ns) => {
+        if (!cancelled) setRootNodes(ns);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Failed to load nodes.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [mapId]);
+
+  return (
+    <aside className="node-tree-panel">
+      <div className="node-tree-header">
+        <h3>Nodes</h3>
+      </div>
+      {loading && <div className="node-tree-state">Loading…</div>}
+      {error && <div className="alert alert-error">{error}</div>}
+      {!loading && !error && rootNodes.length === 0 && (
+        <div className="node-tree-state">No nodes on this map yet.</div>
+      )}
+      <div className="node-tree-list">
+        {rootNodes.map((node) => (
+          <NodeTreeRow
+            key={node.id}
+            mapId={mapId}
+            node={node}
+            depth={0}
+            selectedNodeId={selectedNodeId}
+            onSelect={onSelectNode}
+            onPan={onPanToNode}
+          />
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+// ─── Per-row recursive component ─────────────────────────────────────────────
+
+interface NodeTreeRowProps {
+  mapId: number;
+  node: NodeRecord;
+  depth: number;
+  selectedNodeId: number | null;
+  onSelect: (nodeId: number) => void;
+  onPan: (coords: [number, number]) => void;
+}
+
+function NodeTreeRow({
+  mapId,
+  node,
+  depth,
+  selectedNodeId,
+  onSelect,
+  onPan,
+}: NodeTreeRowProps) {
+  // `children === null` means we haven't fetched yet; `[]` means we have
+  // and there are none. The toggle is shown until we know for certain
+  // the node is a leaf (then it's a placeholder for layout consistency).
+  const [expanded, setExpanded] = useState(false);
+  const [children, setChildren] = useState<NodeRecord[] | null>(null);
+  const [loadingChildren, setLoadingChildren] = useState(false);
+  const [childrenError, setChildrenError] = useState<string | null>(null);
+
+  const handleToggle = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (children === null && !loadingChildren) {
+      setLoadingChildren(true);
+      setChildrenError(null);
+      try {
+        const fetched = await nodesService.listChildren(mapId, node.id);
+        setChildren(fetched);
+        setExpanded(true);
+      } catch {
+        setChildrenError('Failed to load children.');
+      } finally {
+        setLoadingChildren(false);
+      }
+    } else {
+      setExpanded((e) => !e);
+    }
+  };
+
+  const handleSelect = () => {
+    onSelect(node.id);
+    if (node.geoJson) {
+      const coords = derivePanCoords(node.geoJson);
+      if (coords) onPan(coords);
+    }
+  };
+
+  const isLeaf = children !== null && children.length === 0;
+  const isSelected = selectedNodeId === node.id;
+
+  return (
+    <div className="node-tree-row" style={{ paddingLeft: `${depth * 16}px` }}>
+      <div className={`node-tree-row-inner ${isSelected ? 'selected' : ''}`}>
+        {isLeaf ? (
+          <span className="node-tree-toggle node-tree-toggle-spacer" />
+        ) : (
+          <button
+            type="button"
+            className="node-tree-toggle"
+            onClick={handleToggle}
+            disabled={loadingChildren}
+            aria-label={expanded ? 'Collapse' : 'Expand'}
+          >
+            {loadingChildren ? '…' : expanded ? '▼' : '▶'}
+          </button>
+        )}
+        {node.color && (
+          <span
+            className="node-tree-color"
+            style={{ background: node.color }}
+            aria-hidden="true"
+          />
+        )}
+        <button
+          type="button"
+          className="node-tree-name"
+          onClick={handleSelect}
+          title={node.name}
+        >
+          {node.name}
+        </button>
+        {/* Move/copy menu placeholder — wired up when the move/copy frontend
+            ticket lands; backend support is in #90 / #100. */}
+        <button
+          type="button"
+          className="node-tree-menu"
+          title="Move/copy (coming soon)"
+          disabled
+          aria-label="Node actions"
+        >
+          ⋯
+        </button>
+      </div>
+      {childrenError && <div className="alert alert-error">{childrenError}</div>}
+      {expanded && children && children.length > 0 && (
+        <div className="node-tree-children">
+          {children.map((c) => (
+            <NodeTreeRow
+              key={c.id}
+              mapId={mapId}
+              node={c}
+              depth={depth + 1}
+              selectedNodeId={selectedNodeId}
+              onSelect={onSelect}
+              onPan={onPan}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Derive pan coordinates from a GeoJSON geometry ──────────────────────────
+// Returns Leaflet's [lat, lng] tuple. For LineString/Polygon we pick the
+// first vertex — predictable and cheap. (Computing centroids would be
+// nicer but isn't worth the complexity for this ticket.)
+
+function derivePanCoords(g: GeoJsonGeometry): [number, number] | null {
+  if (g.type === 'Point') {
+    const [lng, lat] = g.coordinates as [number, number];
+    return [lat, lng];
+  }
+  if (g.type === 'LineString') {
+    const first = (g.coordinates as [number, number][])[0];
+    return first ? [first[1], first[0]] : null;
+  }
+  if (g.type === 'Polygon') {
+    const first = (g.coordinates as [number, number][][])[0]?.[0];
+    return first ? [first[1], first[0]] : null;
+  }
+  return null;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -335,6 +335,96 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
   color: var(--color-text-muted, #555);
 }
 .map-view-blank .leaflet-container { background: #f5f5f5; }
+
+/* ─── Map detail layout (tree panel + map, #93) ────────────────────────────── */
+.map-detail-layout {
+  display: flex;
+  gap: 1rem;
+  margin: 1rem 0;
+  height: 600px;
+}
+.map-detail-layout .map-view {
+  flex: 1;
+  margin: 0;
+}
+
+/* ─── Node tree panel (#93) ─────────────────────────────────────────────────── */
+.node-tree-panel {
+  width: 280px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+.node-tree-header {
+  padding: .5rem .75rem;
+  border-bottom: 1px solid var(--color-border);
+  background: #fafafa;
+}
+.node-tree-header h3 { margin: 0; font-size: .9rem; font-weight: 600; }
+.node-tree-state {
+  padding: .75rem;
+  font-size: .85rem;
+  color: var(--color-text-muted, #666);
+}
+.node-tree-list { padding: .25rem 0; }
+.node-tree-row { font-size: .85rem; }
+.node-tree-row-inner {
+  display: flex;
+  align-items: center;
+  gap: .25rem;
+  padding: .25rem .5rem;
+}
+.node-tree-row-inner.selected { background: #eff6ff; }
+.node-tree-row-inner:hover { background: #f5f5f5; }
+.node-tree-row-inner.selected:hover { background: #dbeafe; }
+.node-tree-toggle {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  font-size: .7rem;
+  color: var(--color-text-muted, #666);
+}
+.node-tree-toggle:hover { color: var(--color-text); }
+.node-tree-toggle:disabled { cursor: not-allowed; opacity: .6; }
+.node-tree-toggle-spacer { display: inline-block; width: 18px; height: 18px; }
+.node-tree-color {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1px solid #ccc;
+  flex-shrink: 0;
+}
+.node-tree-name {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  flex: 1;
+  padding: 0;
+  font-size: inherit;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.node-tree-name:hover { color: var(--color-primary); }
+.node-tree-menu {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 0 .25rem;
+  color: var(--color-text-muted, #888);
+  font-size: 1rem;
+}
+.node-tree-menu:disabled { cursor: not-allowed; opacity: .4; }
+
 .node-popup h3 { margin: 0 0 .5rem 0; font-size: 1rem; }
 .node-popup p  { margin: .25rem 0; }
 .node-popup-media { margin-top: .5rem; }

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { MapView } from '@/components/Map/MapView';
+import { NodeTreePanel } from '@/components/Tree/NodeTreePanel';
 import { useMap } from '@/hooks/useMap';
 
-// Map detail page. The map view itself rebuilt in #101; the tree panel,
-// node detail view, and edit/delete affordances follow in #93 / #103.
-// For now: load the map record + render the MapView. Node click events
-// surface as a transient banner so the wiring is observable until #93's
-// detail panel listens for them properly.
+// Map detail page. NodeTreePanel + MapView are both wired up to a shared
+// selectedNodeId state — clicking a node in either surface highlights
+// it everywhere. The detail view that listens to selection lands in
+// #103; for now selection just shows a transient banner so the wiring
+// is observable.
 
 export function MapDetailPage() {
   const { mapId, tenantId } = useParams<{ mapId: string; tenantId: string }>();
@@ -16,6 +17,7 @@ export function MapDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
+  const [panTarget, setPanTarget] = useState<[number, number] | null>(null);
 
   useEffect(() => {
     if (!mapId) return;
@@ -40,10 +42,22 @@ export function MapDetailPage() {
       {activeMap.description && <p>{activeMap.description}</p>}
       {selectedNodeId !== null && (
         <div className="alert alert-info">
-          Selected node #{selectedNodeId}. Detail panel lands in #93.
+          Selected node #{selectedNodeId}. Detail panel lands in #103.
         </div>
       )}
-      <MapView map={activeMap} onNodeClick={setSelectedNodeId} />
+      <div className="map-detail-layout">
+        <NodeTreePanel
+          mapId={activeMap.id}
+          selectedNodeId={selectedNodeId}
+          onSelectNode={setSelectedNodeId}
+          onPanToNode={(coords) => setPanTarget(coords)}
+        />
+        <MapView
+          map={activeMap}
+          onNodeClick={setSelectedNodeId}
+          panTarget={panTarget}
+        />
+      </div>
       <button className="btn btn-ghost" onClick={() => navigate(`/tenants/${tenantId}/maps`)}>
         Back to maps
       </button>


### PR DESCRIPTION
Closes #93 (will close manually after merge — auto-close skips non-default-branch PRs).

## Summary

Adds the tree-of-nodes UI alongside the map view: top-level nodes load eagerly via `nodesService.listNodes(mapId, null)`; each row fetches its children lazily on first expand via the dedicated `/children` endpoint from #89. Selecting a row emits the node id upward; clicking a row with geometry also pans the map (Point → itself, LineString/Polygon → first vertex). Selection state is shared between the panel and `MapView` — clicking a layer on the map highlights the same row in the tree.

Detail view + inline notes CRUD lands in **#103 (93.b)**. E2E coverage for the tree behaviors lands in **#104 (93.c)**. The `...` menu on each row is a disabled placeholder until the move/copy frontend ticket lands (backend already shipped in #90 / #100).

## How click-to-pan works

`MapView` accepts a new `panTarget?: [number, number] | null` prop. A small `PanController` child sits inside the `MapContainer` and uses `useLeafletMap()` to call `leafletMap.flyTo(target, zoom, { duration: 0.4 })` when the prop changes. `MapDetailPage` holds the panTarget state — `NodeTreePanel.onPanToNode` calls `setPanTarget(coords)` on row click.

Tuple identity matters here: React's `useEffect` deps compare by `Object.is`, so each new `setPanTarget([lat, lng])` call (even with the same values) creates a new tuple and re-fires the effect. That's the desired behavior — clicking the same row twice re-pans the map both times.

## Lazy children fetch

Each `NodeTreeRow` keeps its own `children: NodeRecord[] | null` state. `null` means "haven't fetched yet"; `[]` means "fetched, none." On first expand the toggle calls `nodesService.listChildren(mapId, nodeId)`, populates state, and switches to the expanded view. Subsequent toggles just flip the `expanded` flag without re-fetching.

That keeps the initial render cheap (one round-trip for the roots) and the deeply-nested case affordable (only paths the user actually opens get fetched). `MAX_NODE_DEPTH = 15` from the backend bounds the worst case anyway.

## Work breakdown

1. Sync nodes-rebuild + branch off as `feature/93-node-tree-panel`
2. Author `frontend/src/components/Tree/NodeTreePanel.tsx`:
   - `NodeTreePanel` — eager root fetch + loading / error / empty states
   - `NodeTreeRow` — recursive, holds its own expanded + lazy-children state
   - `derivePanCoords` helper — geometry → Leaflet `[lat, lng]`
3. Add `panTarget` prop + `PanController` child to `MapView`; insert into all three CRS branches (wgs84 / pixel / blank)
4. Update `MapDetailPage` — flex layout for panel + map, shared `selectedNodeId` state, panTarget plumbing, banner now points at #103 (was #93)
5. Add CSS for `.map-detail-layout` + `.node-tree-*` classes (panel chrome, row hover/selected, color dot, indent)
6. Run `tsc --noEmit` + `npm run lint` — clean
7. Run full E2E suite — 18 passed, 5 fixme'd, 0 failed (regression check, no new specs added here per ticket scope)
8. Smoke check: Vite serves `/src/components/Tree/NodeTreePanel.tsx` (200), HMR clean
9. Public-repo diff scan — clean
10. Commit + push + open this PR

## Files changed

- **frontend/src/components/Tree/NodeTreePanel.tsx** *(new)* — `NodeTreePanel` + `NodeTreeRow` + `derivePanCoords`. ~210 lines including the per-row state machine.
- **frontend/src/components/Map/MapView.tsx** — Adds `panTarget` prop; new `PanController` child wired into all three CRS branches; one extra import (`useLeafletMap` aliased from `useMap`).
- **frontend/src/pages/MapDetailPage.tsx** — Renders `NodeTreePanel` + `MapView` side-by-side; shared `selectedNodeId` state; panTarget state; banner copy updated `#93 → #103`.
- **frontend/src/index.css** — `.map-detail-layout` (flex container) + `.node-tree-*` classes.

## Test plan

- [x] `docker compose exec frontend npx tsc --noEmit` — clean
- [x] `docker compose exec frontend npm run lint` — clean
- [x] `npx playwright test` — 18 passed, 5 fixme, 0 failed (no regressions)
- [x] Vite serves the new component module on `/src/components/Tree/NodeTreePanel.tsx` (200)
- [ ] CI green on PR
- Note: dedicated E2E for expand/collapse + click-to-pan is **out of scope** per the ticket (lands in #104).

## Out of scope (deliberate, per ticket)

- Detail view + inline notes CRUD — #103.
- Visibility-tagging UI — #94 series.
- Plot UI — #95.
- Move/copy UI — `...` menu placeholder kept disabled; backend exists in #90/#100.
- E2E for tree behaviors — #104.

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)