### PR TITLE
docs: post-merge cleanup must be interruption-resistant

### DIFF
--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -125,6 +125,41 @@ merging into a long-running branch, **both** of these are manual:
    long-running-branch context).
 2. Flip the board status to Done.
 
+**How to make this interruption-resistant:**
+
+A "PR merged" message often arrives in the same turn as a "proceed to the
+next task" instruction. The natural failure mode is to jump straight into
+exploring the next ticket and forget the cleanup — *especially* if the
+next task triggers a clarifying question that diverts the conversation.
+The cleanup steps live entirely in the agent's head until they're done,
+so any interruption can drop them.
+
+**The fix:** when a "PR merged" message arrives, the *first* tool call
+must be a `TodoWrite` capturing the cleanup checklist *before* any
+exploration of the next task. Concretely:
+
+1. **First action**: `TodoWrite` with two pending items at the top:
+   - "Close issue #NNN (long-running branch — auto-close didn't fire)"
+   - "Move #NNN board status to Done"
+2. Execute those two items, marking each completed as you go.
+3. *Then* start the next task (which may itself open with a clarifying
+   question — fine, the cleanup is already done).
+
+Why this works: the todo list survives across model responses. Even if
+the next-task work triggers a clarifying question, even if the user
+replies with something unrelated, even if the conversation context
+shifts entirely, the unchecked cleanup items remain visible at the top
+of every turn. The runtime's periodic "TodoWrite hasn't been used
+recently" reminders also resurface stale lists. By contrast, a cleanup
+step that lives only in the agent's narrative response has no such
+durability — once the response is sent, it's gone.
+
+**Skip the TodoWrite only if**: the merged PR was into the default
+branch (`main`) AND the issue auto-closed (visible in the user's
+message or trivially confirmable). In that case the only manual step
+is the board flip — fine to do as a single direct tool call without
+the list overhead.
+
 **Project-specific binding (annotated-maps `Focus on next` board):**
 
 ```bash


### PR DESCRIPTION
## Summary

§2 of \`docs/AI-COLLABORATION-CONVENTIONS.md\` already covered the manual close + board flip required after merging a PR into a long-running branch (auto-close-on-merge only fires for the default branch). What it didn't cover was the *execution discipline* needed to remember those steps when the cleanup arrives entangled with a "proceed to next task" instruction.

The repeating failure mode: "PR merged. Proceed to the next task." → agent jumps straight into exploring the next ticket → clarifying question diverts the conversation → cleanup steps drop on the floor. Concretely, this just happened with #106: PR #138 merged into \`nodes-rebuild\` on Apr 28, but #106 stayed OPEN with status In Progress until Apr 29 when the user noticed.

The rule itself doesn't need to change — it's the execution habit that needs strengthening. This adds a sub-section codifying TodoWrite-as-first-action when receiving "PR merged".

## Why TodoWrite

Three durability properties that narrative prose lacks:

1. The list survives across model responses within a conversation.
2. The runtime periodically nags about stale lists, resurfacing forgotten items.
3. Marking the *next* task in_progress before the cleanup is done would be a visible inversion that's easy to spot in review.

## Work breakdown

- [x] Read existing §2 rule, confirm gap is execution not policy
- [x] Audit recent merged tickets — found #106 still OPEN + In Progress
- [x] Close #106 + flip to Done (the missing maintenance work)
- [x] Add "How to make this interruption-resistant" sub-section to §2
- [x] Update memory replica (\`feedback_ticket_status_lifecycle.md\`) to surface the new sub-rule in its description

## Files changed

- \`docs/AI-COLLABORATION-CONVENTIONS.md\` — Add "How to make this interruption-resistant" sub-section to §2, sandwiched between the long-running-branch caveat and the project-specific GraphQL bindings

(The memory replica at \`~/.claude/projects/.../memory/feedback_ticket_status_lifecycle.md\` was also updated, but that's outside the repo.)

## Test plan

Not testable in code. Validation is behavioural — the next time the user says "PR merged" the agent should respond with TodoWrite as its first tool call, then execute the cleanup, before exploring the next task. If that fails, this rule needs further sharpening.