### PR TITLE
frontend: SSO initiate UI on login form (#167)

### DIFF
--- a/frontend/src/components/Auth/LoginForm.tsx
+++ b/frontend/src/components/Auth/LoginForm.tsx
@@ -1,6 +1,7 @@
 import { useState, FormEvent } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
+import { authService } from '@/services/auth';
 import { extractApiError } from '@/utils/errors';
 
 export function LoginForm() {
@@ -8,8 +9,19 @@ export function LoginForm() {
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [showSso, setShowSso] = useState(false);
+  const [orgSlug, setOrgSlug] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const handleSsoSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const slug = orgSlug.trim();
+    if (!slug) return;
+    // Full-page navigation; the IdP redirects back to /sso/callback which
+    // SsoCallbackPage exchanges for a JWT.
+    authService.ssoInitiate(slug);
+  };
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -59,6 +71,49 @@ export function LoginForm() {
             {loading ? 'Signing in…' : 'Sign In'}
           </button>
         </form>
+
+        <div className="auth-sso-divider"><span>or</span></div>
+
+        {!showSso ? (
+          <button
+            type="button"
+            className="btn btn-ghost btn-full"
+            onClick={() => setShowSso(true)}
+          >
+            Sign in with SSO
+          </button>
+        ) : (
+          <form onSubmit={handleSsoSubmit} className="auth-form auth-sso-form">
+            <div className="form-group">
+              <label htmlFor="org-slug">Organization slug</label>
+              <input
+                id="org-slug"
+                value={orgSlug}
+                onChange={(e) => setOrgSlug(e.target.value)}
+                required
+                placeholder="acme-corp"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+              />
+            </div>
+            <button
+              type="submit"
+              className="btn btn-primary btn-full"
+              disabled={!orgSlug.trim()}
+            >
+              Continue to SSO
+            </button>
+            <button
+              type="button"
+              className="btn btn-ghost btn-full"
+              onClick={() => { setShowSso(false); setOrgSlug(''); }}
+            >
+              Cancel
+            </button>
+          </form>
+        )}
+
         <p className="auth-footer">
           Don't have an account? <Link to="/register">Sign Up</Link>
         </p>

--- a/frontend/src/components/Auth/LoginForm.tsx
+++ b/frontend/src/components/Auth/LoginForm.tsx
@@ -80,7 +80,7 @@ export function LoginForm() {
             className="btn btn-ghost btn-full"
             onClick={() => setShowSso(true)}
           >
-            Sign in with SSO
+            Use SSO
           </button>
         ) : (
           <form onSubmit={handleSsoSubmit} className="auth-form auth-sso-form">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -56,6 +56,22 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
 .auth-card h1 { margin-bottom: 1.5rem; font-size: 1.5rem; }
 .auth-form { display: flex; flex-direction: column; gap: 1rem; }
 .auth-footer { margin-top: 1rem; font-size: .875rem; text-align: center; color: var(--color-text-muted); }
+.auth-sso-divider {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  margin: 1rem 0;
+  color: var(--color-text-muted);
+  font-size: .75rem;
+}
+.auth-sso-divider::before,
+.auth-sso-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
+.auth-sso-form { gap: .5rem; margin-top: .5rem; }
 .auth-footer a { color: var(--color-primary); }
 .form-group { display: flex; flex-direction: column; gap: .375rem; }
 .form-group label { font-size: .875rem; font-weight: 500; }

--- a/frontend/tests/e2e/sso-initiate.spec.ts
+++ b/frontend/tests/e2e/sso-initiate.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E coverage for #167: SSO initiate UI on the login form.
+ *
+ * Tests the toggle + form-submit wiring; doesn't follow the full SSO
+ * redirect (no IdP available in CI). The redirect URL is asserted via
+ * page.route() interception.
+ */
+
+test.describe('SSO initiate (#167)', () => {
+  test('toggle reveals the org-slug form; cancel hides it again', async ({ page }) => {
+    await page.goto('/login');
+
+    // Initial state: only the email/password form is visible; SSO button shown
+    await expect(page.getByLabel(/organization slug/i)).toHaveCount(0);
+    const ssoButton = page.getByRole('button', { name: /sign in with sso/i });
+    await expect(ssoButton).toBeVisible();
+
+    // Click "Sign in with SSO" → org-slug form appears, password form stays
+    await ssoButton.click();
+    await expect(page.getByLabel(/organization slug/i)).toBeVisible();
+    await expect(page.getByLabel(/^email$/i)).toBeVisible();
+
+    // Cancel returns to the initial state
+    await page.getByRole('button', { name: /^cancel$/i }).click();
+    await expect(page.getByLabel(/organization slug/i)).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /sign in with sso/i })).toBeVisible();
+  });
+
+  test('submitting an org slug navigates to the backend SSO initiate URL', async ({ page }) => {
+    // Intercept the redirect so the test doesn't actually follow it (no IdP
+    // available); just assert the URL the browser was sent to.
+    let interceptedUrl: string | null = null;
+    await page.route('**/api/v1/auth/sso/**', (route) => {
+      interceptedUrl = route.request().url();
+      // Stub a 200 so the browser doesn't show an error page; the test
+      // doesn't need to follow further.
+      route.fulfill({ status: 200, contentType: 'text/html', body: 'OK' });
+    });
+
+    await page.goto('/login');
+    await page.getByRole('button', { name: /sign in with sso/i }).click();
+    await page.getByLabel(/organization slug/i).fill('acme-corp');
+    await page.getByRole('button', { name: /continue to sso/i }).click();
+
+    // Wait for the route to fire; expect.poll handles the timing without
+    // a fixed wait.
+    await expect.poll(() => interceptedUrl).toMatch(/\/api\/v1\/auth\/sso\/acme-corp(?:$|\?)/);
+  });
+
+  test('empty org-slug submit is blocked by the disabled button', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByRole('button', { name: /sign in with sso/i }).click();
+    await expect(
+      page.getByRole('button', { name: /continue to sso/i }),
+    ).toBeDisabled();
+  });
+});

