### PR TITLE
frontend: tenant member management UI (#162)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ const MapListPage          = lazy(() => import('@/pages/MapListPage').then((m)  
 const MapDetailPage        = lazy(() => import('@/pages/MapDetailPage').then((m)        => ({ default: m.MapDetailPage })));
 const VisibilityGroupsPage = lazy(() => import('@/pages/VisibilityGroupsPage').then((m) => ({ default: m.VisibilityGroupsPage })));
 const PlotsPage            = lazy(() => import('@/pages/PlotsPage').then((m)            => ({ default: m.PlotsPage })));
+const TenantMembersPage    = lazy(() => import('@/pages/TenantMembersPage').then((m)    => ({ default: m.TenantMembersPage })));
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
@@ -77,6 +78,16 @@ export default function App() {
                 element={
                   <PrivateRoute>
                     <PlotsPage />
+                  </PrivateRoute>
+                }
+              />
+
+              {/* Tenant member management (#162) */}
+              <Route
+                path="/tenants/:tenantId/members"
+                element={
+                  <PrivateRoute>
+                    <TenantMembersPage />
                   </PrivateRoute>
                 }
               />

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -31,6 +31,11 @@ export function Navbar() {
                 Plots
               </Link>
             )}
+            {tenantId && (
+              <Link to={`/tenants/${tenantId}/members`}>
+                Members
+              </Link>
+            )}
             <span className="navbar-user">{user?.username}</span>
             <button onClick={handleLogout} className="btn btn-ghost">
               Sign Out

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1019,3 +1019,42 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
   border-radius: 4px;
 }
 .node-popup-links { margin: .25rem 0; padding-left: 1.25rem; }
