### PR TITLE
Phase 2g.k: Plots in node/note detail panel \u2014 backend + frontend (#139)

### DIFF
--- a/backend/src/controllers/PlotController.cpp
+++ b/backend/src/controllers/PlotController.cpp
@@ -136,6 +136,60 @@ const std::string PLOT_NOTE_VISIBILITY_CTE =
     "         AND n.node_id IN (SELECT start_id FROM node_visible_starts)) "
     ") ";
 
+// Map-scoped visibility CTEs for the reverse-membership endpoints (#139).
+// These mirror NodeController's VISIBILITY_RESOLVE_CTE and NoteController's
+// NOTE_VISIBILITY_CTE — same shape, same MAX_NODE_DEPTH bound — but kept
+// local so PlotController doesn't depend on those private constants. Used
+// by GET /maps/{mid}/nodes/{nid}/plots and the analogous note endpoint.
+
+const std::string MAP_NODE_VISIBILITY_CTE =
+    "WITH RECURSIVE resolve AS ("
+    "  SELECT n.id AS start_id, n.id AS cur_id, n.parent_id, "
+    "         n.visibility_override, 0 AS depth "
+    "  FROM nodes n WHERE n.map_id = ? "
+    "  UNION ALL "
+    "  SELECT r.start_id, p.id, p.parent_id, p.visibility_override, r.depth + 1 "
+    "  FROM resolve r JOIN nodes p ON p.id = r.parent_id "
+    "  WHERE r.visibility_override = FALSE AND r.depth < " +
+        std::to_string(MAX_NODE_DEPTH) +
+    "), visible_starts AS ( "
+    "  SELECT DISTINCT r.start_id FROM resolve r "
+    "  JOIN node_visibility nv "
+    "       ON nv.node_id = r.cur_id AND r.visibility_override = TRUE "
+    "  JOIN visibility_group_members vgm "
+    "       ON vgm.visibility_group_id = nv.visibility_group_id "
+    "  WHERE vgm.user_id = ? "
+    ") ";
+
+const std::string MAP_NOTE_VISIBILITY_CTE =
+    "WITH RECURSIVE node_resolve AS ("
+    "  SELECT nd.id AS start_id, nd.id AS cur_id, nd.parent_id, "
+    "         nd.visibility_override, 0 AS depth "
+    "  FROM nodes nd WHERE nd.map_id = ? "
+    "  UNION ALL "
+    "  SELECT r.start_id, p.id, p.parent_id, p.visibility_override, r.depth + 1 "
+    "  FROM node_resolve r JOIN nodes p ON p.id = r.parent_id "
+    "  WHERE r.visibility_override = FALSE AND r.depth < " +
+        std::to_string(MAX_NODE_DEPTH) +
+    "), node_visible_starts AS ( "
+    "  SELECT DISTINCT r.start_id FROM node_resolve r "
+    "  JOIN node_visibility nv "
+    "       ON nv.node_id = r.cur_id AND r.visibility_override = TRUE "
+    "  JOIN visibility_group_members vgm "
+    "       ON vgm.visibility_group_id = nv.visibility_group_id "
+    "  WHERE vgm.user_id = ? "
+    "), note_visible AS ( "
+    "  SELECT n.id AS visible_note_id FROM notes n "
+    "  JOIN nodes nd ON nd.id = n.node_id AND nd.map_id = ? "
+    "  WHERE (n.visibility_override = TRUE "
+    "         AND EXISTS (SELECT 1 FROM note_visibility nv2 "
+    "                     JOIN visibility_group_members vgm2 "
+    "                          ON vgm2.visibility_group_id = nv2.visibility_group_id "
+    "                     WHERE nv2.note_id = n.id AND vgm2.user_id = ?)) "
+    "     OR (n.visibility_override = FALSE "
+    "         AND n.node_id IN (SELECT start_id FROM node_visible_starts)) "
+    ") ";
+
 }  // anonymous namespace
 
 // ─── GET /api/v1/tenants/{tid}/plots ─────────────────────────────────────────
@@ -713,4 +767,159 @@ void PlotController::removeNote(
                 "db_error", "Failed to detach note"));
         },
         id, noteId, tenantId);