--- a/frontend/tests/e2e/sso-initiate.spec.ts
+++ b/frontend/tests/e2e/sso-initiate.spec.ts
@@ -14,7 +14,7 @@ test.describe('SSO initiate (#167)', () => {
 
     // Initial state: only the email/password form is visible; SSO button shown
     await expect(page.getByLabel(/organization slug/i)).toHaveCount(0);
-    const ssoButton = page.getByRole('button', { name: /sign in with sso/i });
+    const ssoButton = page.getByRole('button', { name: /use sso/i });
     await expect(ssoButton).toBeVisible();
 
     // Click "Sign in with SSO" → org-slug form appears, password form stays
@@ -25,7 +25,7 @@ test.describe('SSO initiate (#167)', () => {
     // Cancel returns to the initial state
     await page.getByRole('button', { name: /^cancel$/i }).click();
     await expect(page.getByLabel(/organization slug/i)).toHaveCount(0);
-    await expect(page.getByRole('button', { name: /sign in with sso/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /use sso/i })).toBeVisible();
   });
 
   test('submitting an org slug navigates to the backend SSO initiate URL', async ({ page }) => {
@@ -40,7 +40,7 @@ test.describe('SSO initiate (#167)', () => {
     });
 
     await page.goto('/login');
-    await page.getByRole('button', { name: /sign in with sso/i }).click();
+    await page.getByRole('button', { name: /use sso/i }).click();
     await page.getByLabel(/organization slug/i).fill('acme-corp');
     await page.getByRole('button', { name: /continue to sso/i }).click();
 
@@ -51,7 +51,7 @@ test.describe('SSO initiate (#167)', () => {
 
   test('empty org-slug submit is blocked by the disabled button', async ({ page }) => {
     await page.goto('/login');
-    await page.getByRole('button', { name: /sign in with sso/i }).click();
+    await page.getByRole('button', { name: /use sso/i }).click();
     await expect(
       page.getByRole('button', { name: /continue to sso/i }),
     ).toBeDisabled();


### PR DESCRIPTION
## Summary

Closes #167. Backend has the SSO initiate endpoint and \`authService.ssoInitiate\` was already wired up; this PR adds the missing UI so users can actually start an SSO flow from the login form. Without this, SSO works only if a user has an external redirect URL — they can't kick it off from the app.

## UX

LoginForm gets two new states:

1. **Default**: email/password form + a divider + a \"Sign in with SSO\" button (toggle, doesn't redirect yet — the slug is needed first)
2. **SSO mode**: org-slug input + \"Continue to SSO\" + \"Cancel\". Submit fires \`authService.ssoInitiate(slug)\`, which is a full-page navigation to \`/api/v1/auth/sso/{slug}\`. The backend redirects to the IdP; \`SsoCallbackPage\` (already shipped) handles the return leg.

The \"Continue to SSO\" button is disabled until the slug field has content; \`Cancel\` returns to the default state.

## Tested

\`frontend/tests/e2e/sso-initiate.spec.ts\` — 3/3 pass:

1. Toggle reveals the org-slug form; cancel hides it again
2. Submitting a slug fires the redirect to \`/api/v1/auth/sso/{slug}\` (intercepted via \`page.route\` to avoid following the redirect — no IdP available in CI)
3. Empty-slug submit is blocked by the disabled button

## Test plan

- [x] tsc + lint clean
- [x] \`npx playwright test sso-initiate\` → 3/3 pass
- [x] Per §4b-2: new UI surface ships with E2E in the same PR

## Out of scope (per ticket)

- Provider listing UI (multi-IdP per organization) — current model is one IdP per org, slug-based
- Auto-detect SSO from the email domain — separate UX call

## Operational impact

No restart, rebuild, or migration needed. Frontend HMR.

## Work breakdown

1. Read ticket #167 + locate LoginForm; confirm \`authService.ssoInitiate\` already exists
2. Add \`showSso\` / \`orgSlug\` state + \`handleSsoSubmit\`
3. Render: divider, toggle button (default state), collapsed org-slug form (SSO mode)
4. CSS: \`.auth-sso-divider\` (or-style separator) + \`.auth-sso-form\` spacing
5. E2E: toggle, redirect interception, disabled-empty
6. tsc + lint + spec → green
7. Commit + push + open PR

## Files changed

- \`frontend/src/components/Auth/LoginForm.tsx\` — add SSO toggle + org-slug form + ssoInitiate call
- \`frontend/src/index.css\` — \`.auth-sso-divider\` + \`.auth-sso-form\` rules
- \`frontend/tests/e2e/sso-initiate.spec.ts\` — new E2E covering toggle, redirect, disabled-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)