+
+/* ─── Tenant admin (members, branding) ──────────────────────────────────────── */
+.tenant-admin-section {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+}
+.tenant-admin-section h2 { font-size: 1.1rem; margin-bottom: 1rem; }
+.tenant-admin-form { display: flex; flex-direction: column; gap: 1rem; }
+.tenant-admin-actions { display: flex; gap: .5rem; }
+.form-hint { font-size: .8rem; color: var(--color-text-muted); }
+
+.member-list { list-style: none; display: flex; flex-direction: column; gap: .5rem; }
+.member-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.3fr) auto auto;
+  align-items: center;
+  gap: .75rem;
+  padding: .5rem .75rem;
+  background: var(--color-bg);
+  border-radius: var(--radius);
+}
+.member-name { font-weight: 500; }
+.member-email { color: var(--color-text-muted); font-size: .85rem; overflow: hidden; text-overflow: ellipsis; }
+.member-role {
+  font-size: .75rem;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  padding: .15rem .5rem;
+  border-radius: var(--radius);
+  background: var(--color-border);
+}
+.member-role-admin  { background: #fee2e2; color: #991b1b; }
+.member-role-editor { background: #dbeafe; color: #1e40af; }
+.member-role-viewer { background: #e2e8f0; color: #475569; }
+
+.btn-sm { padding: .25rem .5rem; font-size: .8rem; }

--- a/frontend/src/pages/TenantMembersPage.tsx
+++ b/frontend/src/pages/TenantMembersPage.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { tenantsService } from '@/services/maps';
+import { useAuthStore } from '@/store/authStore';
+import { extractApiError } from '@/utils/errors';
+import type { TenantMember } from '@/types';
+
+// Tenant-member management (#162). Lists current members, lets admins add
+// new ones (by userId — username/email-based picker is a natural follow-up
+// and is filed separately) and remove existing ones.
+//
+// Self-protection: admins cannot remove themselves if they're the last
+// admin in the tenant — the UI hides the "Remove" action on their own
+// row in that case (the backend would also reject, but the UI guard
+// prevents the wasted submission).
+//
+// Auth-gated by role; non-admins see an "access denied" banner.
+
+const ROLES = ['admin', 'editor', 'viewer'] as const;
+type Role = typeof ROLES[number];
+
+export function TenantMembersPage() {
+  const { tenantId } = useParams<{ tenantId: string }>();
+  const tenantIdNum = Number(tenantId);
+
+  const role = useAuthStore((s) =>
+    s.tenants.find((t) => t.id === tenantIdNum)?.role,
+  );
+  const callerUserId = useAuthStore((s) => s.user?.id);
+  const isAdmin = role === 'admin';
+
+  const [members, setMembers] = useState<TenantMember[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = async () => {
+    try {
+      const fresh = await tenantsService.listMembers(tenantIdNum);
+      setMembers(fresh);
+      setError(null);
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to load tenant members.'));
+    }
+  };
+
+  useEffect(() => {
+    if (!tenantIdNum || !isAdmin) { setLoading(false); return; }
+    let cancelled = false;
+    setLoading(true);
+    tenantsService.listMembers(tenantIdNum)
+      .then((m) => { if (!cancelled) setMembers(m); })
+      .catch((e) => { if (!cancelled) setError(extractApiError(e, 'Failed to load tenant members.')); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [tenantIdNum, isAdmin]);
+
+  if (!tenantIdNum) {
+    return <div className="page-error">Missing tenant in route.</div>;
+  }
+  if (!isAdmin) {
+    return (
+      <div className="page-container">
+        <div className="page-header">
+          <h1>Tenant members</h1>
+          <Link to={`/tenants/${tenantId}/maps`} className="btn btn-ghost">
+            ← Back to maps
+          </Link>
+        </div>
+        <div className="alert alert-error">
+          Only tenant admins can manage members.
+        </div>
+      </div>
+    );
+  }
+  if (loading) return <div className="page-loading">Loading members…</div>;
+
+  const adminCount = members.filter((m) => m.role === 'admin').length;
+
+  const handleRemove = async (m: TenantMember) => {
+    const isSelf = m.userId === callerUserId;
+    const isLastAdmin = m.role === 'admin' && adminCount === 1;
+    if (isLastAdmin) {
+      window.alert('Cannot remove the last admin — promote another admin first.');
+      return;
+    }
+    const confirmMsg = isSelf
+      ? 'Remove yourself from this tenant? You will lose access.'
+      : `Remove ${m.username} from this tenant?`;
+    if (!window.confirm(confirmMsg)) return;
+    try {
+      await tenantsService.removeMember(tenantIdNum, m.userId);
+      await reload();
+    } catch (e) {
+      window.alert(extractApiError(e, 'Failed to remove member.'));
+    }
+  };
+
+  return (
+    <div className="page-container">
+      <div className="page-header">
+        <h1>Tenant members</h1>
+        <Link to={`/tenants/${tenantId}/maps`} className="btn btn-ghost">
+          ← Back to maps
+        </Link>
+      </div>
+      {error && <div className="alert alert-error">{error}</div>}
+
+      <section className="tenant-admin-section">
+        <h2>Current members ({members.length})</h2>
+        {members.length === 0 ? (
+          <p className="empty-state">No members yet.</p>
+        ) : (
+          <ul className="member-list">
+            {members.map((m) => {
+              const isSelf = m.userId === callerUserId;
+              const isLastAdmin = m.role === 'admin' && adminCount === 1;
+              return (
+                <li key={m.userId} className="member-row">
+                  <span className="member-name">
+                    {m.username}{isSelf && ' (you)'}
+                  </span>
+                  <span className="member-email">{m.email}</span>
+                  <span className={`member-role member-role-${m.role}`}>{m.role}</span>
+                  <button
+                    type="button"
+                    className="btn btn-ghost btn-sm"
+                    onClick={() => handleRemove(m)}
+                    disabled={isLastAdmin}
+                    title={isLastAdmin ? 'Cannot remove the last admin' : undefined}
+                  >
+                    Remove
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <AddMemberSection tenantId={tenantIdNum} onAdded={reload} />
+    </div>
+  );
+}
+
+// ─── Add-member form ─────────────────────────────────────────────────────────
+
+function AddMemberSection({
+  tenantId,
+  onAdded,
+}: { tenantId: number; onAdded: () => Promise<void> | void }) {
+  const [userId, setUserId] = useState('');
+  const [role, setRole] = useState<Role>('viewer');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const idNum = Number(userId);
+    if (!Number.isInteger(idNum) || idNum <= 0) {
+      setError('User ID must be a positive integer.');
+      return;
+    }
+    setError(null);
+    setSaving(true);
+    try {
+      await tenantsService.addMember(tenantId, idNum, role);
+      setUserId('');
+      setRole('viewer');
+      await onAdded();
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to add member.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="tenant-admin-section">
+      <h2>Add member</h2>
+      <form className="tenant-admin-form" onSubmit={handleSubmit}>
+        {error && <div className="alert alert-error">{error}</div>}
+        <div className="form-group">
+          <label htmlFor="add-userid">User ID</label>
+          <input
+            id="add-userid"
+            inputMode="numeric"
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+            placeholder="42"
+            required
+          />
+          {/* The backend addMember endpoint takes a numeric user id; the
+              email-or-username picker is intentionally a follow-up
+              (would need a backend user-lookup endpoint that doesn't
+              exist yet). */}
+          <small className="form-hint">
+            The user must already have an account in the same organization.
+            Username/email-based lookup is a planned follow-up.
+          </small>
+        </div>
+        <div className="form-group">
+          <label htmlFor="add-role">Role</label>
+          <select
+            id="add-role"
+            value={role}
+            onChange={(e) => setRole(e.target.value as Role)}
+          >
+            {ROLES.map((r) => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
+        </div>
+        <div className="tenant-admin-actions">
+          <button type="submit" className="btn btn-primary" disabled={saving}>
+            {saving ? 'Adding…' : 'Add member'}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/frontend/tests/e2e/tenant-members.spec.ts
+++ b/frontend/tests/e2e/tenant-members.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import {
+  registerViaApi,
+  seedAuthInBrowser,
+  mysqlQuery,
+} from './helpers';
+
+/**
+ * E2E coverage for #162: tenant member management UI.
+ */
+
+test.describe('Tenant member management (#162)', () => {
+  test('admin sees the member list and can add a same-org user, then remove them', async ({ page, request }) => {
+    const apiA = await registerViaApi(request, 'tm_admin');
+    const apiB = await registerViaApi(request, 'tm_target');
+
+    // Move B into A's org so the cross-org check at the backend allows the
+    // add. (A is admin of their personal tenant by default; B starts in
+    // their own org.)
+    const aOrgId = mysqlQuery(`SELECT org_id FROM users WHERE id=${apiA.user.id};`);
+    mysqlQuery(`UPDATE users SET org_id=${aOrgId} WHERE id=${apiB.user.id};`);
+
+    await seedAuthInBrowser(page, apiA);
+    await page.goto(`/tenants/${apiA.tenantId}/members`);
+
+    // The current admin (A) is the only member to start.
+    await expect(page.getByRole('heading', { name: /Tenant members/i })).toBeVisible();
+    await expect(page.locator('.member-row')).toHaveCount(1);
+    await expect(
+      page.locator('.member-row').filter({ hasText: apiA.user.username }),
+    ).toBeVisible();
+
+    // The admin's own Remove button is disabled (last admin).
+    const ownRow = page.locator('.member-row').filter({ hasText: apiA.user.username });
+    await expect(ownRow.getByRole('button', { name: /^remove$/i })).toBeDisabled();
+
+    // Add B as viewer.
+    await page.getByLabel(/^user id$/i).fill(String(apiB.user.id));
+    await page.getByLabel(/^role$/i).selectOption('viewer');
+    await page.getByRole('button', { name: /add member/i }).click();
+
+    // Member list now has both A and B.
+    await expect(page.locator('.member-row')).toHaveCount(2);
+    const bRow = page.locator('.member-row').filter({ hasText: apiB.user.username });
+    await expect(bRow).toBeVisible();
+    await expect(bRow.getByText(/^viewer$/i)).toBeVisible();
+
+    // Remove B (auto-accept the confirm dialog).
+    page.once('dialog', (d) => d.accept());
+    await bRow.getByRole('button', { name: /^remove$/i }).click();
+    await expect(page.locator('.member-row')).toHaveCount(1);
+  });
+
+  test('non-admin viewer sees an access-denied banner', async ({ page, request }) => {
+    const apiA = await registerViaApi(request, 'tm_admin2');
+    const apiB = await registerViaApi(request, 'tm_viewer');
+
+    // Add B to A's tenant as viewer (via SQL fixture; same as visibility tests).
+    const aOrgId = mysqlQuery(`SELECT org_id FROM users WHERE id=${apiA.user.id};`);
+    mysqlQuery(`UPDATE users SET org_id=${aOrgId} WHERE id=${apiB.user.id};`);
+    mysqlQuery(
+      `INSERT INTO tenant_members (tenant_id, user_id, role) ` +
+      `VALUES (${apiA.tenantId}, ${apiB.user.id}, 'viewer');`
+    );
+
+    // Seed B's session, but with the active tenant set to A's tenant + role=viewer.
+    await seedAuthInBrowser(page, apiB, { id: apiA.tenantId, role: 'viewer' });
+    await page.goto(`/tenants/${apiA.tenantId}/members`);
+
+    await expect(
+      page.getByText(/only tenant admins can manage members/i),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #162. Adds TenantMembersPage at \`/tenants/{tid}/members\` with list, add-member, and remove-member affordances. Page is admin-role-gated.

## Why

Backend's tenant-members CRUD has been live since the rebuild; it was being called only from VisibilityGroupsPage's \"add member\" dropdown to populate candidates. There was no dedicated UI to add a *new* user to the tenant or remove an existing one — admin operations had to go through the API.

## Functionality

- **List**: each member as a row (username + (you) marker if it's the caller, email, role badge, Remove button)
- **Add**: form with userId (numeric) + role (admin/editor/viewer dropdown). Posts → reloads list.
- **Remove**: confirm dialog → DELETE → reloads list.
- **Self-protection**: the caller's own Remove button is disabled if they're the last admin. Backend also enforces this; the UI guard prevents the wasted submission.
- **Permission gate**: non-admins see an \"Only tenant admins can manage members\" banner (the page page ungates the data fetch only when role==='admin').

## Why userId numeric, not email/username?

The backend's \`POST /tenants/{tid}/members\` takes a numeric \`userId\`. There's no \`GET /users/search?q=...\` or similar endpoint to resolve email → userId. Adding one would expand the scope of this PR; the form copy explicitly notes the limitation as a planned follow-up. For an admin tool exercised by people who already know each other's user IDs, this is acceptable v1.

## Layout choice

Per the ticket, the page can either be a separate route or co-located with #163's TenantAdminPage. **Separate route** chosen to avoid a merge conflict between this PR and #204 (#163 branding). Future consolidation into one tenant-admin surface is straightforward (move both into TenantAdminPage as sibling sections, drop one of the routes).

## Tested

\`frontend/tests/e2e/tenant-members.spec.ts\` — 2/2 pass:

1. **Admin happy path**: register admin A and target user B; SQL-fixture B into A's org; A sees themselves only in the member list with last-admin Remove disabled; A adds B as viewer; list shows both; A removes B; list shrinks back.
2. **Non-admin access-denied**: register A and B; SQL-fixture B as a viewer in A's tenant; seed B's session with role=viewer on A's tenant; navigate to /members; assert the access-denied banner.

## Test plan

- [x] tsc + lint clean
- [x] \`npx playwright test tenant-members\` → 2/2 pass
- [x] Per §4b-2: new UI page ships with E2E in the same PR

## Operational impact

No restart, rebuild, or migration needed. Frontend HMR.

## Work breakdown

1. Read ticket + check tenantsService signatures (listMembers, addMember (userId), removeMember)
2. Check backend's addMember body shape — confirms userId numeric + role required; no user-search endpoint exists, so form takes numeric userId with a copy note
3. Decide page location: separate route to avoid conflict with #204
4. TenantMembersPage with role gate, list section, add-member form, last-admin self-protection
5. Navbar \"Members\" link
6. CSS for member rows + role badges (admin/editor/viewer color coding) + .form-hint + .btn-sm
7. E2E: admin happy path + non-admin access-denied
8. tsc + lint + spec → green
9. Commit + push + open PR

## Files changed

- \`frontend/src/App.tsx\` — lazy import + route for \`/tenants/:tenantId/members\`
- \`frontend/src/components/Layout/Navbar.tsx\` — add \"Members\" link
- \`frontend/src/index.css\` — \`.tenant-admin-section\`, \`.member-list\`, \`.member-row\`, \`.member-role-*\`, \`.form-hint\`, \`.btn-sm\` rules
- \`frontend/src/pages/TenantMembersPage.tsx\` — new page with role gate + list + AddMemberSection
- \`frontend/tests/e2e/tenant-members.spec.ts\` — new E2E covering admin happy path and viewer access-denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)