+}
+
+// ─── GET /api/v1/tenants/{tid}/maps/{mid}/nodes/{nid}/plots (#139) ──────────
+//
+// Reverse-membership: list plots that contain the given node. The caller
+// must be able to see the node — a hidden node returns 404, never an empty
+// array, so existence isn't leaked. Admins and map-owners-with-xray bypass
+// the visibility check; everyone else is gated by the same effective-
+// visibility CTE used elsewhere.
+
+void PlotController::listPlotsForNode(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int nodeId) {
+
+    int userId = callerUserId(req);
+    bool isAdmin = isTenantAdmin(req);
+    auto db = drogon::app().getDbClient();
+
+    // Step 1: existence + visibility check, collapsed into one SELECT 1.
+    // Returns 1 row iff the node exists in this tenant+map AND the caller
+    // can see it. 0 rows → 404 in all three failure shapes (doesn't exist,
+    // wrong map/tenant, or not visible) so existence isn't leaked.
+    std::string verifySql;
+    if (!isAdmin) verifySql = MAP_NODE_VISIBILITY_CTE;
+    verifySql +=
+        "SELECT 1 FROM nodes n "
+        "JOIN maps m ON m.id = n.map_id AND m.tenant_id = ? "
+        "WHERE n.id = ? AND n.map_id = ? ";
+    if (!isAdmin) {
+        verifySql +=
+            "AND ((m.owner_id = ? AND m.owner_xray = TRUE) "
+            "     OR n.id IN (SELECT start_id FROM visible_starts)) ";
+    }
+
+    auto onVerify = [callback, tenantId, nodeId]
+        (const drogon::orm::Result& rV) {
+        if (rV.empty()) {
+            callback(errorResponse(drogon::k404NotFound,
+                "not_found", "Node not found"));
+            return;
+        }
+        // Step 2: list plots — no visibility filter on the plots themselves
+        // (plots aren't visibility-tagged). Tenant-scoped to keep cross-
+        // tenant rows out even though the node id alone would already
+        // reach the right plots via plot_nodes.
+        auto db2 = drogon::app().getDbClient();
+        db2->execSqlAsync(
+            "SELECT p.id, p.tenant_id, p.name, p.description, "
+            "       p.created_by, p.created_at, p.updated_at "
+            "FROM plots p "
+            "JOIN plot_nodes pn ON pn.plot_id = p.id AND pn.node_id = ? "
+            "WHERE p.tenant_id = ? "
+            "ORDER BY p.name ASC",
+            [callback](const drogon::orm::Result& rP) {
+                Json::Value arr(Json::arrayValue);
+                for (const auto& row : rP) arr.append(rowToPlot(row));
+                callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+            },
+            [callback](const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Failed to fetch plots for node"));
+            },
+            nodeId, tenantId);
+    };
+
+    auto onErr = [callback](const drogon::orm::DrogonDbException&) {
+        callback(errorResponse(drogon::k500InternalServerError,
+            "db_error", "Failed to verify node visibility"));
+    };
+
+    if (isAdmin) {
+        // verifySql binds: (tenantId, nodeId, mapId)
+        db->execSqlAsync(verifySql, onVerify, onErr,
+            tenantId, nodeId, mapId);
+    } else {
+        // CTE binds (mapId, userId), then verifySql binds
+        // (tenantId, nodeId, mapId) for the SELECT and (userId) for xray.
+        db->execSqlAsync(verifySql, onVerify, onErr,
+            mapId, userId,
+            tenantId, nodeId, mapId, userId);
+    }
+}
+
+// ─── GET /api/v1/tenants/{tid}/maps/{mid}/notes/{nid}/plots (#139) ──────────
+//
+// Reverse-membership for notes. Same shape as listPlotsForNode but with
+// note-visibility semantics (override-on-note OR inherited-from-attached-
+// node visibility). 404 when not visible — see the node version's comment.
+
+void PlotController::listPlotsForNote(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int noteId) {
+
+    int userId = callerUserId(req);
+    bool isAdmin = isTenantAdmin(req);
+    auto db = drogon::app().getDbClient();
+
+    std::string verifySql;
+    if (!isAdmin) verifySql = MAP_NOTE_VISIBILITY_CTE;
+    verifySql +=
+        "SELECT 1 FROM notes n "
+        "JOIN nodes nd ON nd.id = n.node_id "
+        "JOIN maps m ON m.id = nd.map_id AND m.tenant_id = ? "
+        "WHERE n.id = ? AND nd.map_id = ? ";
+    if (!isAdmin) {
+        verifySql +=
+            "AND ((m.owner_id = ? AND m.owner_xray = TRUE) "
+            "     OR n.id IN (SELECT visible_note_id FROM note_visible)) ";
+    }
+
+    auto onVerify = [callback, tenantId, noteId]
+        (const drogon::orm::Result& rV) {
+        if (rV.empty()) {
+            callback(errorResponse(drogon::k404NotFound,
+                "not_found", "Note not found"));
+            return;
+        }
+        auto db2 = drogon::app().getDbClient();
+        db2->execSqlAsync(
+            "SELECT p.id, p.tenant_id, p.name, p.description, "
+            "       p.created_by, p.created_at, p.updated_at "
+            "FROM plots p "
+            "JOIN plot_notes pnn ON pnn.plot_id = p.id AND pnn.note_id = ? "
+            "WHERE p.tenant_id = ? "
+            "ORDER BY p.name ASC",
+            [callback](const drogon::orm::Result& rP) {
+                Json::Value arr(Json::arrayValue);
+                for (const auto& row : rP) arr.append(rowToPlot(row));
+                callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+            },
+            [callback](const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Failed to fetch plots for note"));
+            },
+            noteId, tenantId);
+    };
+
+    auto onErr = [callback](const drogon::orm::DrogonDbException&) {
+        callback(errorResponse(drogon::k500InternalServerError,
+            "db_error", "Failed to verify note visibility"));
+    };
+
+    if (isAdmin) {
+        // verifySql binds: (tenantId, noteId, mapId)
+        db->execSqlAsync(verifySql, onVerify, onErr,
+            tenantId, noteId, mapId);
+    } else {
+        // CTE binds (mapId, userId, mapId, userId), then SELECT binds
+        // (tenantId, noteId, mapId) and xray binds (userId).
+        db->execSqlAsync(verifySql, onVerify, onErr,
+            mapId, userId, mapId, userId,
+            tenantId, noteId, mapId, userId);
+    }
 }

