### PR TITLE
Gate plot listMembers by map_permissions (#213, audit #46 M1)

### DIFF
--- a/backend/src/controllers/PlotController.cpp
+++ b/backend/src/controllers/PlotController.cpp
@@ -489,7 +489,14 @@ void PlotController::listMembers(
                 return;
             }
 
-            // Step 2: fetch visible node members. Admins skip the CTE.
+            // Step 2: fetch visible node members. Admins skip the CTE *and*
+            // the map-permission gate (tenant admin sees everything in
+            // their tenant). Non-admins must satisfy both layers:
+            //   1. Map-permission gate (#213) — caller is map owner OR has
+            //      a per-user grant OR the map has a public grant.
+            //   2. Visibility-group filter (PLOT_NODE_VISIBILITY_CTE) —
+            //      effective visibility tags include a group the caller
+            //      is in (or owner_xray bypass).
             std::string nodeSql;
             if (!isAdmin) nodeSql = PLOT_NODE_VISIBILITY_CTE;
             nodeSql +=
@@ -499,12 +506,19 @@ void PlotController::listMembers(
                 "JOIN maps m ON m.id = n.map_id AND m.tenant_id = ? ";
             if (!isAdmin) {
                 nodeSql +=
-                    "WHERE ((m.owner_id = ? AND m.owner_xray = TRUE) "
+                    "LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ? "
+                    "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
+                    "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
+                    "WHERE (m.owner_id = ? "
+                    "       OR mp.level IN ('view','comment','edit','moderate','admin') "
+                    "       OR mp_pub.level IN ('view','comment','edit','moderate','admin')) "
+                    "  AND ((m.owner_id = ? AND m.owner_xray = TRUE) "
                     "       OR n.id IN (SELECT start_id FROM node_visible_starts)) ";
             }
             nodeSql += "ORDER BY n.created_at ASC";
 
-            // Step 3: fetch visible note members. Admins skip the CTE.
+            // Step 3: fetch visible note members. Same two-layer gate as
+            // nodes — map-permission first, then visibility filter.
             std::string noteSql;
             if (!isAdmin) noteSql = PLOT_NOTE_VISIBILITY_CTE;
             noteSql +=
@@ -516,7 +530,13 @@ void PlotController::listMembers(
                 "JOIN maps m ON m.id = nd.map_id AND m.tenant_id = ? ";
             if (!isAdmin) {
                 noteSql +=
-                    "WHERE ((m.owner_id = ? AND m.owner_xray = TRUE) "
+                    "LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ? "
+                    "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
+                    "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
+                    "WHERE (m.owner_id = ? "
+                    "       OR mp.level IN ('view','comment','edit','moderate','admin') "
+                    "       OR mp_pub.level IN ('view','comment','edit','moderate','admin')) "
+                    "  AND ((m.owner_id = ? AND m.owner_xray = TRUE) "
                     "       OR nt.id IN (SELECT visible_note_id FROM note_visible)) ";
             }
             noteSql += "ORDER BY nt.pinned DESC, nt.created_at ASC";
@@ -548,9 +568,14 @@ void PlotController::listMembers(
                     // — anchor uses plotId, node_visible_starts uses userId,
                     // note_visible's outer JOIN uses plotId, override-TRUE
                     // EXISTS uses userId, then SELECT JOIN uses plotId.
+                    // SELECT binds (post-#213): plotId, tenantId, userId(mp),
+                    // userId(owner-perm), userId(xray).
                     dbT->execSqlAsync(noteSql, onNotes, onNotesErr,
-                        id, userId, id, userId,   // CTE
-                        id, tenantId, userId);    // SELECT WHERE + xray
+                        id, userId, id, userId,            // CTE
+                        id, tenantId,                       // SELECT JOINs
+                        userId,                             // mp.user_id
+                        userId,                             // m.owner_id (perm)
+                        userId);                            // m.owner_id (xray)
                 }
             };
 
@@ -569,9 +594,14 @@ void PlotController::listMembers(
             if (isAdmin) {
                 dbN->execSqlAsync(nodeSql, onNodes, onNodesErr, id, tenantId);
             } else {
+                // SELECT binds (post-#213): plotId, tenantId, userId(mp),
+                // userId(owner-perm), userId(xray).
                 dbN->execSqlAsync(nodeSql, onNodes, onNodesErr,
-                    id, userId,             // CTE (plotId, userId)
-                    id, tenantId, userId);  // SELECT WHERE + xray
+                    id, userId,                          // CTE (plotId, userId)
+                    id, tenantId,                        // SELECT JOINs
+                    userId,                              // mp.user_id
+                    userId,                              // m.owner_id (perm)
+                    userId);                             // m.owner_id (xray)
             }
         },
         [callback](const drogon::orm::DrogonDbException&) {

--- a/backend/tests/test_22_plots.py
+++ b/backend/tests/test_22_plots.py
@@ -324,6 +324,108 @@ mysql_query(f"UPDATE maps SET owner_id={USER_A_ID} WHERE id={MAP_ID};")
 
 print("  All visibility-filter tests passed.")
 
+# ─── Map-permission gate on listMembers (#213) ───────────────────────────────
+#
+# Audit #46 M1: regular listNodes gates by map_permissions, but
+# listMembers used to skip that JOIN. Tenant members without
+# per-map access could see node/note metadata for plot members
+# from maps they couldn't otherwise read.
+#
+# Setup: a second map owned by A with no permission grant for B,
+# a node with override+Players (a group B IS a member of), and
+# the node attached to a plot. Pre-fix: B would see it via the
+# plot's visibility filter alone. Post-fix: B is rejected because
+# the map-permission gate runs first and B has no row.
+
+print("  --- Map-permission gate on listMembers (#213) ---")
+
+# A creates a second map with no map_permissions row for B.
+_, body = http_post(f"/tenants/{TENANT_A}/maps", {
+    "title": "Private Map (#213)",
+    "coordinateSystem": {"type": "wgs84", "center": {"lat": 0, "lng": 0}, "zoom": 3},
+}, TOKEN_A)
+PRIVATE_MAP = json_field(body, ["id"])
+
+# Node with Players visibility — would otherwise be visible to B.
+PRIVATE_NODES_BASE = f"/tenants/{TENANT_A}/maps/{PRIVATE_MAP}/nodes"
+_, body = http_post(PRIVATE_NODES_BASE, {"name": "PrivateNode"}, TOKEN_A)
+PRIVATE_NODE = json_field(body, ["id"])
+http_post(f"{PRIVATE_NODES_BASE}/{PRIVATE_NODE}/visibility",
+          {"override": True, "groupIds": [G_PLAYERS]}, TOKEN_A)
+
+# Note on the private node, also Players-tagged.
+_, body = http_post(f"{PRIVATE_NODES_BASE}/{PRIVATE_NODE}/notes",
+                    {"title": "PrivateNote", "text": "x"}, TOKEN_A)
+PRIVATE_NOTE = json_field(body, ["id"])
+http_post(
+    f"/tenants/{TENANT_A}/maps/{PRIVATE_MAP}/notes/{PRIVATE_NOTE}/visibility",
+    {"override": True, "groupIds": [G_PLAYERS]}, TOKEN_A)
+
+# Attach private members to PLOT_2; also add PLAYERS_NODE (from MAP_ID
+# where B has view permission) so we can verify the fix is *selective* —
+# it filters PRIVATE_NODE but NOT PLAYERS_NODE for the same caller.
+http_post(f"{PLOTS_BASE}/{PLOT_2}/nodes", {"nodeId": PRIVATE_NODE}, TOKEN_A)
+http_post(f"{PLOTS_BASE}/{PLOT_2}/notes", {"noteId": PRIVATE_NOTE}, TOKEN_A)
+http_post(f"{PLOTS_BASE}/{PLOT_2}/nodes", {"nodeId": PLAYERS_NODE}, TOKEN_A)
+
+# Admin still sees everything in the plot, including private-map members.
+status, body = http_get(f"{PLOTS_BASE}/{PLOT_2}/members", TOKEN_A)
+assert_status("admin: listMembers 200", 200, status)
+node_ids = {n["id"] for n in body["nodes"]}
+note_ids = {n["id"] for n in body["notes"]}
+assert_true("admin: sees PrivateNode in plot",  PRIVATE_NODE in node_ids)
+assert_true("admin: sees PrivateNote in plot",  PRIVATE_NOTE in note_ids)
+
+# B (tenant viewer, has Players group, but NO map_permissions on PRIVATE_MAP):
+# pre-fix would see PrivateNode/PrivateNote via plot visibility filter;
+# post-fix the map-permission gate rejects them.
+status, body = http_get(f"{PLOTS_BASE}/{PLOT_2}/members", TOKEN_B)
+assert_status("B: listMembers 200", 200, status)
+node_ids = {n["id"] for n in body["nodes"]}
+note_ids = {n["id"] for n in body["notes"]}
+assert_true("B: PrivateNode hidden (no map permission)",
+            PRIVATE_NODE not in node_ids)
+assert_true("B: PrivateNote hidden (no map permission)",
+            PRIVATE_NOTE not in note_ids)
+
+# Sanity: B still sees PLAYERS_NODE via PLOT_2 (it's on MAP_ID where B has view).
+assert_true("B: still sees PLAYERS_NODE on permitted map",
+            PLAYERS_NODE in node_ids)
+
+# Granting B view on PRIVATE_MAP must restore visibility.
+mysql_query(
+    f"INSERT INTO map_permissions (map_id, user_id, level) "
+    f"VALUES ({PRIVATE_MAP}, {USER_B_ID}, 'view');")
+status, body = http_get(f"{PLOTS_BASE}/{PLOT_2}/members", TOKEN_B)
+node_ids = {n["id"] for n in body["nodes"]}
+note_ids = {n["id"] for n in body["notes"]}
+assert_true("B: PrivateNode visible after permission grant",
+            PRIVATE_NODE in node_ids)
+assert_true("B: PrivateNote visible after permission grant",
+            PRIVATE_NOTE in note_ids)
+
+# Public-map permission also satisfies the gate. Revoke B's per-user
+# row, add a public row instead, and re-check.
+mysql_query(
+    f"DELETE FROM map_permissions "
+    f"WHERE map_id={PRIVATE_MAP} AND user_id={USER_B_ID};")
+mysql_query(
+    f"INSERT INTO map_permissions (map_id, user_id, level) "
+    f"VALUES ({PRIVATE_MAP}, NULL, 'view');")
+status, body = http_get(f"{PLOTS_BASE}/{PLOT_2}/members", TOKEN_B)
+node_ids = {n["id"] for n in body["nodes"]}
+assert_true("B: PrivateNode visible via public map permission",
+            PRIVATE_NODE in node_ids)
+
+# Cleanup: detach private members AND PLAYERS_NODE so the rest of the
+# file's expectations on PLOT_2 are unchanged (the next section adds
+# PLAYERS_NODE itself and asserts membership state).
+http_delete(f"{PLOTS_BASE}/{PLOT_2}/nodes/{PRIVATE_NODE}", TOKEN_A)
+http_delete(f"{PLOTS_BASE}/{PLOT_2}/notes/{PRIVATE_NOTE}", TOKEN_A)
+http_delete(f"{PLOTS_BASE}/{PLOT_2}/nodes/{PLAYERS_NODE}", TOKEN_A)
+
+print("  All map-permission-gate tests passed.")
+
 # ─── Reverse membership: GET /maps/{mid}/nodes/{nid}/plots (#139) ────────────
 #
 # State entering this section: PLOT_1 contains {PLAYERS_NODE, GM_NODE} as


### PR DESCRIPTION
## Summary

Closes #213 (audit #46 M1). Adds the missing map-permission JOIN to
\`PlotController::listMembers\` so non-admins must satisfy *both*
authorization layers — per-map permission first, then visibility-group
filter. Admin and owner_xray bypass are preserved.

Pre-fix: a tenant viewer who was a member of a visibility group could
read node/note metadata via the plots endpoint for entities on maps
they had no \`map_permissions\` row on. Documented in the model as
\"two layers stack\" but the code skipped layer one.

## Files changed

- \`backend/src/controllers/PlotController.cpp\` — non-admin SQL for both the node-members and note-members queries now LEFT JOINs \`map_permissions\` (per-user + public) and ANDs an \`(owner OR mp.level OR mp_pub.level)\` predicate ahead of the existing visibility filter. Bind orders updated and commented.
- \`backend/tests/test_22_plots.py\` — new \"Map-permission gate on listMembers\" section: creates a private second map (no permission row for B), attaches a Players-tagged node and note to PLOT_2 alongside a node from B's permitted map, and verifies B sees only the permitted-map member; then re-tests after granting B per-user permission, and once more after switching to a public-map permission.

## Work breakdown

- [x] Add map_permissions JOIN + predicate to non-admin node SQL
- [x] Same for non-admin note SQL
- [x] Update bind ordering + comments
- [x] Regression test: rejection, per-user grant restores, public grant restores, sibling members on permitted maps still visible
- [x] Local sibling suite (test_14/18/19/20/21/22/23/24/25) all pass

## Test plan

- [x] \`test_22_plots.py\` runs clean (88/88 assertions)
- [x] Sibling visibility/node/plot tests pass
- [x] CI integration job (PR gate)

## Restart needs

Backend rebuild + restart required (controller change). \`docker compose build backend && docker compose up -d backend\`. No migration.

## Burst context

Burst tracking: #219 (Wave 2 audit follow-ups, PR 2 of 6).