### PR TITLE
Frontend: Map edit + delete UI (#160)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -86,6 +86,50 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
 .map-card h3 { font-size: 1rem; margin-bottom: .25rem; }
 .map-card p { font-size: .85rem; color: var(--color-text-muted); margin-bottom: .5rem; }
 .map-card-permission { font-size: .75rem; color: var(--color-text-muted); }
+/* Per-card actions menu (#160). Wrapper is positioned over the card's
+   top-right; the menu button + dropdown sit on top of the card body. */
+.map-card-wrapper { position: relative; }
+.map-card-menu-wrapper {
+  position: absolute;
+  top: .5rem;
+  right: .5rem;
+}
+.map-card-menu-wrapper:focus { outline: none; }
+.map-card-menu {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  width: 1.75rem;
+  height: 1.75rem;
+  font-size: .9rem;
+  cursor: pointer;
+  padding: 0;
+}
+.map-card-menu:hover { background: var(--color-bg); }
+.map-card-menu-dropdown {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  min-width: 7rem;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  margin-top: .25rem;
+}
+.map-card-menu-item {
+  background: transparent;
+  border: none;
+  text-align: left;
+  padding: .35rem .65rem;
+  font-size: .85rem;
+  cursor: pointer;
+}
+.map-card-menu-item:hover { background: var(--color-bg); }
+.map-card-menu-item-danger { color: var(--color-danger); }
 
 /* ─── Map Page ──────────────────────────────────────────────────────────────── */
 .map-page { display: flex; flex-direction: column; height: calc(100vh - var(--nav-height)); }

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -5,6 +5,7 @@ import { NodeTreePanel } from '@/components/Tree/NodeTreePanel';
 import { NodeDetailPanel } from '@/components/Detail/NodeDetailPanel';
 import { useMap } from '@/hooks/useMap';
 import { useAuthStore } from '@/store/authStore';
+import { mapsService } from '@/services/maps';
 import { extractApiError } from '@/utils/errors';
 
 // Map detail page. NodeTreePanel + MapView + NodeDetailPanel are all wired
@@ -76,6 +77,20 @@ export function MapDetailPage() {
     }
   };
 
+  // Delete-from-detail-page (#160). Edit-from-detail isn't here — users
+  // can navigate to /tenants/{tid}/maps to edit. v1 minimum keeps this
+  // page focused on viewing/working with the map.
+  const handleDeleteMap = async () => {
+    if (!activeMap) return;
+    if (!window.confirm(`Delete map "${activeMap.title}"? This cannot be undone.`)) return;
+    try {
+      await mapsService.deleteMap(activeMap.id);
+      navigate(`/tenants/${tenantId}/maps`);
+    } catch (e) {
+      setXrayError(extractApiError(e, 'Failed to delete map.'));
+    }
+  };
+
   return (
     <div className="page-container">
       <div className="page-header">
@@ -91,6 +106,16 @@ export function MapDetailPage() {
               />
               {xraySaving ? 'Saving…' : 'Owner X-ray'}
             </label>
+          )}
+          {isOwner && (
+            <button
+              type="button"
+              className="btn btn-ghost"
+              onClick={handleDeleteMap}
+              title="Delete this map (and all its locations + notes)"
+            >
+              Delete map
+            </button>
           )}
           <Link to={`/tenants/${tenantId}/maps`} className="btn btn-ghost">
             ← Back to maps

--- a/frontend/src/pages/MapListPage.tsx
+++ b/frontend/src/pages/MapListPage.tsx
@@ -1,49 +1,31 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useMap } from '@/hooks/useMap';
+import { mapsService } from '@/services/maps';
 import { extractApiError } from '@/utils/errors';
-import type { CreateMapRequest } from '@/types';
+import type { CreateMapRequest, UpdateMapRequest, MapRecord } from '@/types';
 
 export function MapListPage() {
   const { tenantId } = useParams<{ tenantId: string }>();
-  const { maps, loadMaps, createMap } = useMap();
+  const { maps, loadMaps } = useMap();
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
-  const [title, setTitle] = useState('');
-  const [description, setDescription] = useState('');
-  const [creating, setCreating] = useState(false);
-  const [createError, setCreateError] = useState<string | null>(null);
+  // Edit modal state (#160): when non-null, modal opens in edit mode
+  // pre-populated with this map's title + description.
+  const [editingMap, setEditingMap] = useState<MapRecord | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     loadMaps().finally(() => setLoading(false));
   }, [loadMaps]);
 