--- a/backend/src/controllers/PlotController.h
+++ b/backend/src/controllers/PlotController.h
@@ -23,6 +23,15 @@
  *   POST   /api/v1/tenants/{tenantId}/plots/{id}/notes
  *   DELETE /api/v1/tenants/{tenantId}/plots/{id}/notes/{noteId}
  *
+ * Reverse-membership ("which plots is this item in?", #139):
+ *   GET /api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{nodeId}/plots
+ *   GET /api/v1/tenants/{tenantId}/maps/{mapId}/notes/{noteId}/plots
+ *
+ *   These power the per-item Plots section in the node/note detail panel.
+ *   The caller must be able to see the node/note (visibility check matches
+ *   GET /nodes/{id} and GET /notes/{id}); if visible, returns the array of
+ *   plots that contain it. Hidden items return 404 — never leak existence.
+ *
  * Authorization:
  *   - Read endpoints: any tenant member (TenantFilter enforces).
  *   - Write endpoints (create/update/delete plot, attach/detach members):
@@ -75,6 +84,12 @@ public:
         ADD_METHOD_TO(PlotController::removeNote,
                       "/api/v1/tenants/{tenantId}/plots/{id}/notes/{noteId}",
                       drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(PlotController::listPlotsForNode,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{nodeId}/plots",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+        ADD_METHOD_TO(PlotController::listPlotsForNote,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/notes/{noteId}/plots",
+                      drogon::Get, "JwtFilter", "TenantFilter");
     METHOD_LIST_END
 
     void listPlots(const drogon::HttpRequestPtr&,
@@ -107,4 +122,10 @@ public:
     void removeNote(const drogon::HttpRequestPtr&,
                     std::function<void(const drogon::HttpResponsePtr&)>&&,
                     int tenantId, int id, int noteId);
+    void listPlotsForNode(const drogon::HttpRequestPtr&,
+                          std::function<void(const drogon::HttpResponsePtr&)>&&,
+                          int tenantId, int mapId, int nodeId);
+    void listPlotsForNote(const drogon::HttpRequestPtr&,
+                          std::function<void(const drogon::HttpResponsePtr&)>&&,
+                          int tenantId, int mapId, int noteId);
 };

--- a/backend/tests/test_22_plots.py
+++ b/backend/tests/test_22_plots.py
@@ -324,6 +324,118 @@ mysql_query(f"UPDATE maps SET owner_id={USER_A_ID} WHERE id={MAP_ID};")
 
 print("  All visibility-filter tests passed.")
 
+# ─── Reverse membership: GET /maps/{mid}/nodes/{nid}/plots (#139) ────────────
+#
+# State entering this section: PLOT_1 contains {PLAYERS_NODE, GM_NODE} as
+# nodes and {NOTE_PLAYERS, NOTE_GM} as notes. PLOT_2 exists but currently
+# has no node/note attached to PLAYERS_NODE / GM_NODE. We attach
+# PLAYERS_NODE to PLOT_2 to exercise the multi-plot case.
+
+print("  --- Reverse membership: plots-for-node ---")
+
+http_post(f"{PLOTS_BASE}/{PLOT_2}/nodes", {"nodeId": PLAYERS_NODE}, TOKEN_A)
+
+# Admin: PLAYERS_NODE is in both PLOT_1 and PLOT_2
+status, body = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_ID}/nodes/{PLAYERS_NODE}/plots", TOKEN_A)
+assert_status("plots-for-node admin: 200", 200, status)
+plot_ids = {p["id"] for p in body}
+assert_true("plots-for-node admin: both plots returned",
+            plot_ids == {PLOT_1, PLOT_2})
+
+# Admin: GM_NODE is only in PLOT_1
+status, body = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_ID}/nodes/{GM_NODE}/plots", TOKEN_A)
+plot_ids = {p["id"] for p in body}
+assert_true("plots-for-node admin: GM_NODE only in PLOT_1",
+            plot_ids == {PLOT_1})
+
+# Admin: ROOT was detached from PLOT_1 and was never on PLOT_2 → empty list
+status, body = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_ID}/nodes/{ROOT}/plots", TOKEN_A)
+assert_status("plots-for-node admin: empty returns 200", 200, status)
+assert_true("plots-for-node admin: ROOT empty", body == [])
+
+# Non-admin (B): PLAYERS_NODE is visible to B (in Players group), so B sees both plots
+status, body = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_ID}/nodes/{PLAYERS_NODE}/plots", TOKEN_B)
+assert_status("plots-for-node B: 200 (visible)", 200, status)
+plot_ids = {p["id"] for p in body}
+assert_true("plots-for-node B: PLAYERS_NODE in both plots",
+            plot_ids == {PLOT_1, PLOT_2})
+
+# Non-admin (B): GM_NODE is hidden from B → 404
+status, _ = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_ID}/nodes/{GM_NODE}/plots", TOKEN_B)
+assert_status("plots-for-node B: hidden returns 404", 404, status)
+
+# Unknown node id → 404
+status, _ = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_ID}/nodes/9999999/plots", TOKEN_A)
+assert_status("plots-for-node: unknown node 404", 404, status)
+
+# Wrong map id → 404 (the node exists, but not on this map)
+OTHER_MAP_BODY = http_post(f"/tenants/{TENANT_A}/maps", {
+    "title": "Other Map",
+    "coordinateSystem": {"type": "wgs84", "center": {"lat": 0, "lng": 0}, "zoom": 3},
+}, TOKEN_A)[1]
+OTHER_MAP_ID = json_field(OTHER_MAP_BODY, ["id"])
+status, _ = http_get(
+    f"/tenants/{TENANT_A}/maps/{OTHER_MAP_ID}/nodes/{PLAYERS_NODE}/plots", TOKEN_A)
+assert_status("plots-for-node: wrong map 404", 404, status)
+
+# Owner-xray bypass: B as map owner with xray sees plots even for hidden node
+mysql_query(f"UPDATE maps SET owner_id={USER_B_ID}, owner_xray=TRUE WHERE id={MAP_ID};")
+status, body = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_ID}/nodes/{GM_NODE}/plots", TOKEN_B)
+assert_status("plots-for-node xray: 200 even for hidden node", 200, status)
+assert_true("plots-for-node xray: GM_NODE returned PLOT_1",
+            {p["id"] for p in body} == {PLOT_1})
+mysql_query(f"UPDATE maps SET owner_id={USER_A_ID}, owner_xray=FALSE WHERE id={MAP_ID};")
+
+print("  All plots-for-node tests passed.")
+
+print("  --- Reverse membership: plots-for-note ---")
+
+# Admin: NOTE_PLAYERS is in PLOT_1
+status, body = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_ID}/notes/{NOTE_PLAYERS}/plots", TOKEN_A)
+assert_status("plots-for-note admin: 200", 200, status)
+assert_true("plots-for-note admin: NOTE_PLAYERS in PLOT_1",
+            {p["id"] for p in body} == {PLOT_1})
+
+# Admin: NOTE_GM is in PLOT_1 too
+status, body = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_ID}/notes/{NOTE_GM}/plots", TOKEN_A)
+assert_true("plots-for-note admin: NOTE_GM in PLOT_1",
+            {p["id"] for p in body} == {PLOT_1})
+
+# Non-admin (B): NOTE_PLAYERS visible (inherits Players via parent), sees PLOT_1
+status, body = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_ID}/notes/{NOTE_PLAYERS}/plots", TOKEN_B)
+assert_status("plots-for-note B: 200 (visible)", 200, status)
+assert_true("plots-for-note B: NOTE_PLAYERS in PLOT_1",
+            {p["id"] for p in body} == {PLOT_1})
+
+# Non-admin (B): NOTE_GM hidden → 404
+status, _ = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_ID}/notes/{NOTE_GM}/plots", TOKEN_B)
+assert_status("plots-for-note B: hidden returns 404", 404, status)
+
+# Unknown note id → 404
+status, _ = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_ID}/notes/9999999/plots", TOKEN_A)
+assert_status("plots-for-note: unknown note 404", 404, status)
+
+# Owner-xray bypass for notes
+mysql_query(f"UPDATE maps SET owner_id={USER_B_ID}, owner_xray=TRUE WHERE id={MAP_ID};")
+status, body = http_get(
+    f"/tenants/{TENANT_A}/maps/{MAP_ID}/notes/{NOTE_GM}/plots", TOKEN_B)
+assert_status("plots-for-note xray: 200 even for hidden note", 200, status)
+mysql_query(f"UPDATE maps SET owner_id={USER_A_ID}, owner_xray=FALSE WHERE id={MAP_ID};")
+
+print("  All plots-for-note tests passed.")
+
 # ─── Cleanup CASCADE ─────────────────────────────────────────────────────────
 # Deleting the plot should cascade away both junction tables.
 

