### PR TITLE
Phase 2g.e: Node detail view + inline notes CRUD (#103)

### DIFF
--- a/frontend/src/components/Detail/NodeDetailPanel.tsx
+++ b/frontend/src/components/Detail/NodeDetailPanel.tsx
@@ -1,0 +1,471 @@
+import { useCallback, useEffect, useState } from 'react';
+import { nodesService, notesService, nodeMediaService } from '@/services/maps';
+import { extractApiError } from '@/utils/errors';
+import type {
+  NodeRecord,
+  NodeMediaRecord,
+  NoteRecord,
+  CreateNoteRequest,
+  UpdateNoteRequest,
+} from '@/types';
+
+// NodeDetailPanel — Phase 2g.e (#103). Lives below the tree+map layout
+// in MapDetailPage. When a node is selected (in either the tree or by
+// clicking a layer on the map), this panel shows:
+//   - heading: name
+//   - parent link (clickable; calls onSelectNode for navigation)
+//   - description
+//   - color indicator
+//   - media list (image thumbnails + link list)
+//   - inline notes CRUD (list pinned-first, create/edit/delete)
+//
+// Empty state when nothing is selected.
+
+interface NodeDetailPanelProps {
+  mapId: number;
+  selectedNodeId: number | null;
+  onSelectNode: (nodeId: number) => void;
+}
+
+export function NodeDetailPanel({
+  mapId,
+  selectedNodeId,
+  onSelectNode,
+}: NodeDetailPanelProps) {
+  const [node, setNode] = useState<NodeRecord | null>(null);
+  const [parent, setParent] = useState<NodeRecord | null>(null);
+  const [media, setMedia] = useState<NodeMediaRecord[]>([]);
+  const [notes, setNotes] = useState<NoteRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reload notes after a CRUD op. Tightly scoped so callers don't need
+  // to know the mapId / nodeId separately.
+  const reloadNotes = useCallback(async () => {
+    if (selectedNodeId === null) return;
+    try {
+      const fresh = await notesService.listNotesForNode(mapId, selectedNodeId);
+      setNotes(fresh);
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to refresh notes.'));
+    }
+  }, [mapId, selectedNodeId]);
+
+  useEffect(() => {
+    if (selectedNodeId === null) {
+      setNode(null);
+      setParent(null);
+      setMedia([]);
+      setNotes([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    nodesService
+      .getNode(mapId, selectedNodeId)
+      .then(async (n) => {
+        if (cancelled) return;
+        setNode(n);
+
+        // Parent fetch (one-level breadcrumb). The tree panel renders the
+        // full chain; this is just the immediate-up navigation hop.
+        if (n.parentId !== null) {
+          nodesService
+            .getNode(mapId, n.parentId)
+            .then((p) => { if (!cancelled) setParent(p); })
+            .catch(() => { if (!cancelled) setParent(null); });
+        } else {
+          setParent(null);
+        }
+
+        // Media + notes in parallel; failures don't block each other.
+        const [m, ns] = await Promise.all([
+          nodeMediaService.listMedia(mapId, n.id).catch(() => [] as NodeMediaRecord[]),
+          notesService.listNotesForNode(mapId, n.id).catch(() => [] as NoteRecord[]),
+        ]);
+        if (!cancelled) {
+          setMedia(m);
+          setNotes(ns);
+        }
+      })
+      .catch((e) => { if (!cancelled) setError(extractApiError(e, 'Failed to load node.')); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [mapId, selectedNodeId]);
+
+  if (selectedNodeId === null) {
+    return (
+      <section className="node-detail-panel node-detail-empty">
+        <p>Select a node to see its details.</p>
+      </section>
+    );
+  }
+  if (loading && !node) {
+    return <section className="node-detail-panel">Loading node…</section>;
+  }
+  if (error) {
+    return (
+      <section className="node-detail-panel">
+        <div className="alert alert-error">{error}</div>
+      </section>
+    );
+  }
+  if (!node) return null;
+
+  return (
+    <section className="node-detail-panel">
+      <header className="node-detail-header">
+        <div className="node-detail-titlebar">
+          {node.color && (
+            <span
+              className="node-detail-color"
+              style={{ background: node.color }}
+              aria-hidden="true"
+            />
+          )}
+          <h2>{node.name}</h2>
+        </div>
+        {parent && (
+          <p className="node-detail-breadcrumb">
+            in{' '}
+            <button
+              type="button"
+              className="link-button"
+              onClick={() => onSelectNode(parent.id)}
+            >
+              {parent.name}
+            </button>
+          </p>
+        )}
+      </header>
+
+      {node.description && (
+        <p className="node-detail-description">{node.description}</p>
+      )}
+
+      {media.length > 0 && (
+        <div className="node-detail-media">
+          <h3>Media</h3>
+          {media.filter((m) => m.mediaType === 'image').length > 0 && (
+            <div className="node-detail-media-images">
+              {media
+                .filter((m) => m.mediaType === 'image')
+                .map((m) => (
+                  <img
+                    key={m.id}
+                    src={m.url}
+                    alt={m.caption || node.name}
+                    className="node-detail-thumb"
+                  />
+                ))}
+            </div>
+          )}
+          {media.filter((m) => m.mediaType === 'link').length > 0 && (
+            <ul className="node-detail-media-links">
+              {media
+                .filter((m) => m.mediaType === 'link')
+                .map((m) => (
+                  <li key={m.id}>
+                    <a href={m.url} target="_blank" rel="noopener noreferrer">
+                      {m.caption || m.url}
+                    </a>
+                  </li>
+                ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      <NotesList
+        mapId={mapId}
+        nodeId={node.id}
+        notes={notes}
+        onChange={reloadNotes}
+      />
+    </section>
+  );
+}
+
+// ─── Notes list + inline CRUD ────────────────────────────────────────────────
+
+interface NotesListProps {
+  mapId: number;
+  nodeId: number;
+  notes: NoteRecord[];
+  onChange: () => Promise<void> | void;
+}
+
+function NotesList({ mapId, nodeId, notes, onChange }: NotesListProps) {
+  const [showCreate, setShowCreate] = useState(false);
+
+  // Pinned-first sort (server already does this; defensive re-sort here so
+  // optimistic updates don't drift from the rule).
+  const sorted = [...notes].sort((a, b) => {
+    if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+    return a.createdAt.localeCompare(b.createdAt);
+  });
+
+  return (
+    <div className="node-detail-notes">
+      <div className="node-detail-notes-header">
+        <h3>Notes</h3>
+        {!showCreate && (
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            onClick={() => setShowCreate(true)}
+          >
+            + Note
+          </button>
+        )}
+      </div>
+      {showCreate && (
+        <CreateNoteForm
+          mapId={mapId}
+          nodeId={nodeId}
+          onCancel={() => setShowCreate(false)}
+          onSaved={async () => {
+            setShowCreate(false);
+            await onChange();
+          }}
+        />
+      )}
+      {sorted.length === 0 && !showCreate && (
+        <p className="node-detail-notes-empty">No notes yet.</p>
+      )}
+      <ul className="node-detail-notes-list">
+        {sorted.map((n) => (
+          <li key={n.id}>
+            <NoteCard mapId={mapId} note={n} onChange={onChange} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface CreateNoteFormProps {
+  mapId: number;
+  nodeId: number;
+  onCancel: () => void;
+  onSaved: () => Promise<void> | void;
+}
+
+function CreateNoteForm({ mapId, nodeId, onCancel, onSaved }: CreateNoteFormProps) {
+  const [title, setTitle] = useState('');
+  const [text, setText] = useState('');
+  const [color, setColor] = useState('');
+  const [pinned, setPinned] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSaving(true);
+    try {
+      const req: CreateNoteRequest = { text, pinned };
+      if (title) req.title = title;
+      if (color) req.color = color;
+      await notesService.createNote(mapId, nodeId, req);
+      await onSaved();
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to create note.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="note-form">
+      {error && <div className="alert alert-error">{error}</div>}
+      <input
+        type="text"
+        placeholder="Title (optional)"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <textarea
+        placeholder="Note text"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        required
+        rows={3}
+      />
+      <div className="note-form-row">
+        <input
+          type="text"
+          placeholder="Color (e.g. #ff0000)"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          className="note-form-color"
+        />
+        <label className="note-form-pinned">
+          <input
+            type="checkbox"
+            checked={pinned}
+            onChange={(e) => setPinned(e.target.checked)}
+          />
+          Pinned
+        </label>
+      </div>
+      <div className="note-form-actions">
+        <button type="button" className="btn btn-ghost btn-sm" onClick={onCancel} disabled={saving}>
+          Cancel
+        </button>
+        <button type="submit" className="btn btn-primary btn-sm" disabled={saving || !text}>
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+interface NoteCardProps {
+  mapId: number;
+  note: NoteRecord;
+  onChange: () => Promise<void> | void;
+}
+
+function NoteCard({ mapId, note, onChange }: NoteCardProps) {
+  const [editing, setEditing] = useState(false);
+
+  const handleDelete = async () => {
+    if (!window.confirm('Delete this note?')) return;
+    try {
+      await notesService.deleteNote(mapId, note.id);
+      await onChange();
+    } catch (e) {
+      window.alert(extractApiError(e, 'Failed to delete note.'));
+    }
+  };
+
+  if (editing) {
+    return (
+      <EditNoteForm
+        mapId={mapId}
+        note={note}
+        onCancel={() => setEditing(false)}
+        onSaved={async () => {
+          setEditing(false);
+          await onChange();
+        }}
+      />
+    );
+  }
+
+  return (
+    <article
+      className={`note-card ${note.pinned ? 'note-card-pinned' : ''}`}
+      style={note.color ? { borderLeftColor: note.color } : undefined}
+    >
+      <header className="note-card-header">
+        <div className="note-card-titlebar">
+          {note.pinned && <span className="note-pin" title="Pinned">📌</span>}
+          {note.title && <strong>{note.title}</strong>}
+        </div>
+        {note.canEdit && (
+          <div className="note-card-actions">
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={() => setEditing(true)}
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={handleDelete}
+            >
+              Delete
+            </button>
+          </div>
+        )}
+      </header>
+      <p className="note-card-text">{note.text}</p>
+      <footer className="note-card-footer">
+        <small>by {note.createdByUsername}</small>
+      </footer>
+    </article>
+  );
+}
+
+interface EditNoteFormProps {
+  mapId: number;
+  note: NoteRecord;
+  onCancel: () => void;
+  onSaved: () => Promise<void> | void;
+}
+
+function EditNoteForm({ mapId, note, onCancel, onSaved }: EditNoteFormProps) {
+  const [title, setTitle] = useState(note.title);
+  const [text, setText] = useState(note.text);
+  const [color, setColor] = useState(note.color ?? '');
+  const [pinned, setPinned] = useState(note.pinned);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSaving(true);
+    try {
+      const req: UpdateNoteRequest = { text, pinned };
+      if (title !== note.title) req.title = title;
+      if (color !== (note.color ?? '')) req.color = color;
+      await notesService.updateNote(mapId, note.id, req);
+      await onSaved();
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to save note.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="note-form">
+      {error && <div className="alert alert-error">{error}</div>}
+      <input
+        type="text"
+        placeholder="Title (optional)"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        required
+        rows={3}
+      />
+      <div className="note-form-row">
+        <input
+          type="text"
+          placeholder="Color (e.g. #ff0000)"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          className="note-form-color"
+        />
+        <label className="note-form-pinned">
+          <input
+            type="checkbox"
+            checked={pinned}
+            onChange={(e) => setPinned(e.target.checked)}
+          />
+          Pinned
+        </label>
+      </div>
+      <div className="note-form-actions">
+        <button type="button" className="btn btn-ghost btn-sm" onClick={onCancel} disabled={saving}>
+          Cancel
+        </button>
+        <button type="submit" className="btn btn-primary btn-sm" disabled={saving || !text}>
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -425,6 +425,109 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
 }
 .node-tree-menu:disabled { cursor: not-allowed; opacity: .4; }
 
+/* ─── Node detail panel (#103) ──────────────────────────────────────────────── */
+.node-detail-panel {
+  margin: 1rem 0;
+  padding: 1rem 1.25rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+}
+.node-detail-empty { color: var(--color-text-muted, #666); }
+.node-detail-empty p { margin: 0; }
+.node-detail-header { margin-bottom: .75rem; }
+.node-detail-titlebar { display: flex; align-items: center; gap: .5rem; }
+.node-detail-color {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1px solid #ccc;
+  flex-shrink: 0;
+}
+.node-detail-titlebar h2 { margin: 0; font-size: 1.25rem; }
+.node-detail-breadcrumb { margin: .25rem 0 0; font-size: .85rem; color: var(--color-text-muted, #666); }
+.link-button {
+  border: none;
+  background: transparent;
+  color: var(--color-primary);
+  cursor: pointer;
+  padding: 0;
+  font-size: inherit;
+  text-decoration: underline;
+}
+.link-button:hover { color: var(--color-primary-dark); }
+.node-detail-description { margin: .5rem 0 1rem; font-size: .9rem; }
+.node-detail-media { margin-bottom: 1rem; }
+.node-detail-media h3 { font-size: .9rem; margin-bottom: .5rem; }
+.node-detail-media-images { display: flex; gap: .5rem; flex-wrap: wrap; }
+.node-detail-thumb {
+  max-width: 150px;
+  max-height: 100px;
+  border-radius: 4px;
+}
+.node-detail-media-links { padding-left: 1.25rem; font-size: .85rem; }
+.node-detail-media-links a { color: var(--color-primary); }
+
+/* ─── Notes list inside the detail panel ───────────────────────────────────── */
+.node-detail-notes { margin-top: 1rem; }
+.node-detail-notes-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: .5rem;
+}
+.node-detail-notes-header h3 { margin: 0; font-size: .9rem; }
+.node-detail-notes-empty {
+  font-size: .85rem;
+  color: var(--color-text-muted, #666);
+  margin: 0;
+}
+.node-detail-notes-list { list-style: none; padding: 0; margin: .5rem 0 0; display: flex; flex-direction: column; gap: .5rem; }
+
+/* ─── Note card + form ──────────────────────────────────────────────────────── */
+.note-card {
+  border: 1px solid var(--color-border);
+  border-left: 4px solid var(--color-border);
+  border-radius: var(--radius);
+  background: #fafafa;
+  padding: .5rem .75rem;
+}
+.note-card-pinned { background: #fffbeb; }
+.note-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+  margin-bottom: .25rem;
+}
+.note-card-titlebar { display: flex; align-items: center; gap: .25rem; flex: 1; min-width: 0; }
+.note-pin { font-size: .85rem; }
+.note-card-actions { display: flex; gap: .25rem; }
+.note-card-text { margin: .25rem 0; font-size: .85rem; white-space: pre-wrap; }
+.note-card-footer { font-size: .75rem; color: var(--color-text-muted, #666); margin-top: .25rem; }
+.note-form {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+  padding: .75rem;
+  background: #fafafa;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  margin-bottom: .5rem;
+}
+.note-form input, .note-form textarea {
+  padding: .375rem .5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-size: .85rem;
+  font-family: inherit;
+}
+.note-form-row { display: flex; gap: .75rem; align-items: center; }
+.note-form-color { flex: 1; }
+.note-form-pinned { display: flex; align-items: center; gap: .25rem; font-size: .85rem; cursor: pointer; }
+.note-form-actions { display: flex; justify-content: flex-end; gap: .5rem; }
+
 .node-popup h3 { margin: 0 0 .5rem 0; font-size: 1rem; }
 .node-popup p  { margin: .25rem 0; }
 .node-popup-media { margin-top: .5rem; }

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -2,13 +2,13 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { MapView } from '@/components/Map/MapView';
 import { NodeTreePanel } from '@/components/Tree/NodeTreePanel';
+import { NodeDetailPanel } from '@/components/Detail/NodeDetailPanel';
 import { useMap } from '@/hooks/useMap';
 
-// Map detail page. NodeTreePanel + MapView are both wired up to a shared
-// selectedNodeId state — clicking a node in either surface highlights
-// it everywhere. The detail view that listens to selection lands in
-// #103; for now selection just shows a transient banner so the wiring
-// is observable.
+// Map detail page. NodeTreePanel + MapView + NodeDetailPanel are all wired
+// up to a shared selectedNodeId state — clicking a node in any surface
+// highlights it everywhere; the detail panel re-renders to show its
+// metadata, parent breadcrumb, media, and inline notes CRUD.
 
 export function MapDetailPage() {
   const { mapId, tenantId } = useParams<{ mapId: string; tenantId: string }>();
@@ -40,11 +40,6 @@ export function MapDetailPage() {
         </Link>
       </div>
       {activeMap.description && <p>{activeMap.description}</p>}
-      {selectedNodeId !== null && (
-        <div className="alert alert-info">
-          Selected node #{selectedNodeId}. Detail panel lands in #103.
-        </div>
-      )}
       <div className="map-detail-layout">
         <NodeTreePanel
           mapId={activeMap.id}
@@ -58,6 +53,11 @@ export function MapDetailPage() {
           panTarget={panTarget}
         />
       </div>
+      <NodeDetailPanel
+        mapId={activeMap.id}
+        selectedNodeId={selectedNodeId}
+        onSelectNode={setSelectedNodeId}
+      />
       <button className="btn btn-ghost" onClick={() => navigate(`/tenants/${tenantId}/maps`)}>
         Back to maps
       </button>


### PR DESCRIPTION
Closes #103 (will close manually after merge — auto-close skips non-default-branch PRs).

## Summary

Adds `NodeDetailPanel` below the tree+map layout. When a node is selected — either from `NodeTreePanel` or by clicking a layer on the map — the panel renders the node's full metadata with inline notes CRUD attached:

- **Heading:** name + color indicator dot.
- **Breadcrumb:** clickable link to the parent (one level; calls the same `onSelectNode` setter so navigation re-renders the panel with the parent now in focus).
- **Description.**
- **Media list:** image thumbnails + link list, both sourced from `nodeMediaService.listMedia` (added in #126).
- **Inline notes CRUD:** list pinned-first then by created_at, "+ Note" inline form, per-note edit/delete with the standard `window.confirm` pattern. Uses the existing `notesService` from `services/maps.ts`.

Empty state when nothing is selected. The `selectedNodeId` state in `MapDetailPage` is shared across `NodeTreePanel` + `MapView` + `NodeDetailPanel` — clicking anywhere updates everywhere.

## Notes-CRUD shape

- **Create:** `notesService.createNote(mapId, nodeId, { title?, text, pinned?, color? })` → reload notes via `onChange` callback.
- **Edit:** toggles into a per-card `EditNoteForm` (text, title, color, pinned). Submits `notesService.updateNote(mapId, noteId, …)` and reloads.
- **Delete:** `window.confirm`, then `notesService.deleteNote(mapId, noteId)`.
- **Pin:** boolean field on the form; pinned notes sort first. The list re-sorts client-side after each CRUD as a defensive belt-and-suspenders alongside the server-side `pinned DESC, created_at ASC` order.

## Breadcrumb scope

Just the immediate parent (one level). The full chain is already visible in `NodeTreePanel` on the left, so a multi-level breadcrumb here would be redundant — and clicking the one-level breadcrumb re-renders the detail with that ancestor's parent visible, so users can chain up by repeated clicks.

## Work breakdown

1. Sync nodes-rebuild + branch off as `feature/103-node-detail-view`
2. Author `frontend/src/components/Detail/NodeDetailPanel.tsx` with all subcomponents in one file (panel, NotesList, CreateNoteForm, NoteCard, EditNoteForm) — they're tightly coupled, splitting them across files would just add noise
3. Wire panel into `MapDetailPage`: import, place below the `map-detail-layout`, pass `selectedNodeId` + `setSelectedNodeId`. Drop the transient "Selected node #N. Detail panel lands in #103" banner — the actual panel is here now.
4. Add CSS for `.node-detail-*` (panel chrome, breadcrumb, media), `.note-card*`, `.note-form*` to `index.css`
5. Run `tsc --noEmit` + `npm run lint` — clean
6. Run full E2E suite — 18 passed, 5 fixme'd, 0 failed (no regressions)
7. Public-repo diff scan — clean
8. Commit + push + open this PR

## Files changed

- **frontend/src/components/Detail/NodeDetailPanel.tsx** *(new)* — `NodeDetailPanel` + 4 subcomponents (NotesList, CreateNoteForm, NoteCard, EditNoteForm). ~470 lines including the per-card edit-mode state machine.
- **frontend/src/pages/MapDetailPage.tsx** — Imports `NodeDetailPanel`, places it below the tree+map layout, passes shared selection state. Removes the temporary banner from #93.
- **frontend/src/index.css** — `.node-detail-*` + `.note-card*` + `.note-form*` classes.

## Test plan

- [x] `docker compose exec frontend npx tsc --noEmit` — clean
- [x] `docker compose exec frontend npm run lint` — clean
- [x] `npx playwright test` — 18 passed, 5 fixme, 0 failed (no regressions; dedicated E2E for the new panel + notes CRUD lands with #104)
- [x] CI green on PR

## Out of scope

- E2E coverage for the detail panel + notes CRUD — bundled into #104 per ticket scope (along with the tree-panel E2E from #93).
- Visibility-tagging UI on nodes/notes — #94 + #105.
- Plot UI — #95.
- Move/copy UI — backend exists in #90/#100; frontend ticket TBD.
- Note media management UI — view-only here; full CRUD UI deferred.

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)