### PR TITLE
docs: §13 — surface service-restart needs in reports and PR bodies

### DIFF
--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -715,6 +715,32 @@ In the **conversation report** when handing back work:
   - "DB action needed: `docker compose down -v && docker compose up -d`
     to apply the schema change (or run the migration explicitly)."
 
+**Branch switches count too.** When the agent switches the local
+checkout to a different branch — e.g. branching off `main` for a
+small doc PR while the rest of the work is on a long-running feature
+branch — the running dev stack's behavior may change immediately:
+
+- **Frontend (volume-mounted)**: Vite picks up the new branch's source
+  via HMR within seconds. The browser will start serving the new
+  branch's code on next reload (or sooner). If the two branches differ
+  in significant ways — e.g. one has a dependency the other doesn't —
+  the user may see import errors, missing UI, or unexpected layouts
+  immediately, with no other warning.
+- **Backend (compiled)**: the running binary is whatever was last
+  built. A branch switch alone doesn't change runtime behavior; only
+  a `docker compose up -d --build backend` does. So the backend may
+  silently be on a different branch's code than the frontend.
+- **Database**: unaffected by branch switches at the file level, but
+  schema state reflects whichever migrations have actually been run.
+
+When making a branch switch as part of a multi-step task (especially
+when the user is expected to interact with the running stack), state
+explicitly: "switching from `branchA` to `branchB` — frontend dev
+stack will start serving `branchB`'s code; backend binary unchanged
+(still on `branchA`'s last build); switch back when this PR closes
+out." This prevents the "old code referencing missing dep / new dep
+not yet built / API mismatch between layers" surprise.
+
 In the **PR body**, add a section (or fold into an existing section
 like a "Test plan" with one bullet) calling out the same:
 
@@ -752,6 +778,18 @@ multiple times during the `nodes-rebuild` work and would prefer it be
 surfaced proactively. Two-sided: the answer in the conversation
 prevents the immediate confusion; the answer in the PR body preserves
 the same information for whoever pulls the change later.
+
+**Live test of the rule (same session it was filed):** within minutes
+of opening the PR adding this rule, the agent silently violated it.
+The agent branched off `main` for the doc PR, leaving the local
+checkout on a `main`-based branch. The Docker frontend container's
+volume mount immediately served `main`'s pre-rebuild `MapView.tsx`,
+which references a `leaflet-draw` dependency the rebuild had dropped.
+The user resumed manual smoke testing, hit a Vite import error, and
+had to ask the agent to investigate. The branch-switch clause above
+was added in response. The pattern generalizes: any change to what
+the running stack serves — including filesystem-level changes the
+agent makes — counts as operational impact and must be surfaced.
 
 ---
 

--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -48,6 +48,10 @@ agent instructions:
     source and update the cache before retrying.** Don't blindly retry,
     don't ask the user — refresh on first failure, escalate only if the
     fresh value also fails.
+13. **Surface service-restart needs in both reports and PR bodies.** When
+    a change touches code/config/schema, explicitly state what the user
+    needs to restart (or "no restart needed") in the conversation report
+    AND in a section of the PR body. Skip for doc-only / test-only PRs.
 
 ---
 
@@ -674,6 +678,80 @@ When using a cached value in an operation:
 | GitHub repo metadata | `gh api repos/<owner>/<repo>` |
 | File paths in the project | `find` / `Glob` |
 | External service IDs (Slack channel, JIRA project, etc.) | each service's API |
+
+### 13. Surface service-restart needs in reports and PR bodies
+
+> **Rule:** When a change requires a service restart, container rebuild,
+> migration, or any other operational step before the change takes effect,
+> explicitly state that step in (a) the conversation report when handing
+> back to the user, AND (b) a section of the PR body. When a code/config
+> change requires NO restart, say so explicitly too — both audiences
+> benefit from knowing the agent considered the question. Skip the
+> convention entirely for doc-only or test-only PRs (no operational
+> impact possible).
+
+**Why:** A change to backend C++ requires `docker compose up -d --build
+backend` before the user can exercise it in the running stack. A change
+to a Vite-built dependency may need a full container restart instead of
+relying on HMR. A schema change may need a migration run or a `down -v`
+volume wipe. The user has hit the "I changed something but my browser
+shows the old behavior" trap repeatedly when these steps weren't called
+out — and a future reader of the PR loses important context if the
+restart needed isn't recorded next to the diff. Saying "no restart
+needed" when none is needed is also valuable: it explicitly acknowledges
+the agent considered the question rather than leaving the reader to
+guess whether the agent forgot.
+
+**How to apply:**
+
+In the **conversation report** when handing back work:
+
+- Always include a one-liner about what (if anything) needs restarting
+- Frame the answer either as a single sentence or a small table when
+  multiple layers are touched (backend / frontend / DB / etc.)
+- Examples:
+  - "No restart needed — frontend code change picked up by Vite HMR."
+  - "Backend rebuild needed: `docker compose up -d --build backend`."
+  - "DB action needed: `docker compose down -v && docker compose up -d`
+    to apply the schema change (or run the migration explicitly)."
+
+In the **PR body**, add a section (or fold into an existing section
+like a "Test plan" with one bullet) calling out the same:
+
+```markdown
+## Operational impact
+
+- **Backend**: rebuild required (`docker compose up -d --build backend`)
+- **Frontend**: no restart needed (HMR picks it up)
+- **Database**: no schema change
+```
+
+If no operational impact at all, a single line is fine:
+
+```markdown
+## Operational impact
+
+No restart, rebuild, or migration needed.
+```
+
+**When the rule does not apply:**
+
+- **Pure doc PRs** (`docs/*.md`, README updates, comment-only edits)
+- **Pure test PRs** that don't touch the production code paths exercised
+  by tests (e.g. backend test additions where the controller code is
+  unchanged — tests pick up the new test file automatically)
+- **Workflow / CI-only PRs** (`.github/workflows/*.yml`) where the
+  change only affects future CI runs
+
+For everything else (code, schema, lockfile/dep changes, Dockerfile,
+config files, env vars), include the line.
+
+**Origin:** rule established 2026-05-06 after the user pointed out that
+they'd hit the "I have to ask whether the backend was rebuilt" pattern
+multiple times during the `nodes-rebuild` work and would prefer it be
+surfaced proactively. Two-sided: the answer in the conversation
+prevents the immediate confusion; the answer in the PR body preserves
+the same information for whoever pulls the change later.
 
 ---
 


### PR DESCRIPTION
## Summary

Recurring pattern surfaced during the \`nodes-rebuild\` manual smoke walk: the user kept having to ask whether the backend container had been rebuilt, or whether the frontend needed a restart, before observing a change in the running stack. The information lived entirely in my head until prompted, and a future reader of the PR had the same problem when pulling the change later.

Codify the rule:

- **Conversation reports**: when handing back work, state what to restart (or "no restart needed")
- **PR bodies**: include an "Operational impact" section with the same information, so the operational state is durable next to the diff

The "no restart needed" wording is intentional — saying it explicitly acknowledges that the agent considered the question, rather than leaving the reader to guess whether it was forgotten.

Skipped for doc-only / test-only / workflow-only PRs where no operational impact is possible (this PR itself qualifies — it's doc-only).

## Why this is its own PR

Same pattern as #141, #142, #143, #145, #147 — narrow execution-discipline rule, doc-only, runs alongside other rule-update PRs. Bundling into a feature ticket would bury it.

## Files changed

- \`docs/AI-COLLABORATION-CONVENTIONS.md\` — Add §13 (full section with rule statement, why, how-to-apply for both clauses, when-it-doesn't-apply, origin); add quick-reference entry #13 to the portable rule list at the top

## Memory

The thin-replica memory entry at \`~/.claude/projects/.../memory/feedback_restart_needs.md\` was also created and \`MEMORY.md\` updated to point to it (these live outside the repo per the doc-master / memory-as-pointer convention from §11).

## Test plan

Behavioural. Future PRs touching code/config/schema should include an "Operational impact" section; conversation reports for the same should mention restart needs explicitly. If they don't, the rule needs sharpening.