### PR TITLE
Phase 2g.f: E2E for tree panel + node detail view (#104)

### DIFF
--- a/backend/src/controllers/NoteController.cpp
+++ b/backend/src/controllers/NoteController.cpp
@@ -224,21 +224,44 @@ void NoteController::createNote(
                         return;
                     }
                     int newId = static_cast<int>(r2.insertId());
-                    Json::Value n;
-                    n["id"]                  = newId;
-                    n["nodeId"]              = nodeId;
-                    n["mapId"]               = mapId;
-                    n["createdBy"]           = userId;
-                    n["createdByUsername"]   = callerUsername;
-                    n["title"]               = title;
-                    n["text"]                = text;
-                    n["pinned"]              = false;
-                    n["color"]               = color.empty() ? Json::Value() : Json::Value(color);
-                    n["visibilityOverride"]  = false;
-                    n["canEdit"]             = true;
-                    auto resp = drogon::HttpResponse::newHttpJsonResponse(n);
-                    resp->setStatusCode(drogon::k201Created);
-                    callback(resp);
+
+                    // Re-fetch just the timestamps so the response shape
+                    // matches the GET-style payload exactly (frontend Zod
+                    // schema requires createdAt + updatedAt). Same fix as
+                    // the MapController one in #127.
+                    auto db3 = drogon::app().getDbClient();
+                    db3->execSqlAsync(
+                        "SELECT created_at, updated_at FROM notes WHERE id = ?",
+                        [callback, newId, nodeId, mapId, userId, callerUsername,
+                         title, text, color]
+                        (const drogon::orm::Result& rTs) {
+                            Json::Value n;
+                            n["id"]                  = newId;
+                            n["nodeId"]              = nodeId;
+                            n["mapId"]               = mapId;
+                            n["createdBy"]           = userId;
+                            n["createdByUsername"]   = callerUsername;
+                            n["title"]               = title;
+                            n["text"]                = text;
+                            n["pinned"]              = false;
+                            n["color"]               = color.empty()
+                                                         ? Json::Value()
+                                                         : Json::Value(color);
+                            n["visibilityOverride"]  = false;
+                            n["canEdit"]             = true;
+                            if (!rTs.empty()) {
+                                n["createdAt"] = rTs[0]["created_at"].as<std::string>();
+                                n["updatedAt"] = rTs[0]["updated_at"].as<std::string>();
+                            }
+                            auto resp = drogon::HttpResponse::newHttpJsonResponse(n);
+                            resp->setStatusCode(drogon::k201Created);
+                            callback(resp);
+                        },
+                        [callback](const drogon::orm::DrogonDbException&) {
+                            callback(errorResponse(drogon::k500InternalServerError,
+                                "db_error", "Failed to fetch created note timestamps"));
+                        },
+                        newId);
                 },
                 [callback](const drogon::orm::DrogonDbException&) {
                     callback(errorResponse(drogon::k500InternalServerError,

--- a/frontend/tests/e2e/coordinate-systems.spec.ts
+++ b/frontend/tests/e2e/coordinate-systems.spec.ts
@@ -1,16 +1,20 @@
-import { test, expect, Page, APIRequestContext } from '@playwright/test';
-import { makeUser } from './helpers';
+import { test, expect } from '@playwright/test';
+import {
+  registerViaApi,
+  createMapViaApi,
+  createNodeViaApi,
+  seedAuthInBrowser,
+} from './helpers';
 
 /**
  * E2E coverage for #128 (Phase 2f follow-up): pixel + blank map renderers.
  *
  * The new-map UI in MapListPage hardcodes `wgs84` defaults — there's no
  * UI yet for editing `coordinateSystem` to `pixel` or `blank`. To exercise
- * the renderers, this spec uses the backend API directly to register a
- * user, create a map with the desired coordinate system, attach a node,
- * then seeds `localStorage` so the browser session is authenticated and
- * navigates to the map detail page. The MapView renderer is what's
- * actually under test.
+ * the renderers, this spec uses the API helpers from `helpers.ts` to
+ * register a user, create a map with the desired coordinate system,
+ * attach a node, then seed `localStorage` so the browser session is
+ * authenticated and navigates to the map detail page.
  *
  * Verification per type:
  *  - `pixel` → `<img class="leaflet-image-layer">` with the right src,
@@ -18,81 +22,6 @@ import { makeUser } from './helpers';
  *  - `blank` → no image layer, MapContainer carries `map-view-blank`
  *    class, marker is rendered.
  */
-
-// The Playwright `request` fixture inherits the spec's baseURL (5173), but
-// the backend runs on a different port. Hit it directly so we don't bounce
-// through Vite's dev server.
-const API = process.env.PLAYWRIGHT_API_URL ?? 'http://localhost:8080/api/v1';
-
-interface ApiUser {
-  token: string;
-  tenantId: number;
-  user: { id: number; username: string; email: string };
-}
-
-async function registerViaApi(request: APIRequestContext, tag: string): Promise<ApiUser> {
-  const u = makeUser(tag);
-  const res = await request.post(`${API}/auth/register`, {
-    data: { username: u.username, email: u.email, password: u.password },
-  });
-  expect(res.ok()).toBeTruthy();
-  const body = await res.json();
-  return { token: body.token, tenantId: body.tenantId, user: body.user };
-}
-
-async function createMapViaApi(
-  request: APIRequestContext,
-  api: ApiUser,
-  title: string,
-  coordinateSystem: unknown,
-): Promise<{ id: number }> {
-  const res = await request.post(`${API}/tenants/${api.tenantId}/maps`, {
-    headers: { Authorization: `Bearer ${api.token}` },
-    data: { title, coordinateSystem },
-  });
-  if (!res.ok()) {
-    throw new Error(`createMap failed: ${res.status()} ${await res.text()}`);
-  }
-  return res.json();
-}
-
-async function createNodeViaApi(
-  request: APIRequestContext,
-  api: ApiUser,
-  mapId: number,
-  body: { name: string; geoJson: unknown },
-): Promise<{ id: number }> {
-  const res = await request.post(`${API}/tenants/${api.tenantId}/maps/${mapId}/nodes`, {
-    headers: { Authorization: `Bearer ${api.token}` },
-    data: body,
-  });
-  if (!res.ok()) {
-    throw new Error(`createNode failed: ${res.status()} ${await res.text()}`);
-  }
-  return res.json();
-}
-
-/** Seed the zustand-persisted auth storage so the SPA boots authenticated. */
-async function seedAuthInBrowser(page: Page, api: ApiUser): Promise<void> {
-  // First navigate so localStorage is scoped to the right origin.
-  await page.goto('/login');
-  await page.evaluate((api) => {
-    const persisted = {
-      state: {
-        token: api.token,
-        user: api.user,
-        orgId: null,
-        tenantId: api.tenantId,
-        tenants: [
-          { id: api.tenantId, name: '', slug: '', role: 'admin' as const },
-        ],
-        branding: {},
-      },
-      version: 0,
-    };
-    localStorage.setItem('auth-storage', JSON.stringify(persisted));
-  }, api);
-}
 
 test.describe('Pixel coordinate system', () => {
   test('renders an image overlay and a marker for a placed node', async ({ page, request }) => {

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -1,4 +1,11 @@
 import { randomUUID } from 'crypto';
+import { expect, type APIRequestContext, type Page } from '@playwright/test';
+
+// The Playwright `request` fixture inherits the spec's baseURL (5173), but
+// the backend lives on a different port. Hit it directly for the API
+// helpers below so we don't bounce through Vite's dev server.
+export const API_URL =
+  process.env.PLAYWRIGHT_API_URL ?? 'http://localhost:8080/api/v1';
 
 /**
  * Helpers shared across E2E specs.
@@ -43,4 +50,96 @@ export function makeUser(tag: string): {
     email:    `e2e_${tag}_${id}@e2e.test`,
     password: 'pw_for_e2e_test_only',
   };
+}
+
+// ─── API-driven session setup ────────────────────────────────────────────────
+// Specs that exercise UI which doesn't yet have its own create flow
+// (pixel/blank maps in #128, multi-level node trees in #104) drive setup
+// via direct backend API calls + localStorage seeding. The pattern was
+// originally inlined in coordinate-systems.spec.ts; lifted here once the
+// second spec needed it.
+
+export interface ApiUser {
+  token: string;
+  tenantId: number;
+  user: { id: number; username: string; email: string };
+}
+
+export async function registerViaApi(
+  request: APIRequestContext,
+  tag: string,
+): Promise<ApiUser> {
+  const u = makeUser(tag);
+  const res = await request.post(`${API_URL}/auth/register`, {
+    data: { username: u.username, email: u.email, password: u.password },
+  });
+  expect(res.ok()).toBeTruthy();
+  const body = await res.json();
+  return { token: body.token, tenantId: body.tenantId, user: body.user };
+}
+
+export async function createMapViaApi(
+  request: APIRequestContext,
+  api: ApiUser,
+  title: string,
+  coordinateSystem: unknown,
+): Promise<{ id: number }> {
+  const res = await request.post(`${API_URL}/tenants/${api.tenantId}/maps`, {
+    headers: { Authorization: `Bearer ${api.token}` },
+    data: { title, coordinateSystem },
+  });
+  if (!res.ok()) {
+    throw new Error(`createMap failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+interface CreateNodeBody {
+  name: string;
+  parentId?: number;
+  geoJson?: unknown;
+  description?: string;
+  color?: string;
+}
+
+export async function createNodeViaApi(
+  request: APIRequestContext,
+  api: ApiUser,
+  mapId: number,
+  body: CreateNodeBody,
+): Promise<{ id: number }> {
+  const res = await request.post(
+    `${API_URL}/tenants/${api.tenantId}/maps/${mapId}/nodes`,
+    { headers: { Authorization: `Bearer ${api.token}` }, data: body },
+  );
+  if (!res.ok()) {
+    throw new Error(`createNode failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+/**
+ * Seed the zustand-persisted auth storage so the SPA boots authenticated.
+ * Must be called *before* navigating to any route that requires auth, but
+ * *after* an initial `page.goto('/login')` (or any path on the right
+ * origin) so localStorage is writable.
+ */
+export async function seedAuthInBrowser(page: Page, api: ApiUser): Promise<void> {
+  await page.goto('/login');
+  await page.evaluate((api) => {
+    const persisted = {
+      state: {
+        token: api.token,
+        user: api.user,
+        orgId: null,
+        tenantId: api.tenantId,
+        tenants: [
+          { id: api.tenantId, name: '', slug: '', role: 'admin' as const },
+        ],
+        branding: {},
+      },
+      version: 0,
+    };
+    localStorage.setItem('auth-storage', JSON.stringify(persisted));
+  }, api);
 }

--- a/frontend/tests/e2e/tree.spec.ts
+++ b/frontend/tests/e2e/tree.spec.ts
@@ -1,0 +1,241 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  registerViaApi,
+  createMapViaApi,
+  createNodeViaApi,
+  seedAuthInBrowser,
+} from './helpers';
+
+/**
+ * E2E coverage for #104 (Phase 2g.f): tree panel + node detail view.
+ *
+ * Each test sets up an API-driven session, builds the node fixture it
+ * needs, then drives the UI to verify expand/collapse, click-to-pan,
+ * the parent breadcrumb, and inline notes CRUD.
+ *
+ * Visibility-filter assertions on the tree (a hidden node's children
+ * also hidden) belong with #94/#106 once the tagging UI lands — those
+ * tests aren't in scope here.
+ */
+
+// Locate a tree row by the name of the inner name-button. We can't use
+// `hasText` here because the row's visible text starts with the toggle
+// character (▶/▼), so `^Foo` regexes never match. `has:` finds the row
+// containing a button with the right accessible name and walks up.
+function rowByName(page: Page, name: string) {
+  return page.locator('.node-tree-row-inner', {
+    has: page.getByRole('button', { name, exact: true }),
+  });
+}
+
+// ─── Tree panel: expand/collapse ─────────────────────────────────────────────
+
+test.describe('Tree panel — expand/collapse', () => {
+  test('walks 5 levels of nested nodes by clicking the toggle on each row', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'tree_5lvl');
+    const map = await createMapViaApi(request, api, 'Five-Level Tree', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 3,
+    });
+
+    // Build a 5-deep chain: L0 → L1 → L2 → L3 → L4
+    let parentId: number | undefined;
+    for (let i = 0; i < 5; i++) {
+      const created = await createNodeViaApi(request, api, map.id, {
+        name: `L${i}`,
+        ...(parentId !== undefined ? { parentId } : {}),
+      });
+      parentId = created.id;
+    }
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // Top-level row is L0; subsequent levels need to be expanded one at a time.
+    await expect(page.getByRole('button', { name: /^L0$/ })).toBeVisible();
+    for (let i = 0; i < 4; i++) {
+      // Toggle is the sibling of the name button. We scope by the row's
+      // own name-button to disambiguate. The row layout is:
+      // [toggle][color][name][menu].
+      await rowByName(page, `L${i}`).getByRole('button', { name: 'Expand' }).click();
+      await expect(page.getByRole('button', { name: `L${i + 1}`, exact: true })).toBeVisible();
+    }
+
+    // Collapse one level — its descendants should disappear from the tree.
+    await rowByName(page, 'L0').getByRole('button', { name: 'Collapse' }).click();
+    // After collapsing L0, none of L1..L4 should be in the DOM.
+    for (let i = 1; i < 5; i++) {
+      await expect(page.getByRole('button', { name: new RegExp(`^L${i}$`) })).toHaveCount(0);
+    }
+  });
+
+  test('leaf rows show no toggle button', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'tree_leaf');
+    const map = await createMapViaApi(request, api, 'Leaf Map', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 3,
+    });
+    const parent = await createNodeViaApi(request, api, map.id, { name: 'Parent' });
+    await createNodeViaApi(request, api, map.id, { name: 'Leaf', parentId: parent.id });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // Expand Parent → Leaf appears. Initially Leaf has an Expand button
+    // (children are unknown until we try to fetch them). Clicking Expand
+    // hits the API, gets back [], and the toggle is then replaced with a
+    // spacer to indicate "no children." That's the user-visible signal
+    // that the row is a leaf.
+    await rowByName(page, 'Parent').getByRole('button', { name: 'Expand' }).click();
+    const leafRow = rowByName(page, 'Leaf');
+    await expect(leafRow).toBeVisible();
+    await expect(leafRow.getByRole('button', { name: 'Expand' })).toBeVisible();
+
+    await leafRow.getByRole('button', { name: 'Expand' }).click();
+    await expect(leafRow.locator('.node-tree-toggle-spacer')).toBeVisible();
+  });
+});
+
+// ─── Click-to-pan ────────────────────────────────────────────────────────────
+
+test.describe('Tree panel — click-to-pan', () => {
+  test('clicking a row with a Point geometry pans the map to it', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'tree_pan');
+    // Zoom 10 = city-level. A node at lat=10, lng=10 is far enough off
+    // a center=(0,0) initial view that its marker is NOT in the viewport
+    // before the pan, so a successful in-viewport assertion afterward
+    // can only mean the flyTo actually happened.
+    const map = await createMapViaApi(request, api, 'Pan Test Map', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 10,
+    });
+    await createNodeViaApi(request, api, map.id, {
+      name: 'FarAway',
+      geoJson: { type: 'Point', coordinates: [10, 10] },
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    const marker = page.locator('.leaflet-marker-icon').first();
+    await expect(marker).toHaveCount(1);
+    // Initially the marker is rendered in the DOM but positioned outside
+    // the visible viewport (Leaflet still creates the icon for off-screen
+    // markers).
+    await expect(marker).not.toBeInViewport();
+
+    // Click the tree row. PanController.flyTo() runs for ~400ms.
+    await page.getByRole('button', { name: 'FarAway' }).click();
+
+    // After the pan, the marker should be in the viewport. Bump the
+    // expect timeout above the flyTo duration.
+    await expect(marker).toBeInViewport({ timeout: 3_000 });
+  });
+});
+
+// ─── Detail view + parent breadcrumb ─────────────────────────────────────────
+
+test.describe('Detail view — parent breadcrumb', () => {
+  test('breadcrumb shows the parent and clicking it changes selection', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'detail_breadcrumb');
+    const map = await createMapViaApi(request, api, 'Breadcrumb Map', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 3,
+    });
+    const parent = await createNodeViaApi(request, api, map.id, { name: 'ParentNode' });
+    await createNodeViaApi(request, api, map.id, { name: 'ChildNode', parentId: parent.id });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // Expand parent + select child.
+    await rowByName(page, 'ParentNode').getByRole('button', { name: 'Expand' }).click();
+    await page.getByRole('button', { name: 'ChildNode' }).click();
+
+    // Detail panel shows the child's name as h2 and the parent as a link.
+    await expect(page.getByRole('heading', { name: 'ChildNode' })).toBeVisible();
+    await expect(page.locator('.node-detail-breadcrumb')).toContainText('ParentNode');
+
+    // Clicking the breadcrumb re-selects the parent — heading swaps.
+    await page.locator('.node-detail-breadcrumb').getByRole('button', { name: 'ParentNode' }).click();
+    await expect(page.getByRole('heading', { name: 'ParentNode' })).toBeVisible();
+    // ParentNode has no parent → no breadcrumb element this time.
+    await expect(page.locator('.node-detail-breadcrumb')).toHaveCount(0);
+  });
+});
+
+// ─── Inline notes CRUD ───────────────────────────────────────────────────────
+
+async function selectNode(page: Page, name: string): Promise<void> {
+  await page.getByRole('button', { name }).click();
+}
+
+test.describe('Detail view — inline notes CRUD', () => {
+  test('create + edit + delete + pin', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'notes_crud');
+    const map = await createMapViaApi(request, api, 'Notes Map', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 3,
+    });
+    await createNodeViaApi(request, api, map.id, { name: 'Hub' });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    await selectNode(page, 'Hub');
+    await expect(page.getByRole('heading', { name: 'Hub' })).toBeVisible();
+
+    // ─── Create ────────────────────────────────────────────────────────────
+    await page.getByRole('button', { name: '+ Note' }).click();
+    await page.getByPlaceholder('Title (optional)').fill('First note');
+    await page.getByPlaceholder('Note text').fill('Hello world');
+    await page.getByRole('button', { name: /^Save$/ }).click();
+
+    const firstCard = page.locator('.note-card').filter({ hasText: 'First note' });
+    await expect(firstCard).toBeVisible();
+    await expect(firstCard).toContainText('Hello world');
+
+    // ─── Edit ──────────────────────────────────────────────────────────────
+    await firstCard.getByRole('button', { name: 'Edit' }).click();
+    const textarea = page.locator('.note-form textarea');
+    await textarea.fill('Hello edited');
+    await page.getByRole('button', { name: /^Save$/ }).click();
+    await expect(page.locator('.note-card').filter({ hasText: 'Hello edited' })).toBeVisible();
+
+    // ─── Pin order ─────────────────────────────────────────────────────────
+    // Add a second note (unpinned), then pin the FIRST note via edit.
+    // The pinned note should sort first.
+    await page.getByRole('button', { name: '+ Note' }).click();
+    await page.getByPlaceholder('Title (optional)').fill('Second note');
+    await page.getByPlaceholder('Note text').fill('Another');
+    await page.getByRole('button', { name: /^Save$/ }).click();
+    await expect(page.locator('.note-card').filter({ hasText: 'Second note' })).toBeVisible();
+
+    // Pin the first note via its edit form.
+    await page.locator('.note-card').filter({ hasText: 'First note' })
+      .getByRole('button', { name: 'Edit' }).click();
+    await page.locator('.note-form input[type="checkbox"]').check();
+    await page.getByRole('button', { name: /^Save$/ }).click();
+
+    // Wait for the edit form to close (so we know the save settled),
+    // then check the order: the pinned card should be the first .note-card
+    // in the list.
+    await expect(page.locator('.note-form')).toHaveCount(0);
+    const cardsInOrder = await page.locator('.note-card .note-card-titlebar strong').allTextContents();
+    expect(cardsInOrder[0]).toBe('First note');
+    expect(cardsInOrder).toContain('Second note');
+
+    // ─── Delete ────────────────────────────────────────────────────────────
+    page.once('dialog', (d) => d.accept());
+    await page.locator('.note-card').filter({ hasText: 'First note' })
+      .getByRole('button', { name: 'Delete' }).click();
+    await expect(page.locator('.note-card').filter({ hasText: 'First note' })).toHaveCount(0);
+    // Second note still there.
+    await expect(page.locator('.note-card').filter({ hasText: 'Second note' })).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #104 (will close manually after merge — auto-close skips non-default-branch PRs).

## Summary

New `tree.spec.ts` with five tests covering the UI shipped in #93 and #103:

1. **5-level tree expand/collapse** — builds a chain L0 → L1 → … → L4 via API, drives the UI to expand each level by clicking its row's `Expand` button, asserts each child appears, then collapses L0 and verifies L1–L4 disappear from the DOM.
2. **Leaf-row toggle behavior** — initially a leaf row has an `Expand` button (we don't know it's a leaf until we try); after the first click the API returns `[]` and the toggle is replaced with a spacer.
3. **Click-to-pan** — node placed at `[lat=10, lng=10]` on a `wgs84` map centered at `[0, 0]` zoom 10. The marker is rendered in the DOM but **not** in the viewport before clicking; after clicking the tree row, `flyTo` runs (~400ms) and the marker is in the viewport.
4. **Detail-view parent breadcrumb** — selecting a child shows the parent name as a clickable link; clicking it re-selects the parent (heading swaps; breadcrumb element is then absent because the parent has no parent).
5. **Inline notes CRUD** — create + edit + pin (sort-order) + delete on a selected node, with the standard `window.confirm` accept for delete.

## Helpers extraction

The API-driven setup pattern (`registerViaApi`, `createMapViaApi`, `createNodeViaApi`, `seedAuthInBrowser`, plus `ApiUser` + `API_URL`) was originally inlined in `coordinate-systems.spec.ts`. With this PR being the second spec needing the same pattern, the lift to `helpers.ts` is justified. `coordinate-systems.spec.ts` now imports the shared versions.

## Backend fix uncovered during the rewrite

While debugging the failing notes-CRUD test, I traced "Failed to create note." back to a Zod parse rejection on the frontend: `MapRecordSchema`-style — the `POST /nodes/{id}/notes` response was missing `createdAt` / `updatedAt`. Same root cause + same fix as the `createMap` bug in #127.

`NoteController::createNote` now re-fetches the row's timestamps via a tiny follow-up SELECT after INSERT, then includes them in the response. Backend fast-tier suite passes (20/20, no regressions). I deliberately scoped the SELECT to just the timestamp columns rather than the full GET-shape — the rest of the row's fields are already known to the controller from the request + insertId.

## One nontrivial debugging detour

First test run: 4/5 failed. Root cause was a single locator-pattern mistake — I'd written `hasText: /^L0\\b/` to scope to the L0 row, expecting a `^` anchor against the row's text. But the row's *visible text* starts with the toggle character (▶), so `^L0` never matches. Fixed by switching to `has:` filtering with a descendant button:

```ts
function rowByName(page: Page, name: string) {
  return page.locator('.node-tree-row-inner', {
    has: page.getByRole('button', { name, exact: true }),
  });
}
```

After that all four failures resolved cleanly. Documenting here in case the lesson saves a future spec author the same hour.

## Work breakdown

1. Sync nodes-rebuild + branch off as `feature/104-e2e-tree-notes`
2. Lift `registerViaApi` / `createMapViaApi` / `createNodeViaApi` / `seedAuthInBrowser` from `coordinate-systems.spec.ts` into `helpers.ts`; trim `coordinate-systems.spec.ts` to import them
3. Author `tree.spec.ts` with the five tests + `rowByName` helper
4. First run — 4/5 fail with locator-not-found timeouts; diagnose the `hasText` issue against `^L0` vs. visible text
5. Second run — 3/5 pass; remaining failures are (a) leaf test expecting a spacer immediately on a never-expanded leaf, and (b) notes-CRUD failing on "Failed to create note"
6. Diagnose (b) — backend `createNote` returns a partial record that `NoteRecordSchema.parse()` rejects on the frontend
7. Fix backend: `NoteController::createNote` re-fetches `created_at` + `updated_at` post-INSERT (same pattern as the `createMap` fix in #127)
8. Fix (a) by updating the leaf test to match real component behavior: initial Expand → click → spacer
9. Rebuild backend, restart Docker stack with fresh DB
10. Re-run `tree.spec.ts` — 5 passed (9.0s)
11. Run full E2E suite — 23 passed, 5 fixme, 0 failed (23.3s)
12. Run backend fast tier — 20/20 green, no regressions from the createNote fix
13. Public-repo diff scan — clean
14. Commit + push + open this PR

## Files changed

- **backend/src/controllers/NoteController.cpp** — `createNote` re-fetches `created_at`/`updated_at` post-INSERT and includes them in the response. ~30 lines.
- **frontend/tests/e2e/helpers.ts** — Adds `API_URL`, `ApiUser`, `registerViaApi`, `createMapViaApi`, `createNodeViaApi`, `seedAuthInBrowser`. ~95 lines added.
- **frontend/tests/e2e/coordinate-systems.spec.ts** — Imports the shared helpers; ~80 lines of duplicated setup deleted.
- **frontend/tests/e2e/tree.spec.ts** *(new)* — 5 tests + `rowByName` helper. ~230 lines.

## Test plan

- [x] `npx playwright test tests/e2e/tree.spec.ts` — 5 passed (9.0s)
- [x] `npx playwright test` (full suite) — 23 passed, 5 fixme, 0 failed (23.3s)
- [x] `python3 backend/tests/run-tests.py --tier fast` — 20/20 suites pass (36s; no regressions from the `createNote` fix)
- [ ] CI green on PR

## Out of scope

- Visibility-filter assertions on the tree (a hidden node's children also hidden) — belong with #94.c / #106 once the tagging UI lands.
- Plot-UI E2E — #95.

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)