### PR TITLE
frontend: map sharing / permissions UI on MapDetailPage (#161)

### DIFF
--- a/frontend/src/components/Map/MapSharingModal.tsx
+++ b/frontend/src/components/Map/MapSharingModal.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useState } from 'react';
+import { permissionsService, tenantsService } from '@/services/maps';
+import { useAuthStore } from '@/store/authStore';
+import { extractApiError } from '@/utils/errors';
+import type { MapPermission, PermissionLevel, TenantMember } from '@/types';
+
+// Map sharing / permissions modal (#161). Map owner only — opens from
+// the "Share" button on MapDetailPage. Lists current per-user grants
+// plus the public-access row (userId === null), allows add / change-
+// level / revoke for each, and exposes a separate public toggle.
+//
+// Backend's setPermission requires the target user to be in the same
+// org as the caller; the user-pick dropdown filters tenant members not
+// already granted to keep the choices valid.
+
+const LEVELS: PermissionLevel[] = ['view', 'comment', 'edit', 'moderate', 'admin'];
+
+interface Props {
+  mapId: number;
+  onClose: () => void;
+}
+
+export function MapSharingModal({ mapId, onClose }: Props) {
+  const tenantId = useAuthStore((s) => s.tenantId);
+  const [perms, setPerms] = useState<MapPermission[]>([]);
+  const [members, setMembers] = useState<TenantMember[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = async () => {
+    try {
+      const fresh = await permissionsService.listPermissions(mapId);
+      setPerms(fresh);
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to load permissions.'));
+    }
+  };
+
+  useEffect(() => {
+    if (!tenantId) return;
+    let cancelled = false;
+    setLoading(true);
+    // listPermissions: required for the modal; failure aborts.
+    // listMembers: best-effort to populate the user dropdown — non-admins
+    // get 403 from the backend, so we fall back to a numeric userId input
+    // (the cross-org check still happens server-side on grant).
+    Promise.all([
+      permissionsService.listPermissions(mapId),
+      tenantsService.listMembers(tenantId).catch(() => [] as TenantMember[]),
+    ])
+      .then(([pp, mm]) => {
+        if (cancelled) return;
+        setPerms(pp);
+        setMembers(mm);
+      })
+      .catch((e) => { if (!cancelled) setError(extractApiError(e, 'Failed to load permissions.')); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [mapId, tenantId]);
+
+  const publicPerm = perms.find((p) => p.userId === null) ?? null;
+  const userPerms = perms.filter((p) => p.userId !== null);
+
+  const handleSetLevel = async (userId: number | null, level: PermissionLevel) => {
+    setError(null);
+    try {
+      await permissionsService.setPermission(mapId, { userId, level });
+      await reload();
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to update permission.'));
+    }
+  };
+
+  const handleRemove = async (userId: number | null, label: string) => {
+    if (!window.confirm(`Revoke ${label}'s access to this map?`)) return;
+    setError(null);
+    try {
+      await permissionsService.removePermission(mapId, userId);
+      await reload();
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to revoke permission.'));
+    }
+  };
+
+  const handleTogglePublic = async () => {
+    setError(null);
+    try {
+      if (publicPerm) {
+        await permissionsService.removePermission(mapId, null);
+      } else {
+        await permissionsService.setPermission(mapId, { userId: null, level: 'view' });
+      }
+      await reload();
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to toggle public access.'));
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()} role="dialog">
+        <h2>Sharing</h2>
+        {error && <div className="alert alert-error">{error}</div>}
+
+        {loading ? (
+          <p className="page-loading">Loading permissions…</p>
+        ) : (
+          <>
+            {/* Public toggle */}
+            <section className="sharing-section">
+              <h3>Public access</h3>
+              <label className="sharing-public-toggle">
+                <input
+                  type="checkbox"
+                  checked={publicPerm !== null}
+                  onChange={handleTogglePublic}
+                />
+                Anyone with the link can view
+              </label>
+            </section>
+
+            {/* Per-user grants */}
+            <section className="sharing-section">
+              <h3>People</h3>
+              {userPerms.length === 0 ? (
+                <p className="sharing-empty">No one else has access yet.</p>
+              ) : (
+                <ul className="sharing-grant-list">
+                  {userPerms.map((p) => (
+                    <li key={p.id} className="sharing-grant-row">
+                      <span className="sharing-grant-name">
+                        {p.username ?? `user #${p.userId}`}
+                      </span>
+                      <select
+                        value={p.level}
+                        onChange={(e) =>
+                          handleSetLevel(p.userId, e.target.value as PermissionLevel)
+                        }
+                        aria-label={`Level for ${p.username ?? p.userId}`}
+                      >
+                        {LEVELS.map((lvl) => (
+                          <option key={lvl} value={lvl}>{lvl}</option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        className="btn btn-ghost btn-sm"
+                        onClick={() =>
+                          handleRemove(p.userId, p.username ?? `user #${p.userId}`)
+                        }
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              <AddGrantForm
+                members={members}
+                userPerms={userPerms}
+                onGrant={(userId, level) => handleSetLevel(userId, level)}
+              />
+            </section>
+          </>
+        )}
+
+        <div className="modal-actions">
+          <button type="button" className="btn btn-ghost" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Add-grant form ──────────────────────────────────────────────────────────
+
+interface AddGrantFormProps {
+  members: TenantMember[];
+  userPerms: MapPermission[];
+  onGrant: (userId: number, level: PermissionLevel) => Promise<void> | void;
+}
+
+function AddGrantForm({ members, userPerms, onGrant }: AddGrantFormProps) {
+  const [userId, setUserId] = useState('');
+  const [level, setLevel] = useState<PermissionLevel>('view');
+  const [submitting, setSubmitting] = useState(false);
+
+  // Filter out members already granted; the dropdown is the source of
+  // truth when the listMembers call succeeded. If members list is empty
+  // (call failed or no admin role on the tenant), fall back to a
+  // numeric userId input.
+  const grantedIds = new Set(userPerms.map((p) => p.userId));
+  const candidates = members.filter((m) => !grantedIds.has(m.userId));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const idNum = Number(userId);
+    if (!Number.isInteger(idNum) || idNum <= 0) return;
+    setSubmitting(true);
+    try {
+      await onGrant(idNum, level);
+      setUserId('');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="sharing-add-form" onSubmit={handleSubmit}>
+      {candidates.length > 0 ? (
+        <select
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          required
+          aria-label="User to grant access"
+        >
+          <option value="">Choose a tenant member…</option>
+          {candidates.map((m) => (
+            <option key={m.userId} value={String(m.userId)}>
+              {m.username} ({m.email})
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          type="text"
+          inputMode="numeric"
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          placeholder="User ID"
+          required
+          aria-label="User ID to grant access"
+        />
+      )}
+      <select
+        value={level}
+        onChange={(e) => setLevel(e.target.value as PermissionLevel)}
+        aria-label="Permission level"
+      >
+        {LEVELS.map((lvl) => (
+          <option key={lvl} value={lvl}>{lvl}</option>
+        ))}
+      </select>
+      <button
+        type="submit"
+        className="btn btn-primary btn-sm"
+        disabled={submitting || !userId}
+      >
+        Grant
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1019,3 +1019,30 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
   border-radius: 4px;
 }
 .node-popup-links { margin: .25rem 0; padding-left: 1.25rem; }
+
+/* ─── Map sharing modal (#161) ──────────────────────────────────────────────── */
+.sharing-section { margin: 1rem 0; }
+.sharing-section h3 { font-size: .95rem; margin-bottom: .5rem; color: var(--color-text-muted); }
+.sharing-public-toggle {
+  display: flex; align-items: center; gap: .5rem; font-size: .875rem;
+}
+.sharing-empty { color: var(--color-text-muted); font-size: .85rem; }
+.sharing-grant-list { list-style: none; display: flex; flex-direction: column; gap: .35rem; }
+.sharing-grant-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: .5rem;
+  padding: .35rem .5rem;
+  background: var(--color-bg);
+  border-radius: var(--radius);
+}
+.sharing-grant-name { font-weight: 500; overflow: hidden; text-overflow: ellipsis; }
+.sharing-add-form {
+  display: flex; gap: .5rem; align-items: center; margin-top: .75rem;
+  flex-wrap: wrap;
+}
+.sharing-add-form select, .sharing-add-form input {
+  padding: .35rem .5rem; border: 1px solid var(--color-border); border-radius: var(--radius);
+}
+.sharing-add-form select { flex: 1; min-width: 12rem; }

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { MapView } from '@/components/Map/MapView';
+import { MapSharingModal } from '@/components/Map/MapSharingModal';
 import { NodeTreePanel } from '@/components/Tree/NodeTreePanel';
 import { NodeDetailPanel } from '@/components/Detail/NodeDetailPanel';
 import { useMap } from '@/hooks/useMap';
@@ -33,6 +34,7 @@ export function MapDetailPage() {
   const [panTarget, setPanTarget] = useState<[number, number] | null>(null);
   const [xraySaving, setXraySaving] = useState(false);
   const [xrayError, setXrayError] = useState<string | null>(null);
+  const [showSharing, setShowSharing] = useState(false);
   const currentUserId = useAuthStore((s) => s.user?.id);
 
   useEffect(() => {
@@ -111,6 +113,16 @@ export function MapDetailPage() {
             <button
               type="button"
               className="btn btn-ghost"
+              onClick={() => setShowSharing(true)}
+              title="Manage who can view and edit this map"
+            >
+              Share
+            </button>
+          )}
+          {isOwner && (
+            <button
+              type="button"
+              className="btn btn-ghost"
               onClick={handleDeleteMap}
               title="Delete this map (and all its locations + notes)"
             >
@@ -147,6 +159,12 @@ export function MapDetailPage() {
       <button className="btn btn-ghost" onClick={() => navigate(`/tenants/${tenantId}/maps`)}>
         Back to maps
       </button>
+      {showSharing && (
+        <MapSharingModal
+          mapId={activeMap.id}
+          onClose={() => setShowSharing(false)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/tests/e2e/map-sharing.spec.ts
+++ b/frontend/tests/e2e/map-sharing.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from '@playwright/test';
+import {
+  registerViaApi,
+  createMapViaApi,
+  seedAuthInBrowser,
+  mysqlQuery,
+  API_URL,
+} from './helpers';
+
+/**
+ * E2E coverage for #161: map sharing / permissions UI on the
+ * MapDetailPage "Share" button.
+ *
+ * Backend permission semantics already covered in test_03_maps.py and
+ * test_28_permissions.py (#177). This spec asserts the UI wiring:
+ * modal opens, public toggle, grant + revoke per-user, dropdown
+ * filters out already-granted users.
+ */
+
+test.describe('Map sharing modal (#161)', () => {
+  test('owner toggles public access on, then off', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'share_pub');
+    const map = await createMapViaApi(request, api, 'PublicMap', {
+      type: 'wgs84', center: { lat: 0, lng: 0 }, zoom: 3,
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    await page.getByRole('button', { name: /^share$/i }).click();
+    await expect(page.getByRole('heading', { name: /^sharing$/i })).toBeVisible();
+
+    const publicToggle = page.getByRole('checkbox', {
+      name: /anyone with the link can view/i,
+    });
+    await expect(publicToggle).not.toBeChecked();
+
+    await publicToggle.click();
+    await expect(publicToggle).toBeChecked();
+
+    // Confirm via direct API call: public row exists in /permissions
+    const res = await request.get(
+      `${API_URL}/tenants/${api.tenantId}/maps/${map.id}/permissions`,
+      { headers: { Authorization: `Bearer ${api.token}` } },
+    );
+    const perms = await res.json();
+    expect(perms.some((p: { userId: number | null }) => p.userId === null)).toBe(true);
+
+    // Toggle off
+    await publicToggle.click();
+    await expect(publicToggle).not.toBeChecked();
+  });
+
+  test('owner grants view to a same-org tenant member; per-user grant appears', async ({ page, request }) => {
+    const apiA = await registerViaApi(request, 'share_owner');
+    const apiB = await registerViaApi(request, 'share_target');
+
+    // Move B into A's org + tenant via SQL fixture so the cross-org check
+    // passes and B shows up in the listMembers dropdown.
+    const aOrgId = mysqlQuery(`SELECT org_id FROM users WHERE id=${apiA.user.id};`);
+    mysqlQuery(`UPDATE users SET org_id=${aOrgId} WHERE id=${apiB.user.id};`);
+    mysqlQuery(
+      `INSERT INTO tenant_members (tenant_id, user_id, role) ` +
+      `VALUES (${apiA.tenantId}, ${apiB.user.id}, 'viewer');`
+    );
+
+    const map = await createMapViaApi(request, apiA, 'SharedMap', {
+      type: 'wgs84', center: { lat: 0, lng: 0 }, zoom: 3,
+    });
+
+    await seedAuthInBrowser(page, apiA);
+    await page.goto(`/tenants/${apiA.tenantId}/maps/${map.id}`);
+
+    await page.getByRole('button', { name: /^share$/i }).click();
+    await expect(page.getByRole('heading', { name: /^sharing$/i })).toBeVisible();
+    await expect(page.getByText(/no one else has access yet/i)).toBeVisible();
+
+    // Pick B from the dropdown, level=view (default), submit
+    await page
+      .getByRole('combobox', { name: /user to grant access/i })
+      .selectOption(String(apiB.user.id));
+    await page.getByRole('button', { name: /^grant$/i }).click();
+
+    // The grant row appears with B's username and level=view
+    const bRow = page.locator('.sharing-grant-row').filter({ hasText: apiB.user.username });
+    await expect(bRow).toBeVisible();
+    await expect(bRow.getByRole('combobox')).toHaveValue('view');
+
+    // Revoke (auto-accept the confirm dialog)
+    page.once('dialog', (d) => d.accept());
+    await bRow.getByRole('button', { name: /^remove$/i }).click();
+    await expect(page.locator('.sharing-grant-row')).toHaveCount(0);
+  });
+
+  test('non-owner does not see the Share button', async ({ page, request }) => {
+    const apiA = await registerViaApi(request, 'share_nonowner_a');
+    const apiB = await registerViaApi(request, 'share_nonowner_b');
+    const aOrgId = mysqlQuery(`SELECT org_id FROM users WHERE id=${apiA.user.id};`);
+    mysqlQuery(`UPDATE users SET org_id=${aOrgId} WHERE id=${apiB.user.id};`);
+    mysqlQuery(
+      `INSERT INTO tenant_members (tenant_id, user_id, role) ` +
+      `VALUES (${apiA.tenantId}, ${apiB.user.id}, 'viewer');`
+    );
+
+    const map = await createMapViaApi(request, apiA, 'NonOwnerMap', {
+      type: 'wgs84', center: { lat: 0, lng: 0 }, zoom: 3,
+    });
+
+    // Grant B view so they can load the map detail page
+    await request.put(
+      `${API_URL}/tenants/${apiA.tenantId}/maps/${map.id}/permissions`,
+      {
+        headers: { Authorization: `Bearer ${apiA.token}` },
+        data: { userId: apiB.user.id, level: 'view' },
+      },
+    );
+
+    await seedAuthInBrowser(page, apiB, { id: apiA.tenantId, role: 'viewer' });
+    await page.goto(`/tenants/${apiA.tenantId}/maps/${map.id}`);
+
+    // Map loads (B has view perm)
+    await expect(page.getByRole('heading', { name: 'NonOwnerMap' })).toBeVisible();
+    // But Share is not in the header — only owners get it
+    await expect(page.getByRole('button', { name: /^share$/i })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #161. Adds a \"Share\" button to the MapDetailPage header (owner-only) that opens MapSharingModal — list, grant, change-level, revoke, public toggle. Backend's per-map permissions API has been live since the rebuild; this PR is purely the missing frontend.

## Why

Single-user / single-tenant workflows aren't blocked, but multi-user collaboration requires this. The pre-rebuild app had a sharing UI; the rebuild dropped it. Without this, granting another user view/edit access requires manual API calls.

## UX

- **Header button**: \"Share\" appears only if the caller is the map owner. Backend also enforces (403 on non-owner setPermission); the UI guard avoids a misleading button.
- **Modal sections**:
  - **Public access**: a single checkbox \"Anyone with the link can view\". Toggling on POSTs with \`userId: null, level: 'view'\`; toggling off DELETEs the public row.
  - **People**: list of per-user grants. Each row: username (or \"user #N\" if username didn't load), inline level dropdown that PUTs on change, Remove button that DELETEs after a confirm.
  - **Add-grant form**: dropdown of tenant members filtered to exclude already-granted users + level dropdown + Grant button. Falls back to a numeric userId input if the \`listMembers\` call fails (non-admin caller; cross-org check still happens server-side on submit).
- **Layout**: modal lives at \`src/components/Map/MapSharingModal.tsx\` — co-located with MapView for tighter locality with the page that opens it.

## Tested

\`frontend/tests/e2e/map-sharing.spec.ts\` — 3/3 pass:

1. **Public toggle**: open Share → check \"Anyone with the link can view\" → assert via direct API the public row exists → uncheck → toggle clears
2. **Per-user grant + revoke**: SQL-fixture user B into A's org; A opens Share, picks B from dropdown at level=view, clicks Grant; row appears with the correct level; click Remove (auto-accept confirm); list empties
3. **Non-owner**: B has view-level access on A's map; B navigates to the detail page (loads fine); the Share button is *not* in the header

## Test plan

- [x] tsc + lint clean
- [x] \`npx playwright test map-sharing\` → 3/3 pass
- [x] Per §4b-2: new UI surface ships with E2E in the same PR

## Operational impact

No restart, rebuild, or migration needed. Frontend HMR.

## Work breakdown

1. Read ticket #161 + locate \`permissionsService\` (already wired: listPermissions, setPermission, removePermission with userId-or-public path coercion)
2. Decide layout: modal opening from MapDetailPage header (cleaner than separate route per the ticket)
3. Build \`MapSharingModal\`:
   - \`useEffect\` Promise.all for permissions + tenant members; tenant members fail-soft to numeric-input fallback
   - Public row split out from per-user rows by \`p.userId === null\`
   - Inline level dropdown + Remove + AddGrantForm
4. Wire Share button into MapDetailPage header (owner-only); modal toggled by \`showSharing\` state
5. Initial bug: \`tenantsService.listMembers(0)\` was a placeholder; replaced with \`useAuthStore(s => s.tenantId)\` to get the real tenant
6. CSS: \`.sharing-section\`, \`.sharing-grant-list\`, \`.sharing-grant-row\`, \`.sharing-add-form\`
7. E2E: public toggle, grant+revoke, non-owner-no-button
8. tsc + lint + spec → green
9. Commit + push + open PR

## Files changed

- \`frontend/src/components/Map/MapSharingModal.tsx\` — new modal with permissions list, public toggle, grant/revoke/level-change, add-grant form with member dropdown + numeric-input fallback
- \`frontend/src/index.css\` — \`.sharing-*\` rules for the modal
- \`frontend/src/pages/MapDetailPage.tsx\` — add \"Share\" button (owner-only) that opens the modal
- \`frontend/tests/e2e/map-sharing.spec.ts\` — new E2E covering public toggle, grant+revoke round-trip, and non-owner Share-button absence

🤖 Generated with [Claude Code](https://claude.com/claude-code)