### PR TITLE
frontend: token-refresh interceptor (#168)

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosError } from 'axios';
+import axios, { AxiosInstance, AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { useAuthStore } from '@/store/authStore';
 import type { ApiError } from '@/types';
 
@@ -20,13 +20,69 @@ apiClient.interceptors.request.use((config) => {
   return config;
 });
 
-// Handle 401 globally — clear auth and redirect to login
+// ─── 401 + token-refresh interceptor (#168) ─────────────────────────────────
+//
+// On 401 from any non-`/auth/*` endpoint, attempt a single token refresh and
+// retry the original request transparently. If refresh fails (or itself 401s),
+// log out + redirect — same fallback as before #168.
+//
+// Concurrent 401s share one in-flight refresh: the first 401 fires the
+// refresh, subsequent 401s `await` the same promise, then all retry with the
+// new token. Without this, N parallel failing requests fire N refreshes
+// (and the second+ refresh would itself 401 if the backend rotates tokens).
+//
+// `_refreshRetried` on the request config guards against an infinite loop
+// in the case where the retried original request also 401s — falls through
+// to logout instead of recursing.
+
+type RetryConfig = InternalAxiosRequestConfig & {
+  _refreshRetried?: boolean;
+};
+
+let refreshInFlight: Promise<string | null> | null = null;
+
+function performRefresh(): Promise<string | null> {
+  if (refreshInFlight) return refreshInFlight;
+  refreshInFlight = (async () => {
+    try {
+      // Imported lazily to avoid circular dep with services/auth.ts
+      const { authService } = await import('./auth');
+      const { token } = await authService.refreshToken();
+      useAuthStore.getState().setToken(token);
+      return token;
+    } catch {
+      return null;
+    } finally {
+      refreshInFlight = null;
+    }
+  })();
+  return refreshInFlight;
+}
+
 apiClient.interceptors.response.use(
   (response) => response,
-  (error: AxiosError<ApiError>) => {
-    const url = error.config?.url ?? '';
+  async (error: AxiosError<ApiError>) => {
+    const config = error.config as RetryConfig | undefined;
+    const url = config?.url ?? '';
     const isAuthEndpoint = url.includes('/auth/');
-    if (error.response?.status === 401 && !isAuthEndpoint) {
+    const status = error.response?.status;
+
+    // 401 on a non-auth endpoint, not already a retry → try refresh.
+    if (status === 401 && !isAuthEndpoint && config && !config._refreshRetried) {
+      const newToken = await performRefresh();
+      if (newToken) {
+        config._refreshRetried = true;
+        config.headers = config.headers ?? {};
+        config.headers.Authorization = `Bearer ${newToken}`;
+        return apiClient(config);
+      }
+      // Refresh returned null (failed) → fall through to logout below.
+    }
+
+    // 401 on a non-auth endpoint after refresh-fail (or refresh-retry) → log out.
+    // 401 on an /auth/* endpoint (login, register) propagates as-is — those
+    // 401s are user-facing errors ("wrong password"), not session expiry.
+    if (status === 401 && !isAuthEndpoint) {
       useAuthStore.getState().logout();
       window.location.href = '/login';
     }

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -10,6 +10,7 @@ interface AuthActions {
     tenantId: number,
     tenants: TenantSummary[]
   ) => void;
+  setToken: (token: string) => void;
   setActiveTenant: (tenantId: number) => void;
   setBranding: (branding: TenantBranding) => void;
   logout: () => void;
@@ -32,6 +33,9 @@ export const useAuthStore = create<AuthState & AuthActions>()(
 
       setAuth: (user, token, orgId, tenantId, tenants) =>
         set({ user, token, orgId, tenantId, tenants, isAuthenticated: true }),
+
+      setToken: (token) =>
+        set({ token }),
 
       setActiveTenant: (tenantId) =>
         set({ tenantId, branding: {} }),

--- a/frontend/tests/e2e/token-refresh.spec.ts
+++ b/frontend/tests/e2e/token-refresh.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { registerViaApi, seedAuthInBrowser } from './helpers';
+
+/**
+ * E2E coverage for #168: 401 + token-refresh interceptor.
+ *
+ * **Tested here:** the failure path. When the stored token is invalid,
+ * the next API call 401s, the interceptor attempts /auth/refresh, the
+ * refresh itself 401s (token signature is bad), the user is logged out
+ * and redirected to /login.
+ *
+ * **NOT tested here:** the success path. Exercising "expired but
+ * valid-signature token → refresh succeeds → retry succeeds" requires
+ * a backend knob to issue a deliberately-expired token (or waiting
+ * out the configured TTL). Both are out of scope; the interceptor's
+ * happy path is straightforward enough to read from the diff.
+ */
+
+test.describe('Token refresh interceptor (#168)', () => {
+  test('invalid token → /auth/refresh 401s → user is logged out and redirected', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'tokrefresh_fail');
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps`);
+
+    // Confirm we're on the maps page (the interceptor hasn't fired yet).
+    await expect(page).toHaveURL(/\/maps/);
+
+    // Corrupt the stored JWT — appending garbage breaks the signature so
+    // both the next API request AND the subsequent /auth/refresh attempt
+    // will 401, exercising the "refresh failed → logout" branch.
+    await page.evaluate(() => {
+      const raw = localStorage.getItem('auth-storage');
+      if (!raw) throw new Error('no auth-storage in localStorage');
+      const persisted = JSON.parse(raw);
+      persisted.state.token = persisted.state.token + '_BROKEN';
+      localStorage.setItem('auth-storage', JSON.stringify(persisted));
+    });
+
+    // Force a request through the interceptor by reloading; MapListPage's
+    // useEffect calls loadMaps() → /tenants/{tid}/maps → 401 → refresh
+    // → also 401 → logout + redirect.
+    await page.reload();
+
+    await expect(page).toHaveURL(/\/login$/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #168. Replaces the previous "401 → log out immediately" behavior with "401 → attempt /auth/refresh → retry original request transparently → only log out if refresh itself fails." The token's TTL no longer kicks the user out mid-session.

## Why

Pre-#168, an access token expiring by one minute mid-session dumps the user back to /login and loses their work. The backend's `/auth/refresh` endpoint already exists and `authService.refreshToken()` was wired up; the interceptor just didn't call it. This is a UX papercut, not a functional bug.

## Implementation

- **`store/authStore.ts`** — new `setToken` action so the refresh flow can update only the token field without re-setting user/tenant/orgId.
- **`services/api.ts`** — response interceptor catches 401 on non-`/auth/*` endpoints, fires `performRefresh()`, replays the original request on success.
  - **In-flight dedup**: a module-scope `refreshInFlight: Promise | null` ensures parallel 401s share one refresh request. Without this, N parallel failing requests fire N refreshes and the second+ would itself 401 if the backend rotates tokens.
  - **Retry guard**: the replayed request gets `_refreshRetried = true`, so if it 401s again the interceptor falls through to logout instead of recursing.
  - **Lazy import of `authService`** — avoids the circular dep that a direct import would create (api.ts ↔ auth.ts).

## Tested

- `frontend/tests/e2e/token-refresh.spec.ts` covers the **failure path**: corrupt the stored JWT in localStorage → reload → MapListPage's data-load 401s → interceptor calls /auth/refresh → that 401s too (signature is broken) → user is logged out and redirected to /login. 1/1 pass locally (~2s).
- The **success path** (expired-but-valid-signature token → refresh succeeds → retry succeeds) is **not** automatable without a backend knob to issue a deliberately-expired token. Code review of the diff is straightforward; not a release blocker.

## Test plan

- [x] `npx tsc --noEmit` → no errors
- [x] `npm run lint` → no warnings
- [x] `npx playwright test token-refresh` → 1/1 pass
- [x] No backend changes; no rebuild needed
- [x] Per §4b-2: this change adds a new behavior to a UI flow (session expiry); E2E ships in the same PR

## Operational impact

No restart, rebuild, or migration needed. Frontend HMR picks up the interceptor change.

## Work breakdown

1. Read ticket + locate current 401 interceptor (`services/api.ts`)
2. Inspect `authService.refreshToken` (already exists; calls `POST /auth/refresh`)
3. Inspect `authStore` for token-update action (none — adds `setToken`)
4. Add `setToken: (token) => set({ token })` to authStore
5. Rewrite the response interceptor: in-flight-deduped `performRefresh()` + retry + retry-guard
6. Use lazy `import('./auth')` for `authService` to avoid the circular dep
7. Write E2E for failure path: localStorage token corruption → reload → URL becomes /login
8. tsc + lint + spec pass
9. Commit + push + open PR

## Files changed

- `frontend/src/services/api.ts` — replace simple "401 → logout" interceptor with refresh-then-retry, in-flight-deduped, retry-guarded
- `frontend/src/store/authStore.ts` — new `setToken` action
- `frontend/tests/e2e/token-refresh.spec.ts` — new E2E covering the failure path

🤖 Generated with [Claude Code](https://claude.com/claude-code)