### PR TITLE
#154: createNote must persist the 'pinned' field

### DIFF
--- a/backend/src/controllers/NoteController.cpp
+++ b/backend/src/controllers/NoteController.cpp
@@ -182,6 +182,11 @@ void NoteController::createNote(
     std::string title = (*body).get("title", "").asString();
     std::string text  = (*body)["text"].asString();
     std::string color = (*body).get("color", "").asString();
+    // Mirror updateNote's pinned handling (line 352–353). Default to FALSE
+    // when the field is absent. Bug #154: previously the create path
+    // dropped pinned entirely — column was missing from the INSERT, the
+    // response hardcoded false, and the row landed at the schema default.
+    bool pinned       = (*body).get("pinned", false).asBool();
 
     if (!checkMaxLen("title", title, MAX_TITLE_LEN, callback)) return;
     if (!checkMaxLen("text", text, MAX_TEXT_LEN, callback)) return;
@@ -199,7 +204,7 @@ void NoteController::createNote(
         "WHERE nd.id = ? AND nd.map_id = ? AND m.tenant_id = ? "
         "  AND (m.owner_id = ? OR mp.level IN ('view','comment','edit','moderate','admin') "
         "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
-        [callback, mapId, nodeId, userId, callerUsername, title, text, color]
+        [callback, mapId, nodeId, userId, callerUsername, title, text, color, pinned]
         (const drogon::orm::Result& r) {
             if (r.empty()) {
                 callback(errorResponse(drogon::k403Forbidden,
@@ -211,12 +216,12 @@ void NoteController::createNote(
             // via JOIN through nodes since notes carry node_id only.
             auto db2 = drogon::app().getDbClient();
             db2->execSqlAsync(
-                "INSERT INTO notes (node_id, created_by, title, text, color) "
-                "SELECT ?,?,?,?,NULLIF(?,'') FROM dual "
+                "INSERT INTO notes (node_id, created_by, title, text, color, pinned) "
+                "SELECT ?,?,?,?,NULLIF(?,''),? FROM dual "
                 "WHERE (SELECT COUNT(*) FROM notes n2 "
                 "       JOIN nodes nd2 ON nd2.id = n2.node_id "
                 "       WHERE nd2.map_id = ?) < 10000",
-                [callback, mapId, nodeId, userId, callerUsername, title, text, color]
+                [callback, mapId, nodeId, userId, callerUsername, title, text, color, pinned]
                 (const drogon::orm::Result& r2) {
                     if (r2.affectedRows() == 0) {
                         callback(errorResponse(drogon::k400BadRequest,
@@ -233,7 +238,7 @@ void NoteController::createNote(
                     db3->execSqlAsync(
                         "SELECT created_at, updated_at FROM notes WHERE id = ?",
                         [callback, newId, nodeId, mapId, userId, callerUsername,
-                         title, text, color]
+                         title, text, color, pinned]
                         (const drogon::orm::Result& rTs) {
                             Json::Value n;
                             n["id"]                  = newId;
@@ -243,7 +248,7 @@ void NoteController::createNote(
                             n["createdByUsername"]   = callerUsername;
                             n["title"]               = title;
                             n["text"]                = text;
-                            n["pinned"]              = false;
+                            n["pinned"]              = pinned;
                             n["color"]               = color.empty()
                                                          ? Json::Value()
                                                          : Json::Value(color);
@@ -267,7 +272,7 @@ void NoteController::createNote(
                     callback(errorResponse(drogon::k500InternalServerError,
                         "db_error", "Failed to create note"));
                 },
-                nodeId, userId, title, text, color, mapId);
+                nodeId, userId, title, text, color, pinned, mapId);
         },
         [callback](const drogon::orm::DrogonDbException&) {
             callback(errorResponse(drogon::k500InternalServerError,

--- a/backend/tests/test_16_notes.py
+++ b/backend/tests/test_16_notes.py
@@ -72,6 +72,22 @@ NOTE2 = json_field(body, ["id"])
 assert_json_field("create: color set", body, ["color"], "#ff0000")
 assert_json_field("create: title set", body, ["title"], "Beware")
 
+# Regression for #154: create-note must honor the `pinned` field
+# (previously dropped — INSERT omitted the column, response hardcoded
+# false, row landed at the schema default of FALSE).
+status, body = http_post(LIST_BASE, {
+    "text": "Pinned at creation",
+    "pinned": True,
+}, TOKEN_A)
+assert_status("create: pinned=true returns 201", 201, status)
+NOTE_PIN = json_field(body, ["id"])
+assert_json_field("create: pinned=true reflected in response", body, ["pinned"], True)
+# Round-trip through GET to confirm it's actually persisted, not just
+# echoed in the create response.
+status, body = http_get(f"{NOTE_BASE}/{NOTE_PIN}", TOKEN_A)
+assert_status("create-pinned: GET returns 200", 200, status)
+assert_json_field("create-pinned: pinned persisted in DB", body, ["pinned"], True)
+
 # Validation: missing text
 status, _ = http_post(LIST_BASE, {"title": "no text"}, TOKEN_A)
 assert_status("create: missing text returns 400", 400, status)
@@ -107,8 +123,8 @@ print("  --- List ---")
 status, body = http_get(LIST_BASE, TOKEN_A)
 assert_status("list: returns 200", 200, status)
 assert_true("list: returns array", isinstance(body, list))
-assert_true("list: contains 2 notes on NODE_A1",
-            len([n for n in body if n["nodeId"] == NODE_A1]) == 2)
+assert_true("list: contains 3 notes on NODE_A1",
+            len([n for n in body if n["nodeId"] == NODE_A1]) == 3)
 
 # Note on NODE_A2 only shows under its own list
 status, body = http_get(


### PR DESCRIPTION
## Summary

Closes #154. Surfaced during #137 manual smoke testing — the create-note form's "Pinned" checkbox was silently ignored by the backend. Edit-pin worked; create-pin didn't.

## Root cause

\`backend/src/controllers/NoteController.cpp::createNote\` was broken in two complementary ways:

1. **INSERT omitted \`pinned\`.** The SQL listed only \`(node_id, created_by, title, text, color)\` — even though the request body's \`pinned\` field was reachable, the backend never read it. The new row landed at the schema default \`pinned BOOLEAN DEFAULT FALSE\`.
2. **Response hardcoded \`n["pinned"] = false\`.** This masked the bug from anyone inspecting the POST response — the frontend got back \`pinned: false\` consistently, which matched the (broken) DB state, so no client-side schema-parse error fired.

\`updateNote\` was already correct (line 352–353 + 367), which is why the Edit flow worked.

## Fix

Three changes mirroring \`updateNote\`'s pattern:

1. Read \`pinned\` from the request body, defaulting to \`false\` if absent
2. Add the \`pinned\` column + parameter to the INSERT
3. Replace the hardcoded \`n["pinned"] = false\` with the actual value

## Test additions

\`backend/tests/test_16_notes.py\`:
- POST with \`{"pinned": true}\` → response shows \`pinned: true\` (regression: previously false)
- Follow-up GET on the same note id confirms it's persisted, not just echoed in the response (regression: previously silent drop)
- Updated downstream count assertion (NODE_A1 now has 3 notes after the new test, was 2)

## Test plan

- [x] \`python3 backend/tests/test_16_notes.py\` — 44/44 pass (3 new)
- [x] \`python3 backend/tests/test_22_plots.py\` — 78/78 pass (no regression)
- [x] \`python3 backend/tests/test_21_note_visibility.py\` — 45/45 pass (no regression)
- [ ] PR CI green

## Work breakdown

- [x] Branch off \`nodes-rebuild\`, move #154 to In Progress
- [x] Read \`pinned\` from request body (mirror \`updateNote\`)
- [x] Add \`pinned\` column to INSERT + parameter binding
- [x] Use actual value in response payload
- [x] Test: POST with \`pinned: true\` → response + GET round-trip
- [x] Adjust downstream count assertion that broke from new test data
- [x] Adjacent-suite regression: notes / plots / note-visibility all green

## Files changed

- \`backend/src/controllers/NoteController.cpp\` — Three-line fix in \`createNote\`: read \`pinned\` from body; add to INSERT column list + param binding; use actual value in response
- \`backend/tests/test_16_notes.py\` — Add regression test for create-with-pinned (POST + GET round-trip); adjust the NODE_A1 count assertion downstream

## Notes

- Frontend send-side already worked — \`CreateNoteRequest\` includes \`pinned\` in its type, the create form has a Pinned checkbox, and the service layer passes it through. Pure backend fix.
- After this merges, the manual smoke walk for #137 can resume and the create-form pin will work as users expect (pinned notes float to the top — the existing pinned-first sort already handles it).
- **Not a tightening of the partial-POST-response anti-pattern** captured in #152 — that ticket covers the inverse problem (POST returns LESS than GET). This PR is about a write that didn't persist what the request sent. The two are independent and #152 still stands as filed.