-  const handleCreate = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setCreateError(null);
-    setCreating(true);
+  const handleDelete = async (m: MapRecord) => {
+    if (!window.confirm(`Delete map "${m.title}"? This cannot be undone.`)) return;
     try {
-      // Default new maps to a generic WGS84 view; the user can swap to
-      // pixel or blank coordinate systems via update once that UI lands
-      // (#101 series).
-      const data: CreateMapRequest = {
-        title,
-        description,
-        coordinateSystem: {
-          type: 'wgs84',
-          center: { lat: 0, lng: 0 },
-          zoom: 3,
-        },
-      };
-      const map = await createMap(data);
-      setShowCreate(false);
-      setTitle('');
-      setDescription('');
-      window.location.href = `/tenants/${tenantId}/maps/${map.id}`;
-    } catch (err) {
-      setCreateError(extractApiError(err, 'Failed to create map.'));
-    } finally {
-      setCreating(false);
+      await mapsService.deleteMap(m.id);
+      await loadMaps();
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to delete map.'));
     }
   };
 
@@ -58,43 +40,23 @@ export function MapListPage() {
         </button>
       </div>
 
-      {showCreate && (
-        <div className="modal-overlay">
-          <div className="modal">
-            <h2>Create Map</h2>
-            <form onSubmit={handleCreate} className="auth-form">
-              {createError && <div className="alert alert-error">{createError}</div>}
-              <div className="form-group">
-                <label htmlFor="map-title">Title</label>
-                <input
-                  id="map-title"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  required
-                  placeholder="My Hiking Trails"
-                />
-              </div>
-              <div className="form-group">
-                <label htmlFor="map-description">Description</label>
-                <textarea
-                  id="map-description"
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  placeholder="Optional description…"
-                  rows={3}
-                />
-              </div>
-              <div className="modal-actions">
-                <button type="button" className="btn btn-ghost" onClick={() => setShowCreate(false)} disabled={creating}>
-                  Cancel
-                </button>
-                <button type="submit" className="btn btn-primary" disabled={creating}>
-                  {creating ? 'Creating…' : 'Create'}
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
+      {error && <div className="alert alert-error">{error}</div>}
+
+      {(showCreate || editingMap) && (
+        <MapFormModal
+          mode={editingMap ? 'edit' : 'create'}
+          tenantId={tenantId}
+          existingMap={editingMap ?? undefined}
+          onClose={() => {
+            setShowCreate(false);
+            setEditingMap(null);
+          }}
+          onSaved={async () => {
+            setShowCreate(false);
+            setEditingMap(null);
+            await loadMaps();
+          }}
+        />
       )}
 
       {maps.length === 0 ? (
@@ -107,16 +69,222 @@ export function MapListPage() {
       ) : (
         <div className="map-grid">
           {maps.map((map) => (
-            <Link to={`/tenants/${tenantId}/maps/${map.id}`} key={map.id} className="map-card">
-              <h3>{map.title}</h3>
-              {map.description && <p>{map.description}</p>}
-              <span className="map-card-permission">
-                {map.permission === 'owner' ? '👑 Owner' : map.permission}
-              </span>
-            </Link>
+            <MapCard
+              key={map.id}
+              map={map}
+              tenantId={tenantId}
+              onEdit={() => setEditingMap(map)}
+              onDelete={() => handleDelete(map)}
+            />
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+// ─── Per-card with ⋯ menu (#160) ─────────────────────────────────────────────
+// The card body is a Link to the detail page; the ⋯ menu sits in a
+// non-Link corner so its clicks don't navigate.
+
+interface MapCardProps {
+  map: MapRecord;
+  tenantId: string | undefined;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+function MapCard({ map, tenantId, onEdit, onDelete }: MapCardProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const isOwner = map.permission === 'owner';
+
+  return (
+    <div className="map-card-wrapper">
+      <Link to={`/tenants/${tenantId}/maps/${map.id}`} className="map-card">
+        <h3>{map.title}</h3>
+        {map.description && <p>{map.description}</p>}
+        <span className="map-card-permission">
+          {map.permission === 'owner' ? '👑 Owner' : map.permission}
+        </span>
+      </Link>
+      {isOwner && (
+        <div
+          className="map-card-menu-wrapper"
+          tabIndex={-1}
+          onBlur={(e) => {
+            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+              setMenuOpen(false);
+            }
+          }}
+        >
+          <button
+            type="button"
+            className="map-card-menu"
+            aria-label="Map actions"
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setMenuOpen((m) => !m);
+            }}
+          >
+            ⋯
+          </button>
+          {menuOpen && (
+            <div className="map-card-menu-dropdown" role="menu">
+              <button
+                type="button"
+                role="menuitem"
+                className="map-card-menu-item"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setMenuOpen(false);
+                  onEdit();
+                }}
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="map-card-menu-item map-card-menu-item-danger"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setMenuOpen(false);
+                  onDelete();
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Map form modal — create + edit (#160) ───────────────────────────────────
+// Generalized from the original "+ New Map" form. Mode-specific behavior:
+//   create — blank fields, navigates to the new map's detail page on submit
+//   edit   — pre-populated from existingMap, stays on the list after save;
+//            coordinate system is read-only (changing a map's coord system
+//            mid-flight would invalidate every node's geometry — out of
+//            scope, future ticket)
+
+interface MapFormModalProps {
+  mode: 'create' | 'edit';
+  tenantId: string | undefined;
+  existingMap?: MapRecord;
+  onClose: () => void;
+  onSaved: () => Promise<void> | void;
+}
+
+function MapFormModal({
+  mode,
+  tenantId,
+  existingMap,
+  onClose,
+  onSaved,
+}: MapFormModalProps) {
+  const { createMap, updateMap } = useMap();
+  const [title, setTitle] = useState(existingMap?.title ?? '');
+  const [description, setDescription] = useState(existingMap?.description ?? '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isEdit = mode === 'edit';
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSaving(true);
+    try {
+      if (isEdit && existingMap) {
+        // Partial update: only send fields that actually changed.
+        const req: UpdateMapRequest = {};
+        if (title !== existingMap.title) req.title = title;
+        if (description !== (existingMap.description ?? '')) req.description = description;
+        if (Object.keys(req).length === 0) {
+          await onSaved();
+          return;
+        }
+        await updateMap(existingMap.id, req);
+        await onSaved();
+        return;
+      }
+
+      // mode === 'create'
+      const data: CreateMapRequest = {
+        title,
+        description,
+        // Default new maps to a generic WGS84 view; the user can swap to
+        // pixel or blank coordinate systems via API once the picker UI
+        // lands (separate ticket).
+        coordinateSystem: {
+          type: 'wgs84',
+          center: { lat: 0, lng: 0 },
+          zoom: 3,
+        },
+      };
+      const map = await createMap(data);
+      // On create, navigate straight into the new map's detail page —
+      // matches the pre-#160 behavior so users don't lose that flow.
+      window.location.href = `/tenants/${tenantId}/maps/${map.id}`;
+    } catch (err) {
+      setError(extractApiError(err, isEdit ? 'Failed to update map.' : 'Failed to create map.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <h2>{isEdit ? 'Edit Map' : 'Create Map'}</h2>
+        <form onSubmit={handleSubmit} className="auth-form">
+          {error && <div className="alert alert-error">{error}</div>}
+          <div className="form-group">
+            <label htmlFor="map-title">Title</label>
+            <input
+              id="map-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+              placeholder="My Hiking Trails"
+              autoFocus
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="map-description">Description</label>
+            <textarea
+              id="map-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional description…"
+              rows={3}
+            />
+          </div>
+          <div className="modal-actions">
+            <button
+              type="button"
+              className="btn btn-ghost"
+              onClick={onClose}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={saving || !title.trim()}
+            >
+              {saving ? (isEdit ? 'Saving…' : 'Creating…') : (isEdit ? 'Save' : 'Create')}
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   );
 }

--- a/frontend/tests/e2e/map-edit-delete.spec.ts
+++ b/frontend/tests/e2e/map-edit-delete.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test';
+import {
+  registerViaApi,
+  createMapViaApi,
+  seedAuthInBrowser,
+} from './helpers';
+
+/**
+ * E2E coverage for #160: map edit + delete UI.
+ *
+ * Pre-#160, maps had Read + Create + ownerXray-toggle but no edit-title
+ * and no delete from the UI. These tests exercise the new ⋯ menu on
+ * each map card (edit + delete) plus the Delete-map button on the
+ * detail page header.
+ */
+
+test.describe('Map edit + delete (#160)', () => {
+  test('user edits a map\'s title and description from the list page; changes persist', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'map_edit');
+    await createMapViaApi(request, api, 'Original Title', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 3,
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps`);
+
+    // Find the card and open its ⋯ menu.
+    const card = page.locator('.map-card-wrapper', {
+      has: page.getByRole('heading', { name: 'Original Title', exact: true }),
+    });
+    await card.getByRole('button', { name: /map actions/i }).click();
+    await page.getByRole('menuitem', { name: /^edit$/i }).click();
+
+    // Modal opens in edit mode pre-populated.
+    await expect(page.getByRole('heading', { name: /^edit map$/i })).toBeVisible();
+    const titleField = page.getByLabel(/^title$/i);
+    await expect(titleField).toHaveValue('Original Title');
+
+    // Update + save.
+    await titleField.fill('New Title');
+    await page.getByLabel(/^description$/i).fill('Updated description');
+    await page.getByRole('button', { name: /^save$/i }).click();
+
+    // List shows the new title; old title is gone.
+    await expect(page.getByRole('heading', { name: 'New Title', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Original Title', exact: true })).toHaveCount(0);
+
+    // Reload to confirm persistence (not just optimistic UI).
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'New Title', exact: true })).toBeVisible();
+  });
+
+  test('user deletes a map from the list page card menu; map is gone', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'map_delete_list');
+    await createMapViaApi(request, api, 'ToDelete From List', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 3,
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps`);
+
+    page.once('dialog', (dialog) => dialog.accept());
+    const card = page.locator('.map-card-wrapper', {
+      has: page.getByRole('heading', { name: 'ToDelete From List', exact: true }),
+    });
+    await card.getByRole('button', { name: /map actions/i }).click();
+    await page.getByRole('menuitem', { name: /^delete$/i }).click();
+
+    // Card is gone; empty state appears.
+    await expect(page.getByRole('heading', { name: 'ToDelete From List', exact: true })).toHaveCount(0);
+    await expect(page.getByText(/you don't have any maps yet/i)).toBeVisible();
+  });
+
+  test('user deletes a map from the detail page header; redirects back to list', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'map_delete_detail');
+    const map = await createMapViaApi(request, api, 'ToDelete From Detail', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 3,
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // Sanity: we're on the detail page.
+    await expect(page.getByRole('heading', { name: 'ToDelete From Detail', level: 1 })).toBeVisible();
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.getByRole('button', { name: /^delete map$/i }).click();
+
+    // Redirect to the maps list; the deleted map is gone.
+    await expect(page).toHaveURL(new RegExp(`/tenants/${api.tenantId}/maps$`));
+    await expect(page.getByRole('heading', { name: 'ToDelete From Detail', exact: true })).toHaveCount(0);
+  });
+
+  test('cancelling the edit modal does not save changes', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'map_edit_cancel');
+    await createMapViaApi(request, api, 'Stable Title', {
+      type: 'wgs84',
+      center: { lat: 0, lng: 0 },
+      zoom: 3,
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps`);
+
+    const card = page.locator('.map-card-wrapper', {
+      has: page.getByRole('heading', { name: 'Stable Title', exact: true }),
+    });
+    await card.getByRole('button', { name: /map actions/i }).click();
+    await page.getByRole('menuitem', { name: /^edit$/i }).click();
+
+    await page.getByLabel(/^title$/i).fill('Should Not Persist');
+    await page.getByRole('button', { name: /^cancel$/i }).click();
+
+    await expect(page.getByRole('heading', { name: 'Stable Title', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Should Not Persist', exact: true })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #160. Release-blocker for #137 (Phase 2 closeout). Third "rebuild ships read + partial write" CRUD gap surfaced during the manual smoke walk, after #150 (location create) and #158 (location edit/delete).

Backend has full map CRUD; service layer exposes \`updateMap\` and \`deleteMap\`; \`updateMap\` was being called from exactly one place (the owner_xray toggle). No edit-title or delete affordance anywhere.

## Implementation

- **Generalized \`MapListPage\`'s "+ New Map" form into \`MapFormModal\`** with \`mode: 'create' | 'edit'\` (same refactor pattern as #158's \`LocationFormModal\`). Edit pre-populates title + description; coordinate system is intentionally read-only (changing it mid-flight would invalidate every node's geometry — out of scope, future ticket).
- **Per-card "⋯" menu** on each map card in \`MapListPage\`, owner-only (non-owners don't see it). Same dropdown pattern as the NodeTreeRow menu from #158: \`tabIndex=-1\` wrapper + \`onBlur\` close.
- **Delete button in \`MapDetailPage\` header** (alongside the X-ray toggle), owner-only. On success, navigate to \`/tenants/{tid}/maps\`.
- **Edit-from-detail-page is intentionally NOT in v1.** Users can navigate to the list to edit; one click away. Keeps scope tight; the menu in MapDetailPage was filed for v1.5 if needed.

## Operational impact

- **Frontend**: code-only change. Vite HMR catches it automatically — no \`docker compose restart\` needed.
- **Backend**: untouched.
- **Database**: no schema change.

## Audit findings — filed separately as post-merge follow-ups

While auditing the rebuild's CRUD coverage to confirm no other gaps are #137-blockers, four additional gaps surfaced. All are pre-rebuild capabilities now missing. Each is feature-level rather than CRUD-primitive (so not #137 blockers per the same logic that filed #153, #107, #155 as post-merge):

- **#161** — Map permissions / sharing UI
- **#162** — Tenant member management UI
- **#163** — Tenant branding edit UI
- **#164** — Location move + copy UI (backend ready in #90 / #100)

After this PR (#160) merges, every CRUD primitive on every editable entity in the rebuild has a UI affordance, and #137 is unblocked.

## Work breakdown

- [x] Audit edit/delete coverage across all entities (maps, locations, notes, plots, visibility groups, plot members, vis-group members, permissions, tenant members, branding)
- [x] File #160 (this) + #161/#162/#163/#164 with appropriate sequencing
- [x] Branch off \`nodes-rebuild\`, move #160 to In Progress
- [x] Generalize "+ New Map" form into \`MapFormModal\` (create + edit)
- [x] Add per-card ⋯ menu to MapListPage with Edit + Delete
- [x] Add Delete button to MapDetailPage header (with redirect)
- [x] CSS for the dropdown
- [x] tsc + project lint + per-file lint clean
- [x] E2E (4 tests): edit-persist, delete-from-list, delete-from-detail-redirect, cancel-no-op
- [x] Full E2E regression: 41 passed, 5 skipped (no regressions)

## Files changed

- \`frontend/src/index.css\` — \`.map-card-wrapper\` + \`.map-card-menu*\` (positioned dropdown over each card, danger-styled Delete)
- \`frontend/src/pages/MapDetailPage.tsx\` — Add \`mapsService\` import; \`handleDeleteMap\`; "Delete map" button in header (owner-only) with confirm + redirect
- \`frontend/src/pages/MapListPage.tsx\` — Refactor: extract \`MapCard\` + \`MapFormModal\`; add per-card ⋯ menu with Edit + Delete; modal supports create + edit modes; partial-update body on edit
- \`frontend/tests/e2e/map-edit-delete.spec.ts\` — New: 4 tests covering edit-persist, delete-from-list, delete-from-detail-redirect, cancel-no-op

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean (project) + per-file \`npx eslint\` clean
- [x] \`npx playwright test tests/e2e/map-edit-delete.spec.ts\` — 4/4 pass
- [x] \`npx playwright test\` — 41 passed, 5 skipped (no regressions)
- [ ] PR CI green