### PR TITLE
Phase 2g.j: Plot UI \u2014 admin page + cross-map navigation + E2E (#95)

### DIFF
--- a/docs/TESTING-E2E.md
+++ b/docs/TESTING-E2E.md
@@ -55,6 +55,7 @@ frontend/
 │       ├── notes.spec.ts       # note CRUD + move + note groups (#37)
 │       ├── cross-tenant.spec.ts # tenant isolation across two users (#38)
 │       ├── visibility.spec.ts # override icon, owner_xray, cross-user filter (#106)
+│       ├── plots.spec.ts      # plot CRUD, cross-map nav, visibility filtering (#95)
 │       └── *.spec.ts           # one file per feature area
 └── ...
 ```

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { lazy, Suspense } from 'react';
 const MapListPage          = lazy(() => import('@/pages/MapListPage').then((m)          => ({ default: m.MapListPage })));
 const MapDetailPage        = lazy(() => import('@/pages/MapDetailPage').then((m)        => ({ default: m.MapDetailPage })));
 const VisibilityGroupsPage = lazy(() => import('@/pages/VisibilityGroupsPage').then((m) => ({ default: m.VisibilityGroupsPage })));
+const PlotsPage            = lazy(() => import('@/pages/PlotsPage').then((m)            => ({ default: m.PlotsPage })));
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
@@ -66,6 +67,16 @@ export default function App() {
                 element={
                   <PrivateRoute>
                     <VisibilityGroupsPage />
+                  </PrivateRoute>
+                }
+              />
+
+              {/* Tenant-scoped plot admin (#95) */}
+              <Route
+                path="/tenants/:tenantId/plots"
+                element={
+                  <PrivateRoute>
+                    <PlotsPage />
                   </PrivateRoute>
                 }
               />

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -241,6 +241,53 @@ export type NodeMediaRecord = z.infer<typeof NodeMediaRecordSchema>;
 export const NodeMediaListSchema = z.array(NodeMediaRecordSchema);
 export type NodeMediaList = z.infer<typeof NodeMediaListSchema>;
 
+// ─── Plots (#88 / #95) ───────────────────────────────────────────────────────
+// Tenant-scoped narrative groupings. Plots are many-to-many to both nodes
+// and notes via parallel junction tables; the read endpoint returns the two
+// member lists side by side. Member entries are deliberately a thin slice —
+// just enough to render a clickable row that knows which map to navigate to.
+
+export const PlotRecordSchema = z.object({
+  id: z.number().int(),
+  tenantId: z.number().int(),
+  name: z.string(),
+  description: z.string(),
+  createdBy: z.number().int(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type PlotRecord = z.infer<typeof PlotRecordSchema>;
+
+export const PlotListSchema = z.array(PlotRecordSchema);
+export type PlotList = z.infer<typeof PlotListSchema>;
+
+export const PlotNodeMemberSchema = z.object({
+  id: z.number().int(),
+  mapId: z.number().int(),
+  parentId: z.number().int().nullable(),
+  name: z.string(),
+  color: z.string().nullable(),
+  visibilityOverride: z.boolean(),
+});
+export type PlotNodeMember = z.infer<typeof PlotNodeMemberSchema>;
+
+export const PlotNoteMemberSchema = z.object({
+  id: z.number().int(),
+  nodeId: z.number().int(),
+  mapId: z.number().int(),
+  title: z.string(),
+  pinned: z.boolean(),
+  color: z.string().nullable(),
+  visibilityOverride: z.boolean(),
+});
+export type PlotNoteMember = z.infer<typeof PlotNoteMemberSchema>;
+
+export const PlotMembersSchema = z.object({
+  nodes: z.array(PlotNodeMemberSchema),
+  notes: z.array(PlotNoteMemberSchema),
+});
+export type PlotMembers = z.infer<typeof PlotMembersSchema>;
+
 // ─── Request shapes (used by service callers) ────────────────────────────────
 // These don't need runtime parsing on the way out — they're typed for the
 // caller's convenience. Re-exported from this module so all schema-derived
@@ -274,3 +321,10 @@ export type CreateNoteRequest = {
 };
 
 export type UpdateNoteRequest = Partial<CreateNoteRequest>;
+
+export type CreatePlotRequest = {
+  name: string;
+  description?: string;
+};
+
+export type UpdatePlotRequest = Partial<CreatePlotRequest>;

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -26,6 +26,11 @@ export function Navbar() {
                 Visibility
               </Link>
             )}
+            {tenantId && (
+              <Link to={`/tenants/${tenantId}/plots`}>
+                Plots
+              </Link>
+            )}
             <span className="navbar-user">{user?.username}</span>
             <button onClick={handleLogout} className="btn btn-ghost">
               Sign Out

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -739,6 +739,51 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
   border-top: 1px dashed var(--color-border);
 }
 
+/* ─── Plots admin (#95) ──────────────────────────────────────────────────── */
+/* Reuses the visibility-group row pattern: collapsible row with inline
+   member panel, modal for create/edit. Members are split into Nodes /
+   Notes sub-sections inside each row's body. */
+.plot-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: .75rem; }
+.plot-row {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: .75rem 1rem;
+}
+.plot-header { display: flex; align-items: center; gap: .5rem; cursor: pointer; }
+.plot-toggle { background: none; border: none; cursor: pointer; font-size: .9rem; padding: 0 .25rem; }
+.plot-name { margin: 0; font-size: 1.1rem; flex: 1; }
+.plot-count { font-size: .8rem; color: #666; }
+.plot-actions { display: flex; gap: .25rem; }
+.plot-description { margin: .25rem 0 0 1.5rem; color: #555; font-size: .9rem; }
+.plot-body { margin-top: .75rem; display: flex; flex-direction: column; gap: 1rem; }
+.plot-section h3 { margin: 0 0 .35rem 0; font-size: .95rem; }
+.plot-empty { color: #888; font-size: .85rem; margin: 0 0 .25rem 0; }
+.plot-member-list { list-style: none; padding: 0; margin: 0 0 .35rem 0; display: flex; flex-direction: column; gap: .15rem; }
+.plot-member-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+  padding: .25rem .5rem;
+  border-radius: var(--radius);
+  background: #fafafa;
+}
+.plot-member-link {
+  flex: 1;
+  display: flex;
+  align-items: baseline;
+  gap: .5rem;
+  text-decoration: none;
+  color: inherit;
+}
+.plot-member-link:hover { text-decoration: underline; }
+.plot-member-name { font-weight: 500; }
+.plot-member-map { font-size: .8rem; color: #666; }
+.plot-member-pin { font-size: .8rem; }
+.plot-add-form { display: flex; flex-wrap: wrap; gap: .35rem; align-items: center; }
+.plot-add-form select { flex: 1; min-width: 8rem; }
+
 .node-popup h3 { margin: 0 0 .5rem 0; font-size: 1rem; }
 .node-popup p  { margin: .25rem 0; }
 .node-popup-media { margin-top: .5rem; }

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { MapView } from '@/components/Map/MapView';
 import { NodeTreePanel } from '@/components/Tree/NodeTreePanel';
 import { NodeDetailPanel } from '@/components/Detail/NodeDetailPanel';
@@ -20,6 +20,11 @@ import { extractApiError } from '@/utils/errors';
 export function MapDetailPage() {
   const { mapId, tenantId } = useParams<{ mapId: string; tenantId: string }>();
   const navigate = useNavigate();
+  // `?node=X` query param lets cross-page links (e.g. plot member rows
+  // on /tenants/:tid/plots) deep-link into a specific node. We honor it
+  // exactly once per map load — see the effect below — so subsequent
+  // user-driven node selections aren't fought by stale URL state.
+  const [searchParams] = useSearchParams();
   const { activeMap, loadMap, updateMap } = useMap();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -36,6 +41,20 @@ export function MapDetailPage() {
       .catch(() => setError('Map not found or you do not have permission to view it.'))
       .finally(() => setLoading(false));
   }, [mapId, loadMap]);
+
+  // Honor ?node=N once per map load. Re-running this on every searchParams
+  // change would clobber the user's clicks if they navigated within the
+  // same map — keying on mapId means it only fires when the page (re)mounts
+  // for a different map.
+  useEffect(() => {
+    if (!mapId) return;
+    const nodeParam = searchParams.get('node');
+    if (nodeParam) {
+      const n = Number(nodeParam);
+      if (Number.isFinite(n)) setSelectedNodeId(n);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mapId]);
 
   if (loading) return <div className="page-loading">Loading map…</div>;
   if (error) return <div className="page-error">{error}</div>;

--- a/frontend/src/pages/PlotsPage.tsx
+++ b/frontend/src/pages/PlotsPage.tsx
@@ -1,0 +1,712 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import {
+  plotsService,
+  mapsService,
+  nodesService,
+  notesService,
+} from '@/services/maps';
+import { extractApiError } from '@/utils/errors';
+import type {
+  PlotRecord,
+  PlotMembers,
+  PlotNodeMember,
+  PlotNoteMember,
+  CreatePlotRequest,
+  UpdatePlotRequest,
+  MapRecord,
+  NodeRecord,
+  NoteRecord,
+} from '@/api/schemas';
+
+// Phase 2g.j (#95): Plots admin page. Plots are tenant-scoped narrative
+// groupings tying together nodes + notes across maps; this page surfaces
+// the CRUD + member management the backend has had since #88. Modeled on
+// VisibilityGroupsPage's collapsible-row pattern — read-many + inline
+// member panel + modal for create/edit.
+//
+// Add-member UX is a two-step picker (map → node, or map → node → note)
+// rather than a tenant-wide name search. The backend doesn't expose a
+// cross-map search endpoint, and synthesizing one client-side would mean
+// fetching every map's full node list on first render. The picker keeps
+// the request shape narrow — one map's worth of nodes/notes at a time —
+// at the cost of a couple extra clicks. Cross-map search is the natural
+// follow-up if this becomes painful.
+//
+// Click-to-jump: each member row links to
+//   /tenants/{tid}/maps/{mid}?node={nodeId}
+// MapDetailPage reads the `node` query param on mount and pre-selects.
+// For note members the link points at the note's parent node, since the
+// note shows up in NodeDetailPanel's notes list — selecting the note
+// itself from a query param would need NodeDetailPanel changes that are
+// out of scope for this PR.
+
+export function PlotsPage() {
+  const { tenantId } = useParams<{ tenantId: string }>();
+  const tenantIdNum = Number(tenantId);
+
+  const [plots, setPlots] = useState<PlotRecord[]>([]);
+  const [maps, setMaps] = useState<MapRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editingPlot, setEditingPlot] = useState<PlotRecord | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const reloadPlots = useCallback(async () => {
+    try {
+      const fresh = await plotsService.listPlots(tenantIdNum);
+      setPlots(fresh);
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to load plots.'));
+    }
+  }, [tenantIdNum]);
+
+  useEffect(() => {
+    if (!tenantIdNum) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    Promise.all([
+      reloadPlots(),
+      // Maps feed the add-member pickers. Page-size 100 covers the
+      // common case; if a tenant has more, the picker shows the first
+      // page. A future ticket can add pagination once we hit that.
+      mapsService
+        .listMaps(1, 100, tenantIdNum)
+        .then((m) => { if (!cancelled) setMaps(m.data); })
+        .catch(() => { if (!cancelled) setMaps([]); }),
+    ]).finally(() => {
+      if (!cancelled) setLoading(false);
+    });
+
+    return () => { cancelled = true; };
+  }, [tenantIdNum, reloadPlots]);
+
+  if (!tenantIdNum) {
+    return <div className="page-error">Missing tenant in route.</div>;
+  }
+  if (loading) return <div className="page-loading">Loading plots…</div>;
+
+  return (
+    <div className="page-container">
+      <div className="page-header">
+        <h1>Plots</h1>
+        <div className="header-actions">
+          <button className="btn btn-primary" onClick={() => setShowCreate(true)}>
+            + New Plot
+          </button>
+          <Link to={`/tenants/${tenantId}/maps`} className="btn btn-ghost">
+            ← Back to maps
+          </Link>
+        </div>
+      </div>
+      {error && <div className="alert alert-error">{error}</div>}
+
+      {plots.length === 0 ? (
+        <div className="empty-state">
+          <p>No plots yet.</p>
+        </div>
+      ) : (
+        <ul className="plot-list">
+          {plots.map((p) => (
+            <li key={p.id}>
+              <PlotRow
+                plot={p}
+                tenantId={tenantIdNum}
+                maps={maps}
+                onEdit={() => setEditingPlot(p)}
+                onChange={reloadPlots}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {showCreate && (
+        <PlotFormModal
+          mode="create"
+          tenantId={tenantIdNum}
+          onClose={() => setShowCreate(false)}
+          onSaved={async () => {
+            setShowCreate(false);
+            await reloadPlots();
+          }}
+        />
+      )}
+      {editingPlot && (
+        <PlotFormModal
+          mode="edit"
+          tenantId={tenantIdNum}
+          plot={editingPlot}
+          onClose={() => setEditingPlot(null)}
+          onSaved={async () => {
+            setEditingPlot(null);
+            await reloadPlots();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── Per-plot row (collapsible, with members panel inside) ───────────────────
+
+interface PlotRowProps {
+  plot: PlotRecord;
+  tenantId: number;
+  maps: MapRecord[];
+  onEdit: () => void;
+  onChange: () => Promise<void> | void;
+}
+
+function PlotRow({ plot, tenantId, maps, onEdit, onChange }: PlotRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [members, setMembers] = useState<PlotMembers>({ nodes: [], notes: [] });
+  const [loadingMembers, setLoadingMembers] = useState(false);
+  const [memberError, setMemberError] = useState<string | null>(null);
+
+  const memberCount = members.nodes.length + members.notes.length;
+
+  const reloadMembers = useCallback(async () => {
+    setLoadingMembers(true);
+    setMemberError(null);
+    try {
+      const fresh = await plotsService.listMembers(plot.id, tenantId);
+      setMembers(fresh);
+    } catch (e) {
+      setMemberError(extractApiError(e, 'Failed to load plot members.'));
+    } finally {
+      setLoadingMembers(false);
+    }
+  }, [plot.id, tenantId]);
+
+  const handleToggle = async () => {
+    if (!expanded && memberCount === 0 && !loadingMembers) {
+      await reloadMembers();
+    }
+    setExpanded((e) => !e);
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm(`Delete plot "${plot.name}"?`)) return;
+    try {
+      await plotsService.deletePlot(plot.id, tenantId);
+      await onChange();
+    } catch (e) {
+      window.alert(extractApiError(e, 'Failed to delete plot.'));
+    }
+  };
+
+  const handleRemoveNode = async (nodeId: number) => {
+    try {
+      await plotsService.removeNode(plot.id, nodeId, tenantId);
+      await reloadMembers();
+    } catch (e) {
+      window.alert(extractApiError(e, 'Failed to remove node.'));
+    }
+  };
+
+  const handleRemoveNote = async (noteId: number) => {
+    try {
+      await plotsService.removeNote(plot.id, noteId, tenantId);
+      await reloadMembers();
+    } catch (e) {
+      window.alert(extractApiError(e, 'Failed to remove note.'));
+    }
+  };
+
+  // Resolve map-id → map title for member-row breadcrumbs. Members can
+  // reference maps the caller doesn't have direct access to (e.g. shared
+  // by another tenant member); fall back to the id in that case.
+  const mapTitle = (mapId: number): string => {
+    const m = maps.find((mm) => mm.id === mapId);
+    return m?.title ?? `Map #${mapId}`;
+  };
+
+  return (
+    <article className="plot-row">
+      <header className="plot-header" onClick={handleToggle}>
+        <button
+          type="button"
+          className="plot-toggle"
+          aria-label={expanded ? 'Collapse' : 'Expand'}
+          onClick={(e) => { e.stopPropagation(); handleToggle(); }}
+        >
+          {expanded ? '▼' : '▶'}
+        </button>
+        <h2 className="plot-name">{plot.name}</h2>
+        {expanded && (
+          <span className="plot-count">
+            {loadingMembers
+              ? '…'
+              : `${memberCount} member${memberCount === 1 ? '' : 's'}`}
+          </span>
+        )}
+        <div className="plot-actions">
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            onClick={(e) => { e.stopPropagation(); onEdit(); }}
+          >
+            Edit
+          </button>
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            onClick={(e) => { e.stopPropagation(); handleDelete(); }}
+          >
+            Delete
+          </button>
+        </div>
+      </header>
+      {plot.description && <p className="plot-description">{plot.description}</p>}
+      {expanded && (
+        <div className="plot-body">
+          {memberError && <div className="alert alert-error">{memberError}</div>}
+
+          <section className="plot-section">
+            <h3>Nodes ({members.nodes.length})</h3>
+            {members.nodes.length === 0 ? (
+              <p className="plot-empty">No nodes attached.</p>
+            ) : (
+              <ul className="plot-member-list">
+                {members.nodes.map((n) => (
+                  <PlotNodeRow
+                    key={n.id}
+                    node={n}
+                    tenantId={tenantId}
+                    mapTitle={mapTitle(n.mapId)}
+                    onRemove={() => handleRemoveNode(n.id)}
+                  />
+                ))}
+              </ul>
+            )}
+            <AddNodePicker
+              plotId={plot.id}
+              tenantId={tenantId}
+              maps={maps}
+              currentNodeIds={new Set(members.nodes.map((n) => n.id))}
+              onAdded={reloadMembers}
+            />
+          </section>
+
+          <section className="plot-section">
+            <h3>Notes ({members.notes.length})</h3>
+            {members.notes.length === 0 ? (
+              <p className="plot-empty">No notes attached.</p>
+            ) : (
+              <ul className="plot-member-list">
+                {members.notes.map((n) => (
+                  <PlotNoteRow
+                    key={n.id}
+                    note={n}
+                    tenantId={tenantId}
+                    mapTitle={mapTitle(n.mapId)}
+                    onRemove={() => handleRemoveNote(n.id)}
+                  />
+                ))}
+              </ul>
+            )}
+            <AddNotePicker
+              plotId={plot.id}
+              tenantId={tenantId}
+              maps={maps}
+              currentNoteIds={new Set(members.notes.map((n) => n.id))}
+              onAdded={reloadMembers}
+            />
+          </section>
+        </div>
+      )}
+    </article>
+  );
+}
+
+// ─── Per-member rows ─────────────────────────────────────────────────────────
+
+interface PlotNodeRowProps {
+  node: PlotNodeMember;
+  tenantId: number;
+  mapTitle: string;
+  onRemove: () => void;
+}
+
+function PlotNodeRow({ node, tenantId, mapTitle, onRemove }: PlotNodeRowProps) {
+  return (
+    <li className="plot-member-row">
+      <Link
+        to={`/tenants/${tenantId}/maps/${node.mapId}?node=${node.id}`}
+        className="plot-member-link"
+      >
+        <span className="plot-member-name">{node.name}</span>
+        <span className="plot-member-map">in {mapTitle}</span>
+      </Link>
+      <button type="button" className="btn btn-ghost btn-sm" onClick={onRemove}>
+        Remove
+      </button>
+    </li>
+  );
+}
+
+interface PlotNoteRowProps {
+  note: PlotNoteMember;
+  tenantId: number;
+  mapTitle: string;
+  onRemove: () => void;
+}
+
+function PlotNoteRow({ note, tenantId, mapTitle, onRemove }: PlotNoteRowProps) {
+  // Note links land on the note's parent node — NodeDetailPanel renders
+  // the node's notes inline, so the user sees the right one in context.
+  return (
+    <li className="plot-member-row">
+      <Link
+        to={`/tenants/${tenantId}/maps/${note.mapId}?node=${note.nodeId}`}
+        className="plot-member-link"
+      >
+        <span className="plot-member-name">
+          {note.title || '(untitled note)'}
+          {note.pinned && <span className="plot-member-pin"> 📌</span>}
+        </span>
+        <span className="plot-member-map">in {mapTitle}</span>
+      </Link>
+      <button type="button" className="btn btn-ghost btn-sm" onClick={onRemove}>
+        Remove
+      </button>
+    </li>
+  );
+}
+
+// ─── Add-node picker ─────────────────────────────────────────────────────────
+
+interface AddNodePickerProps {
+  plotId: number;
+  tenantId: number;
+  maps: MapRecord[];
+  currentNodeIds: Set<number>;
+  onAdded: () => Promise<void> | void;
+}
+
+function AddNodePicker({
+  plotId,
+  tenantId,
+  maps,
+  currentNodeIds,
+  onAdded,
+}: AddNodePickerProps) {
+  const [selectedMapId, setSelectedMapId] = useState<string>('');
+  const [nodes, setNodes] = useState<NodeRecord[]>([]);
+  const [selectedNodeId, setSelectedNodeId] = useState<string>('');
+  const [loadingNodes, setLoadingNodes] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedMapId) {
+      setNodes([]);
+      return;
+    }
+    let cancelled = false;
+    setLoadingNodes(true);
+    nodesService
+      .listNodes(Number(selectedMapId), undefined, tenantId)
+      .then((ns) => { if (!cancelled) setNodes(ns); })
+      .catch(() => { if (!cancelled) setNodes([]); })
+      .finally(() => { if (!cancelled) setLoadingNodes(false); });
+    return () => { cancelled = true; };
+  }, [selectedMapId, tenantId]);
+
+  const eligibleNodes = nodes.filter((n) => !currentNodeIds.has(n.id));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedNodeId) return;
+    setError(null);
+    setSaving(true);
+    try {
+      await plotsService.addNode(plotId, Number(selectedNodeId), tenantId);
+      setSelectedNodeId('');
+      await onAdded();
+    } catch (err) {
+      setError(extractApiError(err, 'Failed to add node.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form className="plot-add-form" onSubmit={handleSubmit}>
+      {error && <div className="alert alert-error">{error}</div>}
+      <select
+        value={selectedMapId}
+        onChange={(e) => {
+          setSelectedMapId(e.target.value);
+          setSelectedNodeId('');
+        }}
+        disabled={saving}
+      >
+        <option value="">Pick a map…</option>
+        {maps.map((m) => (
+          <option key={m.id} value={String(m.id)}>{m.title}</option>
+        ))}
+      </select>
+      <select
+        value={selectedNodeId}
+        onChange={(e) => setSelectedNodeId(e.target.value)}
+        disabled={saving || !selectedMapId || loadingNodes}
+      >
+        <option value="">
+          {!selectedMapId
+            ? 'Pick a map first'
+            : loadingNodes
+              ? 'Loading nodes…'
+              : eligibleNodes.length === 0
+                ? 'No eligible nodes'
+                : 'Pick a node…'}
+        </option>
+        {eligibleNodes.map((n) => (
+          <option key={n.id} value={String(n.id)}>{n.name}</option>
+        ))}
+      </select>
+      <button
+        type="submit"
+        className="btn btn-primary btn-sm"
+        disabled={saving || !selectedNodeId}
+      >
+        {saving ? 'Adding…' : 'Add node'}
+      </button>
+    </form>
+  );
+}
+
+// ─── Add-note picker ─────────────────────────────────────────────────────────
+
+interface AddNotePickerProps {
+  plotId: number;
+  tenantId: number;
+  maps: MapRecord[];
+  currentNoteIds: Set<number>;
+  onAdded: () => Promise<void> | void;
+}
+
+function AddNotePicker({
+  plotId,
+  tenantId,
+  maps,
+  currentNoteIds,
+  onAdded,
+}: AddNotePickerProps) {
+  const [selectedMapId, setSelectedMapId] = useState<string>('');
+  const [selectedNodeId, setSelectedNodeId] = useState<string>('');
+  const [nodes, setNodes] = useState<NodeRecord[]>([]);
+  const [notes, setNotes] = useState<NoteRecord[]>([]);
+  const [selectedNoteId, setSelectedNoteId] = useState<string>('');
+  const [loadingNodes, setLoadingNodes] = useState(false);
+  const [loadingNotes, setLoadingNotes] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedMapId) {
+      setNodes([]);
+      return;
+    }
+    let cancelled = false;
+    setLoadingNodes(true);
+    nodesService
+      .listNodes(Number(selectedMapId), undefined, tenantId)
+      .then((ns) => { if (!cancelled) setNodes(ns); })
+      .catch(() => { if (!cancelled) setNodes([]); })
+      .finally(() => { if (!cancelled) setLoadingNodes(false); });
+    return () => { cancelled = true; };
+  }, [selectedMapId, tenantId]);
+
+  useEffect(() => {
+    if (!selectedMapId || !selectedNodeId) {
+      setNotes([]);
+      return;
+    }
+    let cancelled = false;
+    setLoadingNotes(true);
+    notesService
+      .listNotesForNode(Number(selectedMapId), Number(selectedNodeId), tenantId)
+      .then((ns) => { if (!cancelled) setNotes(ns); })
+      .catch(() => { if (!cancelled) setNotes([]); })
+      .finally(() => { if (!cancelled) setLoadingNotes(false); });
+    return () => { cancelled = true; };
+  }, [selectedMapId, selectedNodeId, tenantId]);
+
+  const eligibleNotes = notes.filter((n) => !currentNoteIds.has(n.id));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedNoteId) return;
+    setError(null);
+    setSaving(true);
+    try {
+      await plotsService.addNote(plotId, Number(selectedNoteId), tenantId);
+      setSelectedNoteId('');
+      await onAdded();
+    } catch (err) {
+      setError(extractApiError(err, 'Failed to add note.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form className="plot-add-form" onSubmit={handleSubmit}>
+      {error && <div className="alert alert-error">{error}</div>}
+      <select
+        value={selectedMapId}
+        onChange={(e) => {
+          setSelectedMapId(e.target.value);
+          setSelectedNodeId('');
+          setSelectedNoteId('');
+        }}
+        disabled={saving}
+      >
+        <option value="">Pick a map…</option>
+        {maps.map((m) => (
+          <option key={m.id} value={String(m.id)}>{m.title}</option>
+        ))}
+      </select>
+      <select
+        value={selectedNodeId}
+        onChange={(e) => {
+          setSelectedNodeId(e.target.value);
+          setSelectedNoteId('');
+        }}
+        disabled={saving || !selectedMapId || loadingNodes}
+      >
+        <option value="">
+          {!selectedMapId
+            ? 'Pick a map first'
+            : loadingNodes
+              ? 'Loading nodes…'
+              : 'Pick a node…'}
+        </option>
+        {nodes.map((n) => (
+          <option key={n.id} value={String(n.id)}>{n.name}</option>
+        ))}
+      </select>
+      <select
+        value={selectedNoteId}
+        onChange={(e) => setSelectedNoteId(e.target.value)}
+        disabled={saving || !selectedNodeId || loadingNotes}
+      >
+        <option value="">
+          {!selectedNodeId
+            ? 'Pick a node first'
+            : loadingNotes
+              ? 'Loading notes…'
+              : eligibleNotes.length === 0
+                ? 'No eligible notes'
+                : 'Pick a note…'}
+        </option>
+        {eligibleNotes.map((n) => (
+          <option key={n.id} value={String(n.id)}>
+            {n.title || '(untitled)'}
+          </option>
+        ))}
+      </select>
+      <button
+        type="submit"
+        className="btn btn-primary btn-sm"
+        disabled={saving || !selectedNoteId}
+      >
+        {saving ? 'Adding…' : 'Add note'}
+      </button>
+    </form>
+  );
+}
+
+// ─── Create / edit modal ─────────────────────────────────────────────────────
+
+interface PlotFormModalProps {
+  mode: 'create' | 'edit';
+  tenantId: number;
+  plot?: PlotRecord;
+  onClose: () => void;
+  onSaved: () => Promise<void> | void;
+}
+
+function PlotFormModal({ mode, tenantId, plot, onClose, onSaved }: PlotFormModalProps) {
+  const [name, setName] = useState(plot?.name ?? '');
+  const [description, setDescription] = useState(plot?.description ?? '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSaving(true);
+    try {
+      if (mode === 'create') {
+        const req: CreatePlotRequest = { name };
+        if (description) req.description = description;
+        await plotsService.createPlot(req, tenantId);
+      } else if (plot) {
+        const req: UpdatePlotRequest = {};
+        if (name !== plot.name) req.name = name;
+        if (description !== plot.description) req.description = description;
+        await plotsService.updatePlot(plot.id, req, tenantId);
+      }
+      await onSaved();
+    } catch (err) {
+      setError(extractApiError(err, `Failed to ${mode} plot.`));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <h2>{mode === 'create' ? 'New Plot' : 'Edit Plot'}</h2>
+        <form onSubmit={handleSubmit} className="auth-form">
+          {error && <div className="alert alert-error">{error}</div>}
+          <div className="form-group">
+            <label htmlFor="plot-name">Name</label>
+            <input
+              id="plot-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              placeholder="The Heist, Act II, …"
+              disabled={saving}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="plot-description">Description</label>
+            <textarea
+              id="plot-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional"
+              rows={3}
+              disabled={saving}
+            />
+          </div>
+          <div className="modal-actions">
+            <button
+              type="button"
+              className="btn btn-ghost"
+              onClick={onClose}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={saving || !name}
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/maps.ts
+++ b/frontend/src/services/maps.ts
@@ -14,6 +14,9 @@ import {
   VisibilityGroupMemberListSchema,
   NodeVisibilityStateSchema,
   NoteVisibilityStateSchema,
+  PlotRecordSchema,
+  PlotListSchema,
+  PlotMembersSchema,
   type MapRecord,
   type MapList,
   type NodeRecord,
@@ -36,6 +39,11 @@ import {
   type NodeVisibilityState,
   type NoteVisibilityState,
   type SetVisibilityRequest,
+  type PlotRecord,
+  type PlotList,
+  type PlotMembers,
+  type CreatePlotRequest,
+  type UpdatePlotRequest,
 } from '@/api/schemas';
 import type {
   Tenant,
@@ -372,6 +380,84 @@ export const notesService = {
     await apiClient.post(
       `${tenantBase(tenantId)}/maps/${mapId}/notes/${noteId}/visibility`,
       data,
+    );
+  },
+};
+
+// ─── Plots (#88 / #95) ───────────────────────────────────────────────────────
+// Tenant-scoped narrative groupings tying together nodes + notes across maps.
+// Same `tenantBase` resolution as everything else in this module: callers
+// pass an explicit tenantId (e.g. when browsing another user's tenant via
+// E2E SQL bypass) or rely on the auth-store fallback.
+
+export const plotsService = {
+  async listPlots(tenantId?: number): Promise<PlotList> {
+    const res = await apiClient.get(`${tenantBase(tenantId)}/plots`);
+    return PlotListSchema.parse(res.data);
+  },
+
+  async getPlot(plotId: number, tenantId?: number): Promise<PlotRecord> {
+    const res = await apiClient.get(`${tenantBase(tenantId)}/plots/${plotId}`);
+    return PlotRecordSchema.parse(res.data);
+  },
+
+  async createPlot(data: CreatePlotRequest, tenantId?: number): Promise<PlotRecord> {
+    // Backend's POST returns a partial plot (no createdAt/updatedAt) — same
+    // shape mismatch as updatePlot. POST then GET to return a fully-parsed
+    // record so the caller can rely on the timestamps.
+    const res = await apiClient.post(`${tenantBase(tenantId)}/plots`, data);
+    const id = res.data?.id;
+    if (typeof id !== 'number') {
+      throw new Error('createPlot: response missing id');
+    }
+    return this.getPlot(id, tenantId);
+  },
+
+  async updatePlot(
+    plotId: number,
+    data: UpdatePlotRequest,
+    tenantId?: number,
+  ): Promise<PlotRecord> {
+    // Same shape mismatch as mapsService.updateMap: PUT returns
+    // { id, updated: true }, so re-fetch the parsed record.
+    await apiClient.put(`${tenantBase(tenantId)}/plots/${plotId}`, data);
+    return this.getPlot(plotId, tenantId);
+  },
+
+  async deletePlot(plotId: number, tenantId?: number): Promise<void> {
+    await apiClient.delete(`${tenantBase(tenantId)}/plots/${plotId}`);
+  },
+
+  async listMembers(plotId: number, tenantId?: number): Promise<PlotMembers> {
+    const res = await apiClient.get(
+      `${tenantBase(tenantId)}/plots/${plotId}/members`,
+    );
+    return PlotMembersSchema.parse(res.data);
+  },
+
+  async addNode(plotId: number, nodeId: number, tenantId?: number): Promise<void> {
+    await apiClient.post(
+      `${tenantBase(tenantId)}/plots/${plotId}/nodes`,
+      { nodeId },
+    );
+  },
+
+  async removeNode(plotId: number, nodeId: number, tenantId?: number): Promise<void> {
+    await apiClient.delete(
+      `${tenantBase(tenantId)}/plots/${plotId}/nodes/${nodeId}`,
+    );
+  },
+
+  async addNote(plotId: number, noteId: number, tenantId?: number): Promise<void> {
+    await apiClient.post(
+      `${tenantBase(tenantId)}/plots/${plotId}/notes`,
+      { noteId },
+    );
+  },
+
+  async removeNote(plotId: number, noteId: number, tenantId?: number): Promise<void> {
+    await apiClient.delete(
+      `${tenantBase(tenantId)}/plots/${plotId}/notes/${noteId}`,
     );
   },
 };

--- a/frontend/tests/e2e/plots.spec.ts
+++ b/frontend/tests/e2e/plots.spec.ts
@@ -1,0 +1,267 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import {
+  registerViaApi,
+  createMapViaApi,
+  createNodeViaApi,
+  seedAuthInBrowser,
+  mysqlQuery,
+  API_URL,
+  type ApiUser,
+} from './helpers';
+
+/**
+ * E2E coverage for #95: Plots admin page.
+ *
+ * Plots are tenant-scoped narrative groupings tying together nodes + notes
+ * across maps. The user-facing assertions are:
+ *  1) An admin can create a plot, attach members from multiple maps via the
+ *     two-step picker, and click a member row to land on the right map with
+ *     the right node selected.
+ *  2) The plot member list respects per-node visibility — a non-admin
+ *     tenant member who can't see a tagged node won't see it in the plot
+ *     either, even if the plot owner attached it.
+ *
+ * Visibility test mirrors the cross-user fixture pattern from
+ * visibility.spec.ts (move user B into A's org via SQL bypass, grant
+ * map view via SQL, then check the plot members list as B).
+ */
+
+// ─── Local API helpers ──────────────────────────────────────────────────────
+// Same lift-when-second-spec-needs-it pattern as helpers.ts: hoisting these
+// to helpers.ts is overkill until a third spec needs notes/plots setup.
+
+async function createPlotViaApi(
+  request: APIRequestContext,
+  api: ApiUser,
+  name: string,
+  description?: string,
+): Promise<{ id: number; name: string }> {
+  const res = await request.post(`${API_URL}/tenants/${api.tenantId}/plots`, {
+    headers: { Authorization: `Bearer ${api.token}` },
+    data: description ? { name, description } : { name },
+  });
+  if (!res.ok()) {
+    throw new Error(`createPlot failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function createNoteViaApi(
+  request: APIRequestContext,
+  api: ApiUser,
+  mapId: number,
+  nodeId: number,
+  body: { title?: string; text: string; pinned?: boolean },
+): Promise<{ id: number }> {
+  const res = await request.post(
+    `${API_URL}/tenants/${api.tenantId}/maps/${mapId}/nodes/${nodeId}/notes`,
+    { headers: { Authorization: `Bearer ${api.token}` }, data: body },
+  );
+  if (!res.ok()) {
+    throw new Error(`createNote failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function createVisibilityGroup(
+  request: APIRequestContext,
+  api: ApiUser,
+  name: string,
+): Promise<{ id: number }> {
+  const res = await request.post(
+    `${API_URL}/tenants/${api.tenantId}/visibility-groups`,
+    { headers: { Authorization: `Bearer ${api.token}` }, data: { name } },
+  );
+  if (!res.ok()) throw new Error(`createGroup failed: ${res.status()}`);
+  return res.json();
+}
+
+async function setNodeVisibility(
+  request: APIRequestContext,
+  api: ApiUser,
+  mapId: number,
+  nodeId: number,
+  body: { override?: boolean; groupIds?: number[] },
+): Promise<void> {
+  const res = await request.post(
+    `${API_URL}/tenants/${api.tenantId}/maps/${mapId}/nodes/${nodeId}/visibility`,
+    { headers: { Authorization: `Bearer ${api.token}` }, data: body },
+  );
+  if (!res.ok()) throw new Error(`setNodeVisibility failed: ${res.status()}`);
+}
+
+// ─── Plot CRUD + cross-map navigation ────────────────────────────────────────
+
+test.describe('Plots — CRUD and cross-map navigation', () => {
+  test('owner creates a plot, attaches a node + a note from different maps, and clicks through to the right map+node', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'plot_nav');
+
+    // Two maps — proves the plot aggregates members across maps.
+    const mapA = await createMapViaApi(request, api, 'Plot Map A', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 3,
+    });
+    const mapB = await createMapViaApi(request, api, 'Plot Map B', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 3,
+    });
+    const nodeA = await createNodeViaApi(request, api, mapA.id, { name: 'CityA' });
+    const nodeB = await createNodeViaApi(request, api, mapB.id, { name: 'CityB' });
+    const noteOnB = await createNoteViaApi(request, api, mapB.id, nodeB.id, {
+      title: 'Heist Brief',
+      text: 'The vault opens at midnight.',
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/plots`);
+
+    // Empty state.
+    await expect(page.getByText(/no plots yet/i)).toBeVisible();
+
+    // Create a plot via the modal.
+    await page.getByRole('button', { name: /\+ New Plot/i }).click();
+    await page.getByLabel(/^name$/i).fill('Act II');
+    await page.getByLabel(/^description$/i).fill('The heist arc.');
+    await page.getByRole('button', { name: /^save$/i }).click();
+
+    const plotRow = page.locator('.plot-row', {
+      has: page.getByRole('heading', { name: 'Act II' }),
+    });
+    await expect(plotRow).toBeVisible();
+
+    // Expand the row to reveal the member panel.
+    await plotRow.locator('.plot-toggle').click();
+
+    // Add `CityA` from Map A via the node picker.
+    const addNodeForm = plotRow.locator('.plot-add-form').first();
+    await addNodeForm.locator('select').nth(0).selectOption({ label: 'Plot Map A' });
+    await addNodeForm.locator('select').nth(1).selectOption({ label: 'CityA' });
+    await addNodeForm.getByRole('button', { name: /add node/i }).click();
+    await expect(plotRow.getByRole('link', { name: /CityA/ })).toBeVisible();
+
+    // Add the note on Map B via the note picker. The note picker is the
+    // second .plot-add-form inside the row body.
+    const addNoteForm = plotRow.locator('.plot-add-form').nth(1);
+    await addNoteForm.locator('select').nth(0).selectOption({ label: 'Plot Map B' });
+    await addNoteForm.locator('select').nth(1).selectOption({ label: 'CityB' });
+    await addNoteForm.locator('select').nth(2).selectOption({ label: 'Heist Brief' });
+    await addNoteForm.getByRole('button', { name: /add note/i }).click();
+    await expect(plotRow.getByRole('link', { name: /Heist Brief/ })).toBeVisible();
+
+    // Click-to-jump: clicking CityA lands on Map A with CityA selected.
+    await plotRow.getByRole('link', { name: /CityA/ }).click();
+    await expect(page).toHaveURL(new RegExp(`/maps/${mapA.id}\\?node=${nodeA.id}\\b`));
+    // The detail panel renders the selected node's name as a heading.
+    await expect(page.getByRole('heading', { name: 'CityA' })).toBeVisible();
+
+    // Back to plots; click the note link, land on Map B at CityB.
+    await page.goto(`/tenants/${api.tenantId}/plots`);
+    await page.locator('.plot-row', {
+      has: page.getByRole('heading', { name: 'Act II' }),
+    }).locator('.plot-toggle').click();
+    await page.getByRole('link', { name: /Heist Brief/ }).click();
+    await expect(page).toHaveURL(new RegExp(`/maps/${mapB.id}\\?node=${nodeB.id}\\b`));
+    await expect(page.getByRole('heading', { name: 'CityB' })).toBeVisible();
+    // Sanity-check the note is rendered in the detail panel.
+    await expect(page.getByText('Heist Brief')).toBeVisible();
+
+    // Silence the unused-var warning while making the assertion explicit.
+    expect(noteOnB.id).toBeGreaterThan(0);
+  });
+});
+
+// ─── Visibility filtering on plot member list ───────────────────────────────
+
+test.describe('Plots — visibility filtering', () => {
+  test('a non-admin member only sees plot nodes their visibility grants permit', async ({ browser, request }) => {
+    const apiA = await registerViaApi(request, 'plot_vis_owner');
+    const apiB = await registerViaApi(request, 'plot_vis_member');
+
+    // Move B into A's org + tenant — same fixture as visibility.spec.ts.
+    const aOrgId = mysqlQuery(`SELECT org_id FROM users WHERE id=${apiA.user.id};`);
+    mysqlQuery(`UPDATE users SET org_id=${aOrgId} WHERE id=${apiB.user.id};`);
+    mysqlQuery(
+      `INSERT INTO tenant_members (tenant_id, user_id, role) ` +
+      `VALUES (${apiA.tenantId}, ${apiB.user.id}, 'viewer');`,
+    );
+
+    const map = await createMapViaApi(request, apiA, 'Plot Filter Map', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 3,
+    });
+    mysqlQuery(
+      `INSERT INTO map_permissions (map_id, user_id, level) ` +
+      `VALUES (${map.id}, ${apiB.user.id}, 'view');`,
+    );
+
+    // Two nodes, two visibility groups. Players (B is a member): only sees
+    // PlayersOnly. GMs (B is not a member): GmsOnly is hidden from B.
+    const players = await createVisibilityGroup(request, apiA, 'Players');
+    const gms = await createVisibilityGroup(request, apiA, 'GMs');
+    const playersOnly = await createNodeViaApi(request, apiA, map.id, { name: 'PlayersOnly' });
+    const gmsOnly = await createNodeViaApi(request, apiA, map.id, { name: 'GmsOnly' });
+    await setNodeVisibility(request, apiA, map.id, playersOnly.id, {
+      override: true,
+      groupIds: [players.id],
+    });
+    await setNodeVisibility(request, apiA, map.id, gmsOnly.id, {
+      override: true,
+      groupIds: [gms.id],
+    });
+    // Add B to Players.
+    const addB = await request.post(
+      `${API_URL}/tenants/${apiA.tenantId}/visibility-groups/${players.id}/members`,
+      { headers: { Authorization: `Bearer ${apiA.token}` }, data: { userId: apiB.user.id } },
+    );
+    if (!addB.ok()) throw new Error(`addPlayersMember failed: ${addB.status()}`);
+
+    // Plot with both nodes attached.
+    const plot = await createPlotViaApi(request, apiA, 'Mixed Plot');
+    for (const nodeId of [playersOnly.id, gmsOnly.id]) {
+      const r = await request.post(
+        `${API_URL}/tenants/${apiA.tenantId}/plots/${plot.id}/nodes`,
+        { headers: { Authorization: `Bearer ${apiA.token}` }, data: { nodeId } },
+      );
+      if (!r.ok()) throw new Error(`addPlotNode failed: ${r.status()}`);
+    }
+
+    // ── B browses /tenants/{A.tenantId}/plots: only PlayersOnly visible.
+    const ctxB = await browser.newContext();
+    try {
+      const pageB = await ctxB.newPage();
+      await seedAuthInBrowser(pageB, apiB, { id: apiA.tenantId, role: 'viewer' });
+      await pageB.goto(`/tenants/${apiA.tenantId}/plots`);
+
+      const plotRowB = pageB.locator('.plot-row', {
+        has: pageB.getByRole('heading', { name: 'Mixed Plot' }),
+      });
+      await plotRowB.locator('.plot-toggle').click();
+
+      await expect(plotRowB.getByRole('link', { name: /PlayersOnly/ })).toBeVisible();
+      await expect(plotRowB.getByRole('link', { name: /GmsOnly/ })).toHaveCount(0);
+    } finally {
+      await ctxB.close();
+    }
+
+    // ── A (the owner) sees both members.
+    const ctxA = await browser.newContext();
+    try {
+      const pageA = await ctxA.newPage();
+      await seedAuthInBrowser(pageA, apiA);
+      await pageA.goto(`/tenants/${apiA.tenantId}/plots`);
+
+      const plotRowA = pageA.locator('.plot-row', {
+        has: pageA.getByRole('heading', { name: 'Mixed Plot' }),
+      });
+      await plotRowA.locator('.plot-toggle').click();
+
+      await expect(plotRowA.getByRole('link', { name: /PlayersOnly/ })).toBeVisible();
+      await expect(plotRowA.getByRole('link', { name: /GmsOnly/ })).toBeVisible();
+    } finally {
+      await ctxA.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #95 (with a follow-up split to #139 for the detail-panel "Plots this item is in" section, which needs a backend endpoint that doesn't exist yet).

Tenant-scoped Plots admin page at `/tenants/{tid}/plots` — modeled on the
visibility-group page from #94:

- Collapsible row per plot with member counts
- Inline member panel split into **Nodes** / **Notes** sub-sections
- Two-step picker for adding members (map → node, optionally → note)
- Each member row links to `/tenants/{tid}/maps/{mid}?node={nodeId}`
- Modal for create / edit
- "Plots" link in the navbar

`MapDetailPage` honors `?node=N` on mount, pre-selecting the node so plot-row clicks land on the right map with the right item highlighted in the detail panel. Effect is keyed on `mapId` only — subsequent user clicks within the same map aren't fought by stale URL state.

## Split-out follow-up

The original ticket included a "Plots this item is in" section in the node/note detail panel. That requires backend endpoints that don't exist yet (`GET /nodes/{id}/plots`, `GET /notes/{id}/plots`) — synthesizing them client-side would mean N+1 queries on every detail-panel render. Filed as #139 for a clean follow-up.

## Service-layer alignment

Two PUT/POST endpoints in the plot backend return partial records:
- `POST /plots` returns `{id, tenantId, name, description, createdBy}` (no timestamps)
- `PUT /plots/{id}` returns `{id, updated:true}` (same as `PUT /maps/{id}` from #106)

Both `createPlot` and `updatePlot` follow up with a `GET /plots/{id}` so callers receive a fully-parsed `PlotRecord` matching the Zod schema.

## Work breakdown

- [x] File follow-up #139 for detail-panel "Plots" section
- [x] Plot / PlotMembers / member-row Zod schemas + types
- [x] `plotsService` (list/CRUD/add+remove members) with POST/PUT-then-GET
- [x] PlotsPage: collapsible rows, modal create/edit, two-step pickers
- [x] MapDetailPage: honor `?node=N` query param on mount
- [x] `/tenants/:tenantId/plots` route + Navbar "Plots" link
- [x] CSS for plot rows / sections / pickers
- [x] E2E: create plot, add cross-map node + note, click member → land on right map+selection
- [x] E2E: visibility filtering on plot member list (cross-user via SQL bypass)
- [x] tsc + lint clean
- [x] Plot tests pass standalone
- [x] Full E2E suite passes (28 passed, 5 skipped — no regressions)
- [x] docs/TESTING-E2E.md updated

## Files changed

- `docs/TESTING-E2E.md` — Add `plots.spec.ts` to suite list
- `frontend/src/App.tsx` — Lazy-import `PlotsPage`, register `/tenants/:tenantId/plots` route
- `frontend/src/api/schemas.ts` — `PlotRecord`, `PlotList`, `PlotMembers` (with nested node/note member schemas), `CreatePlotRequest`, `UpdatePlotRequest`
- `frontend/src/components/Layout/Navbar.tsx` — Add "Plots" link beside "Visibility"
- `frontend/src/index.css` — Plot-row / section / member-row / picker styles
- `frontend/src/pages/MapDetailPage.tsx` — Read `?node=N` query param on mount, pre-select the node
- `frontend/src/pages/PlotsPage.tsx` — New: list page + collapsible row + Nodes/Notes sub-sections + AddNodePicker + AddNotePicker + create/edit modal
- `frontend/src/services/maps.ts` — `plotsService` (list/get/create/update/delete + listMembers + add/remove node/note); `createPlot` and `updatePlot` use POST/PUT-then-GET to round-trip the partial backend response shape
- `frontend/tests/e2e/plots.spec.ts` — New: 2 tests (cross-map nav + visibility filtering)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npx playwright test tests/e2e/plots.spec.ts` — 2 passed
- [x] `npx playwright test` — 28 passed, 5 skipped (no regressions)
- [x] PR CI green