### PR TITLE
docs: broaden 'verify after board edit' to all board-affecting gh commands

### DIFF
--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -160,18 +160,30 @@ message or trivially confirmable). In that case the only manual step
 is the board flip — fine to do as a single direct tool call without
 the list overhead.
 
-**Always verify after a board edit.** `gh project item-edit` can
-silently no-op: exit code 0, no output, no actual change. Encountered
-during the #106 cleanup — the first flip command returned cleanly but
-the status stayed at In Progress; only spotted when the user noticed
-the board was wrong on the next turn. The fix is cheap: every board
-edit should be paired with an immediate read-back. Either chain them
-in one shell command (`gh project item-edit ... ; gh project item-list
-... --jq '.items[] | select(.content.number == NNN) | .status'`) or
-run a follow-up read tool call. The board's eventual-consistency
-window is short — a synchronous check in the same turn is sufficient.
-Don't mark the corresponding TodoWrite item completed until the
-read-back returns the expected status.
+**Always verify after any `gh` command that affects the project board.**
+Multiple `gh` invocations can silently no-op the board side-effect:
+exit code 0, no output, no actual change. Confirmed instances:
+
+- **`gh project item-edit ...`** — first board flip during the #106
+  cleanup returned cleanly but the status stayed at In Progress.
+  Spotted only when the user noticed the wrong state on the next turn.
+- **`gh issue create --project "Focus on next" ...`** — the project
+  assignment silently dropped during the #146 file (post-merge
+  cleanup ticket). Required a follow-up `gh project item-add` and a
+  verification read.
+
+The fix is cheap: every board-affecting `gh` invocation should be
+paired with an immediate read-back. Either chain them in one shell
+command (`gh project item-edit ... ; gh project item-list ... --jq
+'.items[] | select(.content.number == NNN) | .status'`) or run a
+follow-up read tool call. The board's eventual-consistency window is
+short — a synchronous check in the same turn is sufficient.
+
+Apply the same pattern to **any new board-affecting `gh` invocation**
+encountered going forward — silent no-ops appear to be a generic
+property of this CLI surface, not isolated to the two commands above.
+Don't mark the corresponding TodoWrite item completed until the read-
+back returns the expected state.
 
 **Delete the local feature branch after the PR merges.** When this
 collaborator merges PRs they configure GitHub to delete the remote


### PR DESCRIPTION
## Summary

Originally added in #142 to cover \`gh project item-edit\` after that command silently no-op'd the #106 board flip. Hit a second instance of the same pattern when filing #146 (Phase 2 post-merge cleanup ticket): \`gh issue create --project "Focus on next" ...\` returned exit 0 but the project assignment didn't take. Required a follow-up \`gh project item-add\` and a verification read.

Two distinct \`gh\` commands now confirmed to silently no-op the board side-effect — looks like a generic property of this CLI surface rather than an isolated bug. Generalize the rule:

- Title: "Always verify after any \`gh\` command that affects the project board" (was: "Always verify after a board edit")
- Cite both confirmed instances (item-edit + issue create --project) as concrete examples
- Add a forward-looking note: apply the same verify-after pattern to any new board-affecting \`gh\` invocation encountered, not just the two listed

## Why this is its own PR

Same execution-discipline-rule pattern as #141, #142, #143, #145 — narrow scope, doc-only, no code change. Bundling into the next feature ticket would bury it.

## Work breakdown

- [x] Branch off latest \`main\`
- [x] Broaden the existing §2 sub-rule to cover both confirmed instances + future ones
- [x] Update memory replica's frontmatter description
- [x] Commit + open PR

## Files changed

- \`docs/AI-COLLABORATION-CONVENTIONS.md\` — Broaden the existing "Always verify after a board edit" sub-rule in §2; cite both confirmed instances and add the forward-looking generalization

(Memory replica at \`~/.claude/projects/.../memory/feedback_ticket_status_lifecycle.md\` also updated.)

## Test plan

Behavioural. Next time a board-affecting \`gh\` command is run (any of them), the workflow should pair it with an immediate read-back and not mark the corresponding TodoWrite item complete until the read confirms.