### PR TITLE
docs: add per-file lint check to §5 pre-PR validation

### DIFF
--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -300,6 +300,30 @@ shape). If truly nothing needs updating, **say so explicitly** in the PR
 description — e.g., "No docs/tests updated — refactor preserves behavior
 exactly and no convention docs exist yet."
 
+**Verify lint/typecheck per-file on the touched files**, not just by
+running the project-wide command. ESLint's daemon and watcher caches can
+hold a stale "clean" answer for a recently-touched file, so a project-
+wide `npm run lint` shortly after writing a file may report 0 errors
+even though a fresh CI run will fail on it. Hit twice in a row on
+PR #142 (verify-after-board-edit) and PR #144 (the unused-`node` var in
+`plots-in-detail-panel.spec.ts` — local lint reported clean, CI caught
+it on a cold cache).
+
+**The fix:** before opening the PR, also run the linter directly on the
+files in your diff:
+
+```bash
+git diff --name-only --diff-filter=AM <base-branch>...HEAD \
+  | grep -E '\.(ts|tsx|js|jsx)$' \
+  | xargs -r npx eslint --max-warnings 0
+```
+
+Or for the smaller per-PR case: `npx eslint <new-or-edited-file>` for
+each file you wrote. The cold per-file invocation bypasses the daemon
+cache and matches what CI will see. Apply the same belt-and-suspenders
+pattern to typecheck if your project has had analogous misses with
+`tsc --noEmit`.
+
 ### 6. PR Test Expectations section (only when failures are expected)
 
 > **Rule:** When some CI checks are expected to fail (e.g., mid-rebuild on a


### PR DESCRIPTION
## Summary

ESLint's daemon and watcher caches can hold a stale "clean" answer for a recently-touched file, so a project-wide \`npm run lint\` shortly after writing a file may report 0 errors even though a fresh CI run will fail on it. Hit twice in a row:

- **PR #142** — verify-after-board-edit; lint passed locally on the doc diff but ESLint cache state was responsible for me trusting "clean" earlier than I should have when I'd been editing other files.
- **PR #144** — the \`const node = ...\` unused-var in \`plots-in-detail-panel.spec.ts\`. Local \`npm run lint\` reported clean; CI's cold-cache run caught it. Re-running locally moments later also caught it.

Add a "Verify lint/typecheck per-file on the touched files" paragraph to §5 with a per-diff one-liner that bypasses the daemon cache and matches what CI will see:

\`\`\`bash
git diff --name-only --diff-filter=AM <base-branch>...HEAD \\
  | grep -E '\\.(ts|tsx|js|jsx)$' \\
  | xargs -r npx eslint --max-warnings 0
\`\`\`

The natural slot is §5 (Always update docs and tests with code) since it's the existing "validate before opening PR" section. Same belt-and-suspenders pattern transfers to typecheck if a similar miss ever shows up.

## Why this is its own PR

Same execution-discipline-rule pattern as #141, #142, #143 — narrow scope, doc-only, no code change. Bundling into the next feature ticket would bury it.

## Work breakdown

- [x] Branch off latest \`main\`
- [x] Append "Verify lint/typecheck per-file on the touched files" paragraph to §5
- [x] Update memory replica's frontmatter description
- [x] Commit + open PR

## Files changed

- \`docs/AI-COLLABORATION-CONVENTIONS.md\` — Append the per-file lint paragraph to §5's "How to apply" section, after the existing "If truly nothing needs updating, say so explicitly" paragraph

(Memory replica at \`~/.claude/projects/.../memory/feedback_docs_and_tests.md\` also updated to surface the new bullet in its description.)

## Test plan

Behavioural. Next time the agent prepares a PR with frontend changes, the workflow should include the per-file lint check after the project-wide one — and the per-file run should agree with what CI will see.