### PR TITLE
frontend: note pin/unpin toggle in NodeDetailPanel (#107)

### DIFF
--- a/frontend/src/components/Detail/NodeDetailPanel.tsx
+++ b/frontend/src/components/Detail/NodeDetailPanel.tsx
@@ -315,6 +315,7 @@ function NoteCard({ mapId, note, onChange }: NoteCardProps) {
   const [showVisibility, setShowVisibility] = useState(false);
   const [showPlots, setShowPlots] = useState(false);
   const [showMedia, setShowMedia] = useState(false);
+  const [togglingPin, setTogglingPin] = useState(false);
 
   const handleDelete = async () => {
     if (!window.confirm('Delete this note?')) return;
@@ -323,6 +324,19 @@ function NoteCard({ mapId, note, onChange }: NoteCardProps) {
       await onChange();
     } catch (e) {
       window.alert(extractApiError(e, 'Failed to delete note.'));
+    }
+  };
+
+  const handleTogglePin = async () => {
+    if (togglingPin) return;
+    setTogglingPin(true);
+    try {
+      await notesService.updateNote(mapId, note.id, { pinned: !note.pinned });
+      await onChange();
+    } catch (e) {
+      window.alert(extractApiError(e, 'Failed to update pin state.'));
+    } finally {
+      setTogglingPin(false);
     }
   };
 
@@ -347,7 +361,20 @@ function NoteCard({ mapId, note, onChange }: NoteCardProps) {
     >
       <header className="note-card-header">
         <div className="note-card-titlebar">
-          {note.pinned && <span className="note-pin" title="Pinned">📌</span>}
+          {note.canEdit ? (
+            <button
+              type="button"
+              className={`note-pin-toggle ${note.pinned ? 'note-pin-toggle-on' : ''}`}
+              onClick={handleTogglePin}
+              disabled={togglingPin}
+              aria-label={note.pinned ? 'Unpin note' : 'Pin note'}
+              title={note.pinned ? 'Unpin' : 'Pin'}
+            >
+              📌
+            </button>
+          ) : (
+            note.pinned && <span className="note-pin" title="Pinned">📌</span>
+          )}
           {note.title && <strong>{note.title}</strong>}
         </div>
         {note.canEdit && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -700,6 +700,19 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
 }
 .note-card-titlebar { display: flex; align-items: center; gap: .25rem; flex: 1; min-width: 0; }
 .note-pin { font-size: .85rem; }
+.note-pin-toggle {
+  font-size: .85rem;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  padding: 0 4px;
+  opacity: 0.35;
+  transition: opacity .12s;
+}
+.note-pin-toggle:hover { opacity: 0.7; }
+.note-pin-toggle:disabled { cursor: progress; }
+.note-pin-toggle-on { opacity: 1; }
+.note-pin-toggle-on:hover { opacity: 0.85; }
 .note-card-actions { display: flex; gap: .25rem; }
 .note-card-text { margin: .25rem 0; font-size: .85rem; white-space: pre-wrap; }
 .note-card-footer { font-size: .75rem; color: var(--color-text-muted, #666); margin-top: .25rem; }

--- a/frontend/tests/e2e/note-pin-toggle.spec.ts
+++ b/frontend/tests/e2e/note-pin-toggle.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+import {
+  registerViaApi,
+  createMapViaApi,
+  createNodeViaApi,
+  seedAuthInBrowser,
+  API_URL,
+} from './helpers';
+
+/**
+ * E2E coverage for #107: note pin/unpin toggle in NodeDetailPanel.
+ *
+ * Backend already accepts `pinned` on note update (and sorts pinned notes
+ * first on read); this ticket adds the inline toggle button so users can
+ * pin/unpin without entering edit mode.
+ */
+
+test.describe('Note pin toggle (#107)', () => {
+  test('user pins a note inline; reload preserves pin state', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'note_pin');
+    const map = await createMapViaApi(request, api, 'PinTest', {
+      type: 'wgs84', center: { lat: 0, lng: 0 }, zoom: 3,
+    });
+    const node = await createNodeViaApi(request, api, map.id, { name: 'Place' });
+
+    // Seed an unpinned note via API (pin toggle is the inline UI under test).
+    const noteRes = await request.post(
+      `${API_URL}/tenants/${api.tenantId}/maps/${map.id}/nodes/${node.id}/notes`,
+      {
+        headers: { Authorization: `Bearer ${api.token}` },
+        data: { text: 'A note that needs pinning' },
+      },
+    );
+    if (!noteRes.ok()) throw new Error(`createNote failed: ${noteRes.status()}`);
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+    await page.getByRole('button', { name: 'Place', exact: true }).click();
+
+    // Toggle is visible, off by default
+    const toggle = page.getByRole('button', { name: /pin note/i });
+    await expect(toggle).toBeVisible();
+
+    // Pin → button label flips, badge added to card
+    await toggle.click();
+    await expect(page.getByRole('button', { name: /unpin note/i })).toBeVisible();
+    await expect(page.locator('.note-card-pinned')).toBeVisible();
+
+    // Reload → pin state persists from the backend
+    await page.reload();
+    await page.getByRole('button', { name: 'Place', exact: true }).click();
+    await expect(page.getByRole('button', { name: /unpin note/i })).toBeVisible();
+    await expect(page.locator('.note-card-pinned')).toBeVisible();
+
+    // Unpin → button flips back
+    await page.getByRole('button', { name: /unpin note/i }).click();
+    await expect(page.getByRole('button', { name: /pin note/i })).toBeVisible();
+    await expect(page.locator('.note-card-pinned')).toHaveCount(0);
+  });
+
+  test('two notes: pinned one sorts above unpinned after toggle', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'note_pin_sort');
+    const map = await createMapViaApi(request, api, 'PinSort', {
+      type: 'wgs84', center: { lat: 0, lng: 0 }, zoom: 3,
+    });
+    const node = await createNodeViaApi(request, api, map.id, { name: 'P' });
+
+    const seedNote = async (text: string) => {
+      const r = await request.post(
+        `${API_URL}/tenants/${api.tenantId}/maps/${map.id}/nodes/${node.id}/notes`,
+        { headers: { Authorization: `Bearer ${api.token}` }, data: { text } },
+      );
+      if (!r.ok()) throw new Error(`createNote failed: ${r.status()}`);
+    };
+    await seedNote('First note');
+    await seedNote('Second note');
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+    await page.getByRole('button', { name: 'P', exact: true }).click();
+
+    // Pin "Second note" — find its card by text + click the pin toggle inside it.
+    const secondCard = page.locator('.note-card', { hasText: 'Second note' });
+    await secondCard.getByRole('button', { name: /pin note/i }).click();
+
+    // After reload (defensive against optimistic-only UI), assert the
+    // pinned-first sort: first card text should be "Second note".
+    await page.reload();
+    await page.getByRole('button', { name: 'P', exact: true }).click();
+    const firstCardText = await page.locator('.note-card').first().textContent();
+    expect(firstCardText).toContain('Second note');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #107. Adds an inline pin/unpin button to each note card in NodeDetailPanel. Backend already accepts \`pinned\` on update and sorts pinned-first on read; this PR is purely the frontend toggle so users don't have to enter the Edit form to pin/unpin.

## Changes

- **NoteCard** (NodeDetailPanel.tsx): the static 📌 indicator is replaced with a toggle button when \`note.canEdit\` is true. Faded opacity when unpinned, full opacity when pinned. \`handleTogglePin\` calls \`notesService.updateNote(mapId, noteId, { pinned: !pinned })\` and refreshes via \`onChange\`. Button disables while in-flight to prevent double-submits. Non-canEdit viewers still see the static \`<span>\` badge.
- **CSS**: new \`.note-pin-toggle\` / \`.note-pin-toggle-on\` rules — same icon (📌), opacity-based active state, hover transitions.

## Tested

\`frontend/tests/e2e/note-pin-toggle.spec.ts\` — 2/2 pass:

1. Pin a fresh unpinned note; reload to confirm persistence; unpin to confirm the round-trip
2. Two seeded notes; pin the second one; reload; assert pinned-first sort puts \"Second note\" before \"First note\"

## Test plan

- [x] \`npx tsc --noEmit\` → clean
- [x] \`npm run lint\` → clean
- [x] \`npx playwright test note-pin-toggle\` → 2/2 pass
- [x] Per §4b-2: new UI affordance ships with E2E in the same PR

## Operational impact

No restart, rebuild, or migration needed. Frontend HMR.

## Work breakdown

1. Read ticket #107 + locate NoteCard in NodeDetailPanel
2. Confirm backend \`UpdateNoteRequest\` accepts partial \`{ pinned }\` (Partial<CreateNoteRequest> in schemas.ts ✓)
3. Add \`togglingPin\` state + \`handleTogglePin\` to NoteCard
4. Replace conditional 📌 span with toggle button (only when canEdit)
5. CSS: opacity-based active/hover state for the toggle
6. E2E: round-trip + sort scenarios
7. tsc + lint + spec → green
8. Commit + push + open PR

## Files changed

- \`frontend/src/components/Detail/NodeDetailPanel.tsx\` — add pin toggle button + handler in NoteCard
- \`frontend/src/index.css\` — \`.note-pin-toggle\` styles (opacity-based active state)
- \`frontend/tests/e2e/note-pin-toggle.spec.ts\` — new E2E covering pin round-trip + pinned-first sort

🤖 Generated with [Claude Code](https://claude.com/claude-code)