### PR TITLE
Block last-admin self-demotion (#214, audit #46 M2)

### DIFF
--- a/backend/src/controllers/TenantController.cpp
+++ b/backend/src/controllers/TenantController.cpp
@@ -261,6 +261,7 @@ void TenantController::addMember(
 
     int         targetUserId = (*body)["userId"].asInt();
     std::string role         = (*body)["role"].asString();
+    int         callerId     = req->getAttributes()->get<int>("userId");
 
     if (role != "admin" && role != "editor" && role != "viewer") {
         auto resp = drogon::HttpResponse::newHttpJsonResponse(
@@ -270,55 +271,86 @@ void TenantController::addMember(
         return;
     }
 
-    // Verify target user is in the same org as this tenant
-    auto db = drogon::app().getDbClient();
-    db->execSqlAsync(
-        "SELECT u.id FROM users u "
-        "JOIN tenants t ON t.org_id = u.org_id "
-        "WHERE t.id = ? AND u.id = ? LIMIT 1",
-        [callback, req, tenantId, targetUserId, role](const drogon::orm::Result& r) {
-            if (r.empty()) {
-                auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                    errorJson("bad_request", "Target user is not in this organization"));
-                resp->setStatusCode(drogon::k400BadRequest);
-                callback(resp);
-                return;
-            }
-
-            int callerId = 0;
-            try { callerId = req->getAttributes()->get<int>("userId"); } catch (...) {}
-
-            auto db2 = drogon::app().getDbClient();
-            db2->execSqlAsync(
-                "INSERT INTO tenant_members (tenant_id, user_id, role) "
-                "VALUES (?,?,?) "
-                "ON DUPLICATE KEY UPDATE role=VALUES(role)",
-                [callback, req, callerId, tenantId, targetUserId, role](const drogon::orm::Result&) {
-                    Json::Value detail; detail["role"] = role;
-                    AuditLog::record("member_add", req, callerId, targetUserId, tenantId, detail);
-                    Json::Value v;
-                    v["userId"] = targetUserId;
-                    v["role"]   = role;
-                    v["added"]  = true;
-                    auto resp = drogon::HttpResponse::newHttpJsonResponse(v);
-                    resp->setStatusCode(drogon::k201Created);
-                    callback(resp);
-                },
-                [callback](const drogon::orm::DrogonDbException&) {
+    // Continuation: existing org-membership check + INSERT/UPDATE.
+    auto proceed = [callback, req, tenantId, callerId, targetUserId, role]() {
+        auto dbInner = drogon::app().getDbClient();
+        dbInner->execSqlAsync(
+            "SELECT u.id FROM users u "
+            "JOIN tenants t ON t.org_id = u.org_id "
+            "WHERE t.id = ? AND u.id = ? LIMIT 1",
+            [callback, req, tenantId, callerId, targetUserId, role](const drogon::orm::Result& r) {
+                if (r.empty()) {
                     auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                        errorJson("db_error", "Failed to add member"));
-                    resp->setStatusCode(drogon::k500InternalServerError);
+                        errorJson("bad_request", "Target user is not in this organization"));
+                    resp->setStatusCode(drogon::k400BadRequest);
                     callback(resp);
-                },
-                tenantId, targetUserId, role);
-        },
-        [callback](const drogon::orm::DrogonDbException&) {
-            auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                errorJson("db_error", "Database error"));
-            resp->setStatusCode(drogon::k500InternalServerError);
-            callback(resp);
-        },
-        tenantId, targetUserId);
+                    return;
+                }
+                auto db2 = drogon::app().getDbClient();
+                db2->execSqlAsync(
+                    "INSERT INTO tenant_members (tenant_id, user_id, role) "
+                    "VALUES (?,?,?) "
+                    "ON DUPLICATE KEY UPDATE role=VALUES(role)",
+                    [callback, req, callerId, tenantId, targetUserId, role](const drogon::orm::Result&) {
+                        Json::Value detail; detail["role"] = role;
+                        AuditLog::record("member_add", req, callerId, targetUserId, tenantId, detail);
+                        Json::Value v;
+                        v["userId"] = targetUserId;
+                        v["role"]   = role;
+                        v["added"]  = true;
+                        auto resp = drogon::HttpResponse::newHttpJsonResponse(v);
+                        resp->setStatusCode(drogon::k201Created);
+                        callback(resp);
+                    },
+                    [callback](const drogon::orm::DrogonDbException&) {
+                        auto resp = drogon::HttpResponse::newHttpJsonResponse(
+                            errorJson("db_error", "Failed to add member"));
+                        resp->setStatusCode(drogon::k500InternalServerError);
+                        callback(resp);
+                    },
+                    tenantId, targetUserId, role);
+            },
+            [callback](const drogon::orm::DrogonDbException&) {
+                auto resp = drogon::HttpResponse::newHttpJsonResponse(
+                    errorJson("db_error", "Database error"));
+                resp->setStatusCode(drogon::k500InternalServerError);
+                callback(resp);
+            },
+            tenantId, targetUserId);
+    };
+
+    // Self-demote guard: if the caller is targeting themselves with a
+    // non-admin role and they're the only admin, refuse — there's no
+    // API-only path to recover (removeMember blocks self-removal, no
+    // role-change endpoint exists), so the tenant would be orphaned.
+    if (targetUserId == callerId && role != "admin") {
+        auto db = drogon::app().getDbClient();
+        db->execSqlAsync(
+            "SELECT COUNT(*) AS c FROM tenant_members "
+            "WHERE tenant_id = ? AND role = 'admin'",
+            [callback, proceed](const drogon::orm::Result& r) {
+                int adminCount = r[0]["c"].as<int>();
+                if (adminCount <= 1) {
+                    auto resp = drogon::HttpResponse::newHttpJsonResponse(
+                        errorJson("bad_request",
+                            "Cannot demote the last admin; promote another admin first"));
+                    resp->setStatusCode(drogon::k400BadRequest);
+                    callback(resp);
+                    return;
+                }
+                proceed();
+            },
+            [callback](const drogon::orm::DrogonDbException&) {
+                auto resp = drogon::HttpResponse::newHttpJsonResponse(
+                    errorJson("db_error", "Database error"));
+                resp->setStatusCode(drogon::k500InternalServerError);
+                callback(resp);
+            },
+            tenantId);
+        return;
+    }
+
+    proceed();
 }
 
 // ─── DELETE /api/v1/tenants/{tenantId}/members/{userId} ───────────────────────