--- a/docs/TESTING-E2E.md
+++ b/docs/TESTING-E2E.md
@@ -56,6 +56,7 @@ frontend/
 │       ├── cross-tenant.spec.ts # tenant isolation across two users (#38)
 │       ├── visibility.spec.ts # override icon, owner_xray, cross-user filter (#106)
 │       ├── plots.spec.ts      # plot CRUD, cross-map nav, visibility filtering (#95)
+│       ├── plots-in-detail-panel.spec.ts  # node/note "Plots" section attach round-trip (#139)
 │       └── *.spec.ts           # one file per feature area
 └── ...
 ```

--- a/frontend/src/components/Detail/NodeDetailPanel.tsx
+++ b/frontend/src/components/Detail/NodeDetailPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { nodesService, notesService, nodeMediaService } from '@/services/maps';
 import { extractApiError } from '@/utils/errors';
 import { VisibilityEditor } from '@/components/Visibility/VisibilityEditor';
+import { PlotsSection } from '@/components/Detail/PlotsSection';
 import type {
   NodeRecord,
   NodeMediaRecord,
@@ -185,6 +186,10 @@ export function NodeDetailPanel({
         <VisibilityEditor kind="node" entityId={node.id} mapId={mapId} />
       </section>
 
+      <section className="node-detail-plots">
+        <PlotsSection mapId={mapId} kind="node" entityId={node.id} />
+      </section>
+
       <NotesList
         mapId={mapId}
         nodeId={node.id}
@@ -339,6 +344,7 @@ interface NoteCardProps {
 function NoteCard({ mapId, note, onChange }: NoteCardProps) {
   const [editing, setEditing] = useState(false);
   const [showVisibility, setShowVisibility] = useState(false);
+  const [showPlots, setShowPlots] = useState(false);
 
   const handleDelete = async () => {
     if (!window.confirm('Delete this note?')) return;
@@ -393,6 +399,13 @@ function NoteCard({ mapId, note, onChange }: NoteCardProps) {
             <button
               type="button"
               className="btn btn-ghost btn-sm"
+              onClick={() => setShowPlots((v) => !v)}
+            >
+              {showPlots ? 'Hide plots' : 'Plots'}
+            </button>
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
               onClick={handleDelete}
             >
               Delete
@@ -407,6 +420,11 @@ function NoteCard({ mapId, note, onChange }: NoteCardProps) {
       {showVisibility && (
         <div className="note-card-visibility">
           <VisibilityEditor kind="note" entityId={note.id} mapId={mapId} />
+        </div>
+      )}
+      {showPlots && (
+        <div className="note-card-plots">
+          <PlotsSection mapId={mapId} kind="note" entityId={note.id} />
         </div>
       )}
     </article>

--- a/frontend/src/components/Detail/PlotsSection.tsx
+++ b/frontend/src/components/Detail/PlotsSection.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useState, useMemo } from 'react';
+import { plotsService } from '@/services/maps';
+import { extractApiError } from '@/utils/errors';
+import type { PlotRecord } from '@/api/schemas';
+
+// Phase 2g.k (#139): per-item Plots section in the node/note detail
+// panel. Lists the plots this node/note is in; quick-add picks from the
+// tenant's full plot list minus what's already attached.
+//
+// Backed by two new endpoints from #139:
+//   GET /tenants/{tid}/maps/{mid}/nodes/{nid}/plots
+//   GET /tenants/{tid}/maps/{mid}/notes/{nid}/plots
+// Both return 404 if the caller can't see the underlying entity — the
+// component renders that state as a benign empty + error message rather
+// than swallowing it, since the parent panel only shows this section
+// when an item *is* selected and visible.
+//
+// The quick-add dropdown reuses the existing plot CRUD mutations from
+// plotsService (addNode / removeNode / addNote / removeNote). When the
+// list of available plots is empty (all attached, or the tenant has no
+// plots yet), the form collapses into a small disabled hint.
+
+interface PlotsSectionProps {
+  mapId: number;
+  kind: 'node' | 'note';
+  entityId: number;
+}
+
+export function PlotsSection({ mapId, kind, entityId }: PlotsSectionProps) {
+  const [attached, setAttached] = useState<PlotRecord[]>([]);
+  const [allPlots, setAllPlots] = useState<PlotRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedPlotId, setSelectedPlotId] = useState<string>('');
+  const [busy, setBusy] = useState(false);
+
+  const loadAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // Two requests in parallel: this entity's plots + the tenant's
+      // full plot list (powers the "available to attach" picker).
+      const [mine, all] = await Promise.all([
+        kind === 'node'
+          ? plotsService.listPlotsForNode(mapId, entityId)
+          : plotsService.listPlotsForNote(mapId, entityId),
+        plotsService.listPlots(),
+      ]);
+      setAttached(mine);
+      setAllPlots(all);
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to load plots.'));
+      setAttached([]);
+      setAllPlots([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [mapId, kind, entityId]);
+
+  useEffect(() => {
+    loadAll();
+  }, [loadAll]);
+
+  const attachedIds = useMemo(
+    () => new Set(attached.map((p) => p.id)),
+    [attached],
+  );
+  const eligible = useMemo(
+    () => allPlots.filter((p) => !attachedIds.has(p.id)),
+    [allPlots, attachedIds],
+  );
+
+  const handleAttach = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedPlotId) return;
+    const plotId = Number(selectedPlotId);
+    setBusy(true);
+    setError(null);
+    try {
+      if (kind === 'node') {
+        await plotsService.addNode(plotId, entityId);
+      } else {
+        await plotsService.addNote(plotId, entityId);
+      }
+      setSelectedPlotId('');
+      await loadAll();
+    } catch (err) {
+      setError(extractApiError(err, 'Failed to attach to plot.'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDetach = async (plotId: number) => {
+    setBusy(true);
+    setError(null);
+    try {
+      if (kind === 'node') {
+        await plotsService.removeNode(plotId, entityId);
+      } else {
+        await plotsService.removeNote(plotId, entityId);
+      }
+      await loadAll();
+    } catch (err) {
+      setError(extractApiError(err, 'Failed to detach from plot.'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="plots-section">
+        <h3>Plots</h3>
+        <p className="plots-section-empty">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="plots-section">
+      <h3>Plots</h3>
+      {error && <div className="alert alert-error">{error}</div>}
+
+      {attached.length === 0 ? (
+        <p className="plots-section-empty">Not in any plot.</p>
+      ) : (
+        <ul className="plots-section-list">
+          {attached.map((p) => (
+            <li key={p.id} className="plots-section-row">
+              <span className="plots-section-name">{p.name}</span>
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                onClick={() => handleDetach(p.id)}
+                disabled={busy}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {eligible.length > 0 ? (
+        <form className="plots-section-add" onSubmit={handleAttach}>
+          <select
+            value={selectedPlotId}
+            onChange={(e) => setSelectedPlotId(e.target.value)}
+            disabled={busy}
+          >
+            <option value="">Add to plot…</option>
+            {eligible.map((p) => (
+              <option key={p.id} value={String(p.id)}>{p.name}</option>
+            ))}
+          </select>
+          <button
+            type="submit"
+            className="btn btn-primary btn-sm"
+            disabled={busy || !selectedPlotId}
+          >
+            {busy ? 'Adding…' : 'Add'}
+          </button>
+        </form>
+      ) : allPlots.length === 0 ? (
+        <p className="plots-section-hint">
+          No plots in this tenant yet — create one on the Plots page.
+        </p>
+      ) : (
+        <p className="plots-section-hint">Already in every plot.</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -678,6 +678,52 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
   border-top: 1px solid var(--color-border);
 }
 .node-detail-visibility h3 { font-size: .9rem; margin: 0 0 .5rem; }
+
+/* ─── Plots section in node/note detail (#139) ──────────────────────────── */
+/* Same border-top + spacing rhythm as the visibility section above so the
+   detail panel reads as a stack of equally-weighted sub-sections. */
+.node-detail-plots {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+}
+.plots-section h3 { font-size: .9rem; margin: 0 0 .5rem; }
+.plots-section-empty,
+.plots-section-hint {
+  font-size: .8rem;
+  color: #888;
+  margin: .25rem 0;
+}
+.plots-section-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 .5rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+}
+.plots-section-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+  padding: .25rem .5rem;
+  border-radius: var(--radius);
+  background: #fafafa;
+  font-size: .85rem;
+}
+.plots-section-name { font-weight: 500; }
+.plots-section-add {
+  display: flex;
+  align-items: center;
+  gap: .35rem;
+}
+.plots-section-add select { flex: 1; min-width: 8rem; }
+.note-card-plots {
+  margin-top: .5rem;
+  padding-top: .5rem;
+  border-top: 1px dashed var(--color-border);
+}
 .visibility-editor {
   display: flex;
   flex-direction: column;

--- a/frontend/src/services/maps.ts
+++ b/frontend/src/services/maps.ts
@@ -460,4 +460,31 @@ export const plotsService = {
       `${tenantBase(tenantId)}/plots/${plotId}/notes/${noteId}`,
     );
   },
+
+  // ─── Reverse membership (#139) ───────────────────────────────────────────
+  // "Which plots is this item in?" — backs the per-item Plots section in
+  // the node/note detail panel. Backend returns 404 when the caller can't
+  // see the node/note (existence is never leaked).
+
+  async listPlotsForNode(
+    mapId: number,
+    nodeId: number,
+    tenantId?: number,
+  ): Promise<PlotList> {
+    const res = await apiClient.get(
+      `${tenantBase(tenantId)}/maps/${mapId}/nodes/${nodeId}/plots`,
+    );
+    return PlotListSchema.parse(res.data);
+  },
+
+  async listPlotsForNote(
+    mapId: number,
+    noteId: number,
+    tenantId?: number,
+  ): Promise<PlotList> {
+    const res = await apiClient.get(
+      `${tenantBase(tenantId)}/maps/${mapId}/notes/${noteId}/plots`,
+    );
+    return PlotListSchema.parse(res.data);
+  },
 };

--- a/frontend/tests/e2e/plots-in-detail-panel.spec.ts
+++ b/frontend/tests/e2e/plots-in-detail-panel.spec.ts
@@ -56,7 +56,7 @@ test.describe('Plots in detail panel — node', () => {
       center: { lat: 0, lng: 0 },
       zoom: 3,
     });
-    const node = await createNodeViaApi(request, api, map.id, { name: 'TownA' });
+    await createNodeViaApi(request, api, map.id, { name: 'TownA' });
     await createPlotViaApi(request, api, 'Detail Plot');
 
     await seedAuthInBrowser(page, api);

--- a/frontend/tests/e2e/plots-in-detail-panel.spec.ts
+++ b/frontend/tests/e2e/plots-in-detail-panel.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import {
+  registerViaApi,
+  createMapViaApi,
+  createNodeViaApi,
+  seedAuthInBrowser,
+  API_URL,
+  type ApiUser,
+} from './helpers';
+
+/**
+ * E2E coverage for #139: per-item Plots section in node/note detail panel.
+ *
+ * Tests the round-trip: attach an item to a plot from the detail panel,
+ * then verify the change is observable on the Plots admin page (i.e. the
+ * write actually hit the same backend store the read uses).
+ */
+
+async function createPlotViaApi(
+  request: APIRequestContext,
+  api: ApiUser,
+  name: string,
+): Promise<{ id: number; name: string }> {
+  const res = await request.post(`${API_URL}/tenants/${api.tenantId}/plots`, {
+    headers: { Authorization: `Bearer ${api.token}` },
+    data: { name },
+  });
+  if (!res.ok()) {
+    throw new Error(`createPlot failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function createNoteViaApi(
+  request: APIRequestContext,
+  api: ApiUser,
+  mapId: number,
+  nodeId: number,
+  body: { title?: string; text: string },
+): Promise<{ id: number }> {
+  const res = await request.post(
+    `${API_URL}/tenants/${api.tenantId}/maps/${mapId}/nodes/${nodeId}/notes`,
+    { headers: { Authorization: `Bearer ${api.token}` }, data: body },
+  );
+  if (!res.ok()) {
+    throw new Error(`createNote failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+test.describe('Plots in detail panel — node', () => {
+  test('attach a node to a plot from the detail panel; verify on plots page', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'plot_detail_node');
+    const map = await createMapViaApi(request, api, 'Detail-Plot Map', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 3,
+    });
+    const node = await createNodeViaApi(request, api, map.id, { name: 'TownA' });
+    await createPlotViaApi(request, api, 'Detail Plot');
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // Select the node in the tree → triggers detail panel render.
+    await page.getByRole('button', { name: 'TownA', exact: true }).click();
+
+    // The detail panel renders the Plots section with empty state initially.
+    const plotsSection = page.locator('.node-detail-plots .plots-section');
+    await expect(plotsSection).toBeVisible();
+    await expect(plotsSection.getByText(/not in any plot/i)).toBeVisible();
+
+    // Pick "Detail Plot" from the add-to-plot dropdown and submit.
+    await plotsSection.locator('select').selectOption({ label: 'Detail Plot' });
+    await plotsSection.getByRole('button', { name: /^add$/i }).click();
+
+    // The attached list now shows the plot with a Remove button.
+    const attachedRow = plotsSection.locator('.plots-section-row', {
+      has: page.getByText('Detail Plot'),
+    });
+    await expect(attachedRow).toBeVisible();
+
+    // Verify the attachment is observable on the Plots admin page —
+    // confirms the write actually round-tripped through the same store
+    // the read endpoint uses.
+    await page.goto(`/tenants/${api.tenantId}/plots`);
+    const plotRow = page.locator('.plot-row', {
+      has: page.getByRole('heading', { name: 'Detail Plot' }),
+    });
+    await plotRow.locator('.plot-toggle').click();
+    await expect(plotRow.getByRole('link', { name: /TownA/ })).toBeVisible();
+
+    // Round-trip: detach back from the detail panel, verify the plot's
+    // member list is empty.
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+    await page.getByRole('button', { name: 'TownA', exact: true }).click();
+    await page.locator('.node-detail-plots .plots-section').getByRole('button', { name: /remove/i }).click();
+    await expect(page.locator('.node-detail-plots .plots-section').getByText(/not in any plot/i)).toBeVisible();
+  });
+});
+
+test.describe('Plots in detail panel — note', () => {
+  test('attach a note to a plot from the per-note section; verify on plots page', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'plot_detail_note');
+    const map = await createMapViaApi(request, api, 'Detail-Plot Note Map', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 3,
+    });
+    const node = await createNodeViaApi(request, api, map.id, { name: 'NoteHost' });
+    await createNoteViaApi(request, api, map.id, node.id, {
+      title: 'Important Detail',
+      text: 'Plot-relevant content.',
+    });
+    await createPlotViaApi(request, api, 'Note Plot');
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+    await page.getByRole('button', { name: 'NoteHost', exact: true }).click();
+
+    // The note card renders inside NotesList. Click "Plots" to expand its
+    // collapsible plots section.
+    const noteCard = page.locator('.note-card', {
+      has: page.getByText('Important Detail'),
+    });
+    await noteCard.getByRole('button', { name: /^plots$/i }).click();
+
+    // The per-note plots section renders inside .note-card-plots.
+    const notePlots = noteCard.locator('.note-card-plots .plots-section');
+    await expect(notePlots).toBeVisible();
+    await expect(notePlots.getByText(/not in any plot/i)).toBeVisible();
+
+    // Attach the note to "Note Plot".
+    await notePlots.locator('select').selectOption({ label: 'Note Plot' });
+    await notePlots.getByRole('button', { name: /^add$/i }).click();
+
+    await expect(notePlots.locator('.plots-section-row', {
+      has: page.getByText('Note Plot'),
+    })).toBeVisible();
+
+    // Verify on the Plots admin page that the note is now in this plot.
+    await page.goto(`/tenants/${api.tenantId}/plots`);
+    const plotRow = page.locator('.plot-row', {
+      has: page.getByRole('heading', { name: 'Note Plot' }),
+    });
+    await plotRow.locator('.plot-toggle').click();
+    await expect(plotRow.getByRole('link', { name: /Important Detail/ })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #139. Reverse-membership endpoints + per-item Plots section in the detail panel. Closes the loop on #95 — previously you could see who's in a plot from the Plots admin page; now you can also see which plots an item is in (and add/remove from the same place you're already looking at the item).

## Backend

Two new endpoints, gated on the same effective-visibility CTE the rest of the read endpoints use. If the caller can't see the node/note, the endpoint returns 404 — never leaks existence. Map-owner xray bypass is honored exactly like \`listMembers\` from #88.

- \`GET /api/v1/tenants/{tid}/maps/{mid}/nodes/{nid}/plots\` → \`Plot[]\`
- \`GET /api/v1/tenants/{tid}/maps/{mid}/notes/{nid}/plots\` → \`Plot[]\`

Two new map-scoped CTE constants (\`MAP_NODE_VISIBILITY_CTE\`, \`MAP_NOTE_VISIBILITY_CTE\`) — same shape as the per-controller versions in NodeController/NoteController, kept local so PlotController doesn't depend on those private constants. Documented in the header comment.

20 new tests in \`test_22_plots.py\` covering admin/non-admin/xray paths, empty results, and the 404 cases (unknown id, wrong map, hidden item). All 78 plot tests pass.

## Frontend

- \`plotsService.listPlotsForNode\` + \`listPlotsForNote\` mirror the existing service signatures (parsed via \`PlotListSchema\`).
- New shared \`PlotsSection\` component takes \`{ mapId, kind: 'node' | 'note', entityId }\`. Loads the entity's plots + the tenant's full plot list in parallel, renders the attached list with quick-remove buttons and a dropdown of unattached plots for quick-add.
- Slotted into \`NodeDetailPanel\` between Visibility and NotesList (always visible).
- Slotted into \`NoteCard\` as a collapsible section behind a "Plots" toggle button — mirrors the existing visibility-toggle pattern there to keep the per-note card from getting too dense.

## Tests

- 2 new E2E specs in \`plots-in-detail-panel.spec.ts\` covering the full round-trip: attach in detail panel → verify on plots page → detach back from detail panel.

## Work breakdown

- [x] Backend: extend PlotController.h with 2 new routes
- [x] Backend: implement listPlotsForNode + listPlotsForNote
- [x] Backend: 20 new tests in test_22_plots.py — all 78 pass
- [x] Frontend: plotsService.listPlotsForNode + listPlotsForNote
- [x] Frontend: shared PlotsSection component
- [x] Frontend: slot into NodeDetailPanel + NoteCard
- [x] Frontend: CSS rhythm matches existing visibility section
- [x] Frontend: tsc + lint clean
- [x] E2E: 2 tests, both pass standalone
- [x] Full E2E: 30 passed, 5 skipped (no regressions)
- [x] Backend regression: visibility (19/20/21) + plots (22) all pass
- [x] docs/TESTING-E2E.md updated

## Files changed

- \`backend/src/controllers/PlotController.cpp\` — Add MAP_NODE_VISIBILITY_CTE + MAP_NOTE_VISIBILITY_CTE constants; implement listPlotsForNode + listPlotsForNote with two-step (verify visibility → list plots) flow
- \`backend/src/controllers/PlotController.h\` — Register two new routes; declare two new methods; document the reverse-membership endpoints in the header comment
- \`backend/tests/test_22_plots.py\` — Append 20 reverse-membership tests covering admin/non-admin/xray/404 cases for both node and note endpoints
- \`docs/TESTING-E2E.md\` — Add \`plots-in-detail-panel.spec.ts\` to the file list
- \`frontend/src/components/Detail/NodeDetailPanel.tsx\` — Import PlotsSection; render in a new \`<section className="node-detail-plots">\` between Visibility and NotesList; add Plots toggle to NoteCard with collapsible \`.note-card-plots\` section
- \`frontend/src/components/Detail/PlotsSection.tsx\` — New: shared component for both node and note contexts; loads plots-for-entity + tenant plots in parallel; quick-add dropdown + per-row remove
- \`frontend/src/index.css\` — \`.node-detail-plots\`, \`.plots-section\` family, \`.note-card-plots\` (matching the visibility-section rhythm)
- \`frontend/src/services/maps.ts\` — Add listPlotsForNode + listPlotsForNote to plotsService
- \`frontend/tests/e2e/plots-in-detail-panel.spec.ts\` — New: 2 round-trip tests (one for nodes, one for notes)

## Test plan

- [x] \`python3 backend/tests/test_22_plots.py\` — 78/78 pass (20 new)
- [x] Backend regression: \`test_19/20/21_*_visibility*.py\` + \`test_22_plots.py\` all green (184 tests)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] \`npx playwright test tests/e2e/plots-in-detail-panel.spec.ts\` — 2/2 pass
- [x] \`npx playwright test\` — 30 passed, 5 skipped (no regressions)
- [ ] PR CI green