### PR TITLE
docs: verify every board edit, since gh can silently no-op

### DIFF
--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -160,6 +160,19 @@ message or trivially confirmable). In that case the only manual step
 is the board flip — fine to do as a single direct tool call without
 the list overhead.
 
+**Always verify after a board edit.** `gh project item-edit` can
+silently no-op: exit code 0, no output, no actual change. Encountered
+during the #106 cleanup — the first flip command returned cleanly but
+the status stayed at In Progress; only spotted when the user noticed
+the board was wrong on the next turn. The fix is cheap: every board
+edit should be paired with an immediate read-back. Either chain them
+in one shell command (`gh project item-edit ... ; gh project item-list
+... --jq '.items[] | select(.content.number == NNN) | .status'`) or
+run a follow-up read tool call. The board's eventual-consistency
+window is short — a synchronous check in the same turn is sufficient.
+Don't mark the corresponding TodoWrite item completed until the
+read-back returns the expected status.
+
 **Project-specific binding (annotated-maps `Focus on next` board):**
 
 ```bash


### PR DESCRIPTION
## Summary

Follow-up to #141. \`gh project item-edit\` is not always synchronously authoritative — it can return exit 0 with no output and yet leave the board status unchanged. Hit this during the #106 cleanup: the first flip command looked clean, the status stayed at In Progress, and the discrepancy only surfaced when the user noticed the wrong state on the next turn.

Add an "Always verify after a board edit" paragraph to §2's "How to apply" section: pair every edit with an immediate read-back, and don't mark the corresponding TodoWrite item completed until the read confirms the expected status.

## Why this is its own PR

This is the same kind of execution-discipline rule as #141 — narrow scope, doc-only, no code change. Bundling it with the next feature ticket would bury it; keeping it separate lets the rule be approved on its merits and ensures the agent sees it active before the next board flip happens.

## Work breakdown

- [x] Branch off latest \`main\`
- [x] Add "Always verify after a board edit" paragraph to §2
- [x] Update memory replica's frontmatter description to surface the new bullet
- [x] Commit + open PR

## Files changed

- \`docs/AI-COLLABORATION-CONVENTIONS.md\` — Append the verify-after-edit paragraph to §2's existing "How to make this interruption-resistant" section, right after the "Skip the TodoWrite only if" paragraph

(The memory replica at \`~/.claude/projects/.../memory/feedback_ticket_status_lifecycle.md\` was also updated to mention the new sub-rule in its description.)

## Test plan

Behavioural, not testable in code. The next time the agent flips a board status, it should chain or follow up with a read-back, and not mark the cleanup todo completed until the read confirms.