### PR TITLE
Validate removePermission target (#216, audit #46 L1)

### DIFF
--- a/backend/src/controllers/MapController.cpp
+++ b/backend/src/controllers/MapController.cpp
@@ -1,8 +1,10 @@
 #include "MapController.h"
 #include "AuditLog.h"
 #include "ErrorResponse.h"
+#include <charconv>
 #include <drogon/drogon.h>
 #include <sstream>
+#include <system_error>
 
 static int callerUserId(const drogon::HttpRequestPtr& req) {
     try { return req->getAttributes()->get<int>("userId"); }
@@ -681,12 +683,31 @@ void MapController::removePermission(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId, int id, const std::string& target) {
 
+    // Validate `target` up-front. Path is bound as std::string by the
+    // router, so anything goes; reject early with 400 instead of letting
+    // std::stoi throw and surface as a 500. Accept "public" or a
+    // positive integer userId; nothing else.
+    int targetId = 0;
+    if (target != "public") {
+        auto first = target.data();
+        auto last  = first + target.size();
+        auto [ptr, ec] = std::from_chars(first, last, targetId);
+        if (ec != std::errc{} || ptr != last || targetId <= 0) {
+            auto resp = drogon::HttpResponse::newHttpJsonResponse(
+                errorJson("bad_request",
+                    "Permission target must be 'public' or a positive user id"));
+            resp->setStatusCode(drogon::k400BadRequest);
+            callback(resp);
+            return;
+        }
+    }
+
     int callerId = callerUserId(req);
     auto db      = drogon::app().getDbClient();
 
     db->execSqlAsync(
         "SELECT id FROM maps WHERE id=? AND tenant_id=? AND owner_id=?",
-        [callback, id, target](const drogon::orm::Result& r) {
+        [callback, id, target, targetId](const drogon::orm::Result& r) {
             if (r.empty()) {
                 auto resp = drogon::HttpResponse::newHttpJsonResponse(
                     errorJson("forbidden", "Only the map owner can remove permissions"));
@@ -711,7 +732,6 @@ void MapController::removePermission(
                     },
                     id);
             } else {
-                int targetId = std::stoi(target);
                 db2->execSqlAsync(
                     "DELETE FROM map_permissions WHERE map_id=? AND user_id=?",
                     [callback](const drogon::orm::Result&) {

--- a/backend/tests/test_28_permissions.py
+++ b/backend/tests/test_28_permissions.py
@@ -166,4 +166,19 @@ status, _ = http_delete(f"/tenants/{OWNER_TID}/maps/{MAP_ID}/permissions/{COLLAB
 assert_status("delete user permission → 204", 204, status)
 
 
+print("  --- DELETE permission-target validation (#216) ---")
+# Audit #46 L1: removePermission used std::stoi unguarded on the path
+# segment. Non-numeric, non-"public" values threw and surfaced as 500.
+# Validate that the handler now returns a clean 400 instead.
+for bad in ["abc", "123abc", "-7", "0", ""]:
+    status, body = http_delete(
+        f"/tenants/{OWNER_TID}/maps/{MAP_ID}/permissions/{bad}", OWNER_TOK)
+    label = bad if bad else "<empty>"
+    # Empty string falls through Drogon's router as a missing path segment
+    # and becomes a 404 from the framework — accept either as "not 500".
+    assert_true(f"bad target '{label}' rejected (not 500)",
+                status in (400, 404),
+                f"expected 400/404 for {bad!r}, got {status}")
+
+
 sys.exit(0 if report() else 1)


### PR DESCRIPTION
## Summary

Closes #216 (audit #46 L1). \`MapController::removePermission\` previously
called \`std::stoi(target)\` on the URL path segment unguarded — non-numeric
inputs other than \`"public"\` threw and surfaced as 500. Replaces with
\`std::from_chars\` + early validation that rejects with a clean 400.

## Files changed

- \`backend/src/controllers/MapController.cpp\` — add \`<charconv>\` and \`<system_error>\` includes; validate \`target\` up-front in \`removePermission\` (accept \`"public"\` or a positive integer userId); reject anything else with 400 \`bad_request\` before any DB call. Captured \`targetId\` is then passed through to the existing DELETE branch.
- \`backend/tests/test_28_permissions.py\` — new "permission-target validation" loop asserting that bad inputs (\`abc\`, \`123abc\`, \`-7\`, \`0\`, empty) return 400 or 404 (router-handled), never 500.

## Work breakdown

- [x] Validate \`target\` with \`std::from_chars\` ahead of the SELECT
- [x] Drop the embedded \`std::stoi\` call inside the lambda
- [x] Regression test loop in \`test_28_permissions.py\`
- [x] Sibling tests (test_03, test_09, test_27, test_28) all pass

## Test plan

- [x] \`test_28_permissions.py\` runs clean (34/34 assertions)
- [x] Sibling MapController/security tests pass
- [x] CI integration job (PR gate)

## Restart needs

Backend rebuild + restart required (controller change). \`docker compose build backend && docker compose up -d backend\`. No migration.

## Burst context

Burst tracking: #219 (Wave 2 audit follow-ups, PR 3 of 6).