### PR TITLE
docs: delete local feature branch as part of post-merge cleanup

### DIFF
--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -173,6 +173,31 @@ window is short — a synchronous check in the same turn is sufficient.
 Don't mark the corresponding TodoWrite item completed until the
 read-back returns the expected status.
 
+**Delete the local feature branch after the PR merges.** When this
+collaborator merges PRs they configure GitHub to delete the remote
+branch automatically; the local branch persists with a `: gone`
+upstream marker (visible in `git branch -vv`). These accumulate fast
+on a long-running project and clutter both `git branch` output and
+the agent's mental model of "what's still in flight." Add to the
+post-merge TodoWrite list:
+
+- "Delete local branch \`feature/NNN-...\` (remote was auto-deleted on merge)"
+
+Run `git branch -D <name>` (force, since git can't always confirm the
+merge happened — the remote is already gone, and the commits are in
+\`main\`/\`nodes-rebuild\` already if the PR merged). Skip if the
+branch is the current checkout — switch to \`main\` first. Skip the
+shared long-running branches (\`main\`, \`nodes-rebuild\`).
+
+To bulk-prune at any point, the safe one-liner is:
+
+```bash
+git fetch --all --prune                         # update : gone markers
+git branch -vv \
+  | awk '/: gone\]/ { print $1 }' \
+  | xargs -r -n1 git branch -D
+```
+
 **Project-specific binding (annotated-maps `Focus on next` board):**
 
 ```bash


### PR DESCRIPTION
## Summary

Third in the §2 execution-discipline series after #141 (post-merge cleanup must be interruption-resistant) and #142 (verify every board edit). This collaborator has GitHub configured to auto-delete the remote branch on PR merge. Locals persist as \`[origin/...: gone]\` entries (visible in \`git branch -vv\`) and accumulate fast — after a few weeks of \`nodes-rebuild\` work, \`git branch -vv\` showed ~50 of them. Easy to fix; just needs to be in the cleanup checklist alongside issue close + board flip.

Add to §2:

- A line in the post-merge TodoWrite list: "Delete local branch \`feature/NNN-...\`"
- The mechanical guidance: \`git branch -D\` (safe because the merge already happened on the remote), switch off the branch first if it's the current checkout, skip shared/long-running branches.
- A bulk-prune one-liner for periodic cleanup of branches that have already accumulated.

## Why this is its own PR

Same rationale as #141 and #142 — narrow scope, doc-only, no code change. Bundling it into the next feature ticket would bury it.

## Work breakdown

- [x] Audit local branches — confirmed ~50 branches with \`: gone\` upstream markers
- [x] Branch off latest \`main\` (post-#142)
- [x] Append "Delete the local feature branch after the PR merges" sub-rule to §2
- [x] Update memory replica's frontmatter description
- [x] Commit + open PR

After this PR merges:
- [ ] Bulk-prune the accumulated local branches (separate user request, performed in the same conversation but outside this PR)

## Files changed

- \`docs/AI-COLLABORATION-CONVENTIONS.md\` — Append the local-branch-delete sub-rule to §2's "How to make this interruption-resistant" section, after the verify-after-edit paragraph

(Memory replica at \`~/.claude/projects/.../memory/feedback_ticket_status_lifecycle.md\` also updated to mention the new bullet in its description.)

## Test plan

Behavioural. Next time the agent receives "PR merged", the TodoWrite list should include the local-branch-delete item, and it should be executed before declaring cleanup done.