### PR TITLE
tools: consolidate dev scripts under scripts/ + add wait-for-pr-checks.sh

### DIFF
--- a/cmd_rebuild.sh
+++ b/cmd_rebuild.sh
@@ -1,2 +1,0 @@
-echo "Rebuilding..."
-docker compose build --no-cache backend && docker compose up -d

--- a/scripts/cmd_grand_restart.sh
+++ b/scripts/cmd_grand_restart.sh
@@ -1,3 +1,7 @@
+# Run from the repo root so `docker compose` finds docker-compose.yml and
+# `database/seed-local-dev.py` resolves regardless of the caller's cwd.
+cd "$(git rev-parse --show-toplevel)"
+
 echo "\n\n**************** Stopping the stack...\n"
 docker compose down -v
 echo "\n\n**************** Rebuilding...\n"

--- a/scripts/cmd_rebuild.sh
+++ b/scripts/cmd_rebuild.sh
@@ -1,0 +1,5 @@
+# Run from the repo root so `docker compose` finds docker-compose.yml.
+cd "$(git rev-parse --show-toplevel)"
+
+echo "Rebuilding..."
+docker compose build --no-cache backend && docker compose up -d

--- a/scripts/count_lines.py
+++ b/scripts/count_lines.py
@@ -52,7 +52,10 @@ def examine_directory(path):
 
 
 def main():
-    root = Path('.')
+    # Resolve to the repo root so the count is consistent regardless of the
+    # caller's cwd. Script lives at scripts/count_lines.py; parent.parent
+    # is the repo root.
+    root = Path(__file__).resolve().parent.parent
     total_count = examine_directory(root)
     print(f"Number of lines: {total_count}")
 

--- a/scripts/wait-for-pr-checks.sh
+++ b/scripts/wait-for-pr-checks.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env zsh
+#
+# wait-for-pr-checks.sh — wait briefly for the GitHub Actions run on the
+# current branch to register, then watch it and play an audio cue when it
+# completes (passed / failed).
+#
+# Usage:
+#   scripts/wait-for-pr-checks.sh [branch-name]
+#
+# Branch defaults to the current git branch. Override the registration
+# delay with PR_CHECKS_INITIAL_DELAY=<seconds> (default 10).
+#
+# Requirements:
+#   - `gh` CLI authenticated against this repo
+#   - `say` (built-in on macOS; on Linux, swap for paplay/notify-send)
+
+set -euo pipefail
+
+BRANCH="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+INITIAL_DELAY="${PR_CHECKS_INITIAL_DELAY:-10}"
+
+echo "Waiting ${INITIAL_DELAY}s for the workflow run on '${BRANCH}' to register..."
+sleep "${INITIAL_DELAY}"
+
+RUN_ID=$(gh run list \
+  --branch "${BRANCH}" \
+  --limit 1 \
+  --json databaseId \
+  --jq '.[0].databaseId' 2>/dev/null || true)
+
+if [[ -z "${RUN_ID}" ]]; then
+  echo "No workflow runs found for branch '${BRANCH}'." >&2
+  say "No GitHub workflow run found"
+  exit 1
+fi
+
+echo "Watching run ${RUN_ID} on branch '${BRANCH}'..."
+
+# `gh run watch --exit-status` blocks until the run finishes and
+# propagates the run's success/failure as the script's exit code.
+if gh run watch "${RUN_ID}" --exit-status; then
+  say "PR checks passed"
+else
+  say "PR checks failed"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Two related changes that together leave the repo with a tidier scripts layout:

1. **New: `scripts/wait-for-pr-checks.sh`** — small zsh helper that pairs with `gh pr create`. Waits ~10s for the GitHub Actions workflow run on the current branch to register, then `gh run watch`es it and plays a `say` audio cue ("PR checks passed" or "PR checks failed") when it completes. Lets you step away after opening a PR and get an audio nudge once CI lands either way.
2. **Moved: `cmd_grand_restart.sh`, `cmd_rebuild.sh`, `count_lines.py` → `scripts/`** — same scripts, relocated to consolidate dev tooling. Small fixup on each so they still work from any cwd: shell scripts `cd "$(git rev-parse --show-toplevel)"` at the top; `count_lines.py` uses `Path(__file__).resolve().parent.parent` instead of `Path('.')`.

