### PR TITLE
ci: retry-on-429 with backoff in registerViaApi (E2E rate-limit resilience)

### DIFF
--- a/backend/config.docker.json
+++ b/backend/config.docker.json
@@ -41,7 +41,7 @@
       "max_size_bytes": 10485760
     },
     "rate_limit": {
-      "max_requests": 1000,
+      "max_requests": 100,
       "window_seconds": 60
     },
     "allowed_origins": ["http://localhost:5173"],

--- a/backend/config.docker.json
+++ b/backend/config.docker.json
@@ -41,7 +41,7 @@
       "max_size_bytes": 10485760
     },
     "rate_limit": {
-      "max_requests": 100,
+      "max_requests": 1000,
       "window_seconds": 60
     },
     "allowed_origins": ["http://localhost:5173"],

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -74,16 +74,23 @@ export async function registerViaApi(
   const u = makeUser(tag);
   // /auth/register is rate-limited per-IP (no JWT yet to key on userId).
   // In multi-worker CI all tests share one IP, so the suite can saturate
-  // the bucket near the tail. Defensive single-retry on 429 with a short
-  // backoff catches a one-off saturation without masking a real outage.
-  // Backend config (config.docker.json) is sized for 10× current suite
-  // load; this retry is belt-and-suspenders.
+  // the bucket near the tail — and the backend's own rate-limit test
+  // (test_06_rate_limit_fast.py) explicitly fills the bucket as part of
+  // verifying the limiter, leaving E2E to start with a saturated bucket.
+  //
+  // Backoff schedule: [2, 5, 10] seconds. With a 60s window and a 100-
+  // request limit, an entry expires every ~600ms. After 17s of total
+  // backoff (worst case), ~28 entries have aged out — comfortably enough
+  // for E2E's burst rate. Real outages still surface on the final 429
+  // via the existing toBeTruthy assertion.
+  const BACKOFFS_MS = [2000, 5000, 10000];
   const post = () => request.post(`${API_URL}/auth/register`, {
     data: { username: u.username, email: u.email, password: u.password },
   });
   let res = await post();
-  if (res.status() === 429) {
-    await new Promise((r) => setTimeout(r, 1500));
+  for (const delay of BACKOFFS_MS) {
+    if (res.status() !== 429) break;
+    await new Promise((r) => setTimeout(r, delay));
     res = await post();
   }
   expect(res.ok()).toBeTruthy();

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -72,9 +72,20 @@ export async function registerViaApi(
   tag: string,
 ): Promise<ApiUser> {
   const u = makeUser(tag);
-  const res = await request.post(`${API_URL}/auth/register`, {
+  // /auth/register is rate-limited per-IP (no JWT yet to key on userId).
+  // In multi-worker CI all tests share one IP, so the suite can saturate
+  // the bucket near the tail. Defensive single-retry on 429 with a short
+  // backoff catches a one-off saturation without masking a real outage.
+  // Backend config (config.docker.json) is sized for 10× current suite
+  // load; this retry is belt-and-suspenders.
+  const post = () => request.post(`${API_URL}/auth/register`, {
     data: { username: u.username, email: u.email, password: u.password },
   });
+  let res = await post();
+  if (res.status() === 429) {
+    await new Promise((r) => setTimeout(r, 1500));
+    res = await post();
+  }
   expect(res.ok()).toBeTruthy();
   const body = await res.json();
   return { token: body.token, tenantId: body.tenantId, user: body.user };


### PR DESCRIPTION
## Summary

Run [25457209788](https://github.com/dcltdw/annotated-maps/actions/runs/25457209788/job/74689834791) (the post-#165 push to \`nodes-rebuild\`) failed two E2E tests at the tail of the suite. Both failed at \`registerViaApi\`'s \`expect(res.ok()).toBeTruthy()\` in [helpers.ts:78](frontend/tests/e2e/helpers.ts). Both pass locally. Both fail in <200ms in CI — consistent with a backend 429.

## Diagnosis

\`/auth/register\` is rate-limited per-IP (no JWT yet to key on userId). Config in \`backend/config.docker.json\` is **100 req/60s** for unauthenticated endpoints.

The E2E suite registers ~50 users in CI, sometimes in burst (multi-worker). But the bigger contributor is **\`backend/tests/test_06_rate_limit_fast.py\`** — it deliberately saturates the bucket (~100 requests) to verify 429 behavior, then exits. The bucket holds entries for 60s. E2E starts immediately after, finds a saturated bucket, gets 429s on register calls.

Locally this didn't reproduce because \`playwright.config.ts\` sets workers=1 and the suite runs over ~45s — enough time for entries to age out organically. CI runs ALL of backend-tier-fast (~40s) followed immediately by E2E, with the bucket near-full at the handoff.

## First attempt (reverted in this PR)

Initial commit bumped \`max_requests\` 100 → 1000 to give E2E headroom. CI then failed differently:

- E2E ✅ passed (more headroom)
- Backend ❌ failed — \`test_06\` looped only 150 requests expecting to hit 429, but with the 1000-limit, 150 wasn't enough

Naively fixing test_06 to read the config would re-saturate the (now-larger) bucket right before E2E, breaking E2E in turn. The "bigger bucket" approach trades one failure for another.

## Final approach

**Keep the original config (100/60s).** Make E2E's register helper resilient to a saturated bucket through retry-with-backoff, which gives the bucket window time to age out entries naturally.

\`\`\`typescript
const BACKOFFS_MS = [2000, 5000, 10000];
let res = await post();
for (const delay of BACKOFFS_MS) {
  if (res.status() !== 429) break;
  await new Promise((r) => setTimeout(r, delay));
  res = await post();
}
expect(res.ok()).toBeTruthy();
\`\`\`

With a 60-second window and 100-request limit, the bucket trims at ~1 entry per 600ms. After 17s of total backoff (worst case, all three retries fire), ~28 entries have aged out — comfortable headroom for E2E's burst rate. Real outages still surface on the final 429.

## Test plan

Local validation reproduces the exact CI scenario:

\`\`\`
$ python3 backend/tests/run-tests.py --tier fast
Tier: fast
Duration: 42s
All test suites passed.

$ npx playwright test
43 passed (45.6s)  5 skipped
\`\`\`

The backend tier saturates the bucket via test_06, then E2E runs immediately. With the retry helper, E2E passes cleanly.

- [x] tsc + lint clean
- [x] Backend fast tier: all suites pass (test_06 still triggers + asserts 429)
- [x] Full E2E run immediately after, with saturated bucket: 43 passed, 5 skipped, no regressions
- [x] PR CI green

## Files changed

- \`frontend/tests/e2e/helpers.ts\` — Three-step backoff retry [2s, 5s, 10s] in \`registerViaApi\` to absorb bucket saturation through window aging

## Why this approach over the bumped-config one

| | Bumped config | Retry-with-backoff |
|---|---|---|
| Backend test fix | Required (test_06 loop ceiling) | None |
| Saturation handoff issue | Re-introduced at the larger limit | Naturally absorbed |
| Config drift between dev/CI/prod | Wider | Same as before |
| Real-outage detection | Unchanged | Unchanged (final retry fails loudly) |
| Test runtime impact | None | Up to +17s in worst case (rare, only when bucket saturated) |

## Operational impact

- **Backend**: rebuild required (config reverted from 1000 back to 100). \`docker compose up -d --build backend\`.
- **Frontend**: untouched (helpers.ts is test code, not the running app).
- **DB**: untouched.

## Note for future readers

The E2E rate-limit interplay with backend test_06 is non-obvious. Anyone tempted to bump the dev rate limit "for headroom" should read this PR's commit history (initial attempt, then revision) before doing so. The retry-with-backoff in \`registerViaApi\` is the supported pattern.