--- a/backend/tests/test_05_tenants.py
+++ b/backend/tests/test_05_tenants.py
@@ -87,6 +87,45 @@ assert_status("addMember: invalid role returns 400", 400, status)
 
 print("  All member add tests passed.")
 
+# ─── Self-demote guard (#214) ────────────────────────────────────────────────
+
+print("  --- Self-demote guard (#214) ---")
+
+# Last-admin self-demote must be rejected. ADMIN is currently the only
+# admin in the tenant (COLLEAGUE was added as editor above).
+status, _ = http_post(f"/tenants/{TENANT_ID}/members",
+                      {"userId": ADMIN_ID, "role": "viewer"}, TOKEN_ADMIN)
+assert_status("addMember: last-admin self-demote returns 400", 400, status)
+
+# Self-promote-to-admin (no-op) is a self-targeted write but role IS admin
+# — must still succeed (it's an idempotent re-affirmation, not a demote).
+status, _ = http_post(f"/tenants/{TENANT_ID}/members",
+                      {"userId": ADMIN_ID, "role": "admin"}, TOKEN_ADMIN)
+assert_status("addMember: self admin re-affirm returns 201", 201, status)
+
+# With a second admin present, self-demote IS allowed. Promote COLLEAGUE
+# to admin first, then demote self, then restore self to admin so the
+# remaining tests in this file still see admin role.
+status, _ = http_post(f"/tenants/{TENANT_ID}/members",
+                      {"userId": int(COLLEAGUE_ID), "role": "admin"}, TOKEN_ADMIN)
+assert_status("addMember: promote colleague to admin returns 201", 201, status)
+
+status, _ = http_post(f"/tenants/{TENANT_ID}/members",
+                      {"userId": ADMIN_ID, "role": "viewer"}, TOKEN_ADMIN)
+assert_status("addMember: self-demote with co-admin returns 201", 201, status)
+
+# Restore admin role via direct DB (the API can't re-promote a non-admin
+# back to admin without a separate role-change endpoint).
+mysql_query(f"UPDATE tenant_members SET role='admin' "
+            f"WHERE tenant_id={TENANT_ID} AND user_id={ADMIN_ID};")
+
+# Demote colleague back to editor for the remove test below.
+status, _ = http_post(f"/tenants/{TENANT_ID}/members",
+                      {"userId": int(COLLEAGUE_ID), "role": "editor"}, TOKEN_ADMIN)
+assert_status("addMember: demote colleague back to editor returns 201", 201, status)
+
+print("  All self-demote tests passed.")
+
 print("  --- Member list/remove ---")
 
 status, _ = http_get(f"/tenants/{TENANT_ID}/members", TOKEN_ADMIN)


### PR DESCRIPTION
## Summary

Closes #214 (audit #46 M2). \`TenantController::addMember\` now refuses
last-admin self-demotion: when caller targets their own userId with a
non-admin role and there's only one admin in the tenant, return 400
\`Cannot demote the last admin; promote another admin first\`.

Without this guard, the lone admin could POST \`{userId: <self>, role: 'viewer'}\`
and orphan the tenant — \`removeMember\` already blocks self-removal,
no role-change endpoint exists, and recovery would require DB
intervention.

## Files changed

- \`backend/src/controllers/TenantController.cpp\` — extract the existing org-check + INSERT chain into a \`proceed()\` continuation; add a self-demote guard that runs a \`SELECT COUNT(*)\` ahead of \`proceed()\` when \`targetUserId == callerId && role != "admin"\`.
- \`backend/tests/test_05_tenants.py\` — four new assertions: last-admin self-demote rejected; self admin re-affirm allowed (idempotent); self-demote allowed when a co-admin exists; setup/teardown promotes/demotes a colleague to validate the multi-admin path.

## Work breakdown

- [x] Extract proceed() continuation in \`addMember\`
- [x] Add self-demote count + guard
- [x] Regression tests (4 assertions covering both branches)
- [x] Run \`test_05\` + sibling fast-tier tests (\`test_01\`, \`test_02\`, \`test_09\`, \`test_28\`) locally — all pass

## Test plan

- [x] \`backend/tests/test_05_tenants.py\` runs clean (19/19 assertions)
- [x] Sibling tests pass (auth, filters, security, permissions)
- [x] CI integration job (PR gate)

## Restart needs

Backend rebuild + restart required (controller change). \`docker compose build backend && docker compose up -d backend\`. No migration.

## Burst context

Burst tracking: #219 (Wave 2 audit follow-ups, PR 1 of 6).