## `wait-for-pr-checks.sh` usage

```sh
scripts/wait-for-pr-checks.sh                              # current branch
scripts/wait-for-pr-checks.sh <branch-name>                # explicit branch
PR_CHECKS_INITIAL_DELAY=20 scripts/wait-for-pr-checks.sh   # tune wait
```

Exit code mirrors `gh run watch --exit-status`: 0 when the run passed, 1 when it failed (or no run was found).

## Why the cwd fixups matter

Before the move, `cmd_*.sh` and `count_lines.py` lived at the repo root and assumed cwd was the repo root. Moving them to `scripts/` would silently break that assumption when invoked from inside `scripts/` (e.g., `cd scripts && bash cmd_rebuild.sh` would fail to find `docker-compose.yml`). The two-line `cd "$(git rev-parse --show-toplevel)"` pattern + `Path(__file__).resolve().parent.parent` makes them runnable from anywhere in the repo. Verified: `python3 scripts/count_lines.py` from the repo root returns a real number; from inside `scripts/` it returns the same number (now), instead of just counting `scripts/`.

## Work breakdown

1. Branch off `main` as `tools/pr-watch-script`
2. **Commit 1** — author `scripts/wait-for-pr-checks.sh` (~45 lines, single zsh script). chmod +x.
3. Smoke-check dependencies: `which say`, `which gh`, `gh run list … databaseId` query (returned a real numeric ID), `zsh -n` syntax check
4. Commit + push + open PR into main
5. **Commit 2** — `git mv` the three existing scripts into `scripts/`; add cwd fixups so they work from any directory
6. Verify: `bash -n` on each .sh, `python3 -c "ast.parse(...)"` on the .py, then run `python3 scripts/count_lines.py` end-to-end (returns 16694)
7. Update this PR's title + body to reflect the broader scope

## Files changed

- **scripts/wait-for-pr-checks.sh** *(new, commit 1)* — Single zsh script. Header doc-comment covers usage and requirements; the body is a straightforward `gh run list` → `gh run watch` → `say` pipeline.
- **scripts/cmd_grand_restart.sh** *(moved from repo root, commit 2)* — Adds `cd "$(git rev-parse --show-toplevel)"` so `docker compose` and the seed-local-dev path still resolve.
- **scripts/cmd_rebuild.sh** *(moved from repo root, commit 2)* — Same `cd` fixup.
- **scripts/count_lines.py** *(moved from repo root, commit 2)* — Switches `Path('.')` to `Path(__file__).resolve().parent.parent` so the count is cwd-independent.

## Test plan

- [x] `which say && which gh` — both resolve
- [x] `gh run list --limit 1 --json databaseId --jq '.[0].databaseId'` — returns a numeric run ID
- [x] `zsh -n scripts/wait-for-pr-checks.sh` — syntax OK
- [x] `bash -n scripts/cmd_grand_restart.sh && bash -n scripts/cmd_rebuild.sh` — syntax OK
- [x] `python3 scripts/count_lines.py` — returns a number (verified 16694)
- [ ] End-to-end: run `scripts/wait-for-pr-checks.sh` against this PR's own CI run to verify the audio cue fires and the exit code reflects the outcome.

## Out of scope

- Cross-platform support beyond macOS — `say` is macOS-specific. Linux folks can swap for `paplay` / `notify-send`; not needed for the current dev setup.
- Renaming the `cmd_*.sh` scripts — kept their names verbatim; renames are scope creep.
- Adding shebangs to `cmd_*.sh` — they were running fine without them; not touching.
- Documentation in `DEVELOPER-GUIDE.md` — the new script's header doc-comment is self-contained, and the moved scripts already worked the way devs use them.

## Public-repo diff scan

- Live credentials: **none**
- Real PII: **none**
- Internal hostnames / private IPs: **none**

🤖 Generated with [Claude Code](https://claude.com/claude-code)