### PR TITLE
Cap node count per map (#217, audit #46 L2)

### DIFF
--- a/backend/src/controllers/NodeController.cpp
+++ b/backend/src/controllers/NodeController.cpp
@@ -345,9 +345,29 @@ void NodeController::createNode(
             // Build INSERT SQL with NULLs inlined for absent optional
             // columns (parent_id, geo_json). Avoids the parameter-binding
             // type gymnastics that plain CASE expressions induced.
+            //
+            // Per-map cap (#217 / audit #46 L2): COUNT before INSERT and
+            // reject if at the limit. The per-tenant 1000-map cap
+            // doesn't bound a single hot map; this does.
             auto doInsert = [callback, req, mapId, userId, callerUsername,
                              name, description, color, hasGeo, geoJsonStr,
                              hasParent, parentId, tenantId]() {
+                auto dbCap = drogon::app().getDbClient();
+                dbCap->execSqlAsync(
+                    "SELECT COUNT(*) AS c FROM nodes WHERE map_id = ?",
+                    [callback, req, mapId, userId, callerUsername,
+                     name, description, color, hasGeo, geoJsonStr,
+                     hasParent, parentId, tenantId]
+                    (const drogon::orm::Result& rCap) {
+                        int existing = rCap[0]["c"].as<int>();
+                        if (existing >= MAX_NODES_PER_MAP) {
+                            callback(errorResponse(drogon::k400BadRequest,
+                                "bad_request",
+                                "Map node limit reached (" +
+                                std::to_string(MAX_NODES_PER_MAP) + ")"));
+                            return;
+                        }
+                        (void)callerUsername;
                 auto db3 = drogon::app().getDbClient();
 
                 auto insertedCb = [callback, req, mapId, userId, tenantId]
@@ -411,6 +431,12 @@ void NodeController::createNode(
                     db3->execSqlAsync(sql, insertedCb, errCb,
                         mapId, userId, name, description, color);
                 }
+                    },  // end COUNT success callback
+                    [callback](const drogon::orm::DrogonDbException&) {
+                        callback(errorResponse(drogon::k500InternalServerError,
+                            "db_error", "Failed to count map nodes"));
+                    },
+                    mapId);
             };
 
             // Step 2: if parent given, verify same-map and depth.
@@ -1727,6 +1753,17 @@ void NodeController::copyNode(
                                 sources->push_back(std::move(s));
                             }
 
+                            // Per-map cap (#217 / audit #46 L2): copies
+                            // can multiply node counts quickly. Verify
+                            // destMap.count + sources.size() <= cap
+                            // before any INSERTs, so a partial copy can't
+                            // wedge a map past the limit. The continuation
+                            // (idMap setup + copy loop) is hoisted into a
+                            // lambda the cap-check invokes on success.
+                            auto continueCopy = [callback, req, tenantId, id, userId,
+                                                  destMapId, hasNewParent, newParentIsNull,
+                                                  newParentId, sources]() {
+
                             auto idMap   = std::make_shared<std::unordered_map<int,int>>();
                             auto rootCopyId = std::make_shared<int>(0);
 
@@ -1987,6 +2024,31 @@ void NodeController::copyNode(
                                 }
                             };
                             (*step)();
+
+                            };  // end continueCopy lambda
+
+                            // Run the cap-check; on success it invokes continueCopy.
+                            auto dbCap = drogon::app().getDbClient();
+                            dbCap->execSqlAsync(
+                                "SELECT COUNT(*) AS c FROM nodes WHERE map_id = ?",
+                                [callback, sources, continueCopy]
+                                (const drogon::orm::Result& rCap) {
+                                    int existing = rCap[0]["c"].as<int>();
+                                    int incoming = static_cast<int>(sources->size());
+                                    if (existing + incoming > MAX_NODES_PER_MAP) {
+                                        callback(errorResponse(drogon::k400BadRequest,
+                                            "bad_request",
+                                            "Copy would exceed map node limit (" +
+                                            std::to_string(MAX_NODES_PER_MAP) + ")"));
+                                        return;
+                                    }
+                                    continueCopy();
+                                },
+                                [callback](const drogon::orm::DrogonDbException&) {
+                                    callback(errorResponse(drogon::k500InternalServerError,
+                                        "db_error", "Failed to count destination nodes"));
+                                },
+                                destMapId);
                         },
                         [callback](const drogon::orm::DrogonDbException&) {
                             callback(errorResponse(drogon::k500InternalServerError,

--- a/backend/src/controllers/NodeController.h
+++ b/backend/src/controllers/NodeController.h
@@ -173,3 +173,12 @@ public:
 // nesting limit. Deleting a deeply nested root would otherwise hit
 // "cascade nesting too deep" once descendants exceed that boundary.
 inline constexpr int MAX_NODE_DEPTH = 15;
+
+// Per-map node count cap (#217 / audit #46 L2). Bounds an editor
+// from creating an unbounded fan-out under one map and slowing
+// listNodes/getSubtree for everyone with map access. The per-tenant
+// 1000-map cap already bounds total fan-out across maps; this caps
+// any single hot map. 5000 is the rough order of "largest reasonable
+// real-world tree" — revisit if production telemetry surfaces a slow
+// map outlier under the limit, or if legitimate workflows hit it.
+inline constexpr int MAX_NODES_PER_MAP = 5000;

--- a/backend/tests/test_14_nodes.py
+++ b/backend/tests/test_14_nodes.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 from helpers import (
     reset_counters, report, assert_status, assert_json_field, assert_json_exists,
     assert_true, http_post, http_get, http_put, http_delete,
-    register_user, json_field,
+    register_user, json_field, mysql_query,
 )
 
 reset_counters()
@@ -20,7 +20,8 @@ print("=== Node Tests ===")
 TOKEN_A = register_user(f"t14_a_{RUN_ID}", f"t14_a_{RUN_ID}@test.com", "testpass123")
 _, body_a = http_post("/auth/login",
     {"email": f"t14_a_{RUN_ID}@test.com", "password": "testpass123"})
-TENANT_A = json_field(body_a, ["tenantId"])
+TENANT_A   = json_field(body_a, ["tenantId"])
+USER_A_ID  = json_field(body_a, ["user", "id"])
 
 TOKEN_B = register_user(f"t14_b_{RUN_ID}", f"t14_b_{RUN_ID}@test.com", "testpass123")
 _, body_b = http_post("/auth/login",
@@ -220,5 +221,45 @@ status, _ = http_post(BASE, {"name": "TooDeep", "parentId": chain[-1]}, TOKEN_A)
 assert_status("max depth: inserting beyond limit returns 400", 400, status)
 
 print("  All max-depth tests passed.")
+
+# ─── Per-map node count cap (#217) ───────────────────────────────────────────
+# Audit #46 L2: createNode COUNTs existing nodes and rejects with 400
+# when at MAX_NODES_PER_MAP (5,000). Filling 5,000 via HTTP is slow;
+# bulk-fill via SQL up to one-below-limit, then exercise the boundary
+# via the API.
+
+print("  --- Per-map node count cap (#217) ---")
+
+_, body = http_post(f"/tenants/{TENANT_A}/maps", {
+    "title": f"Cap test {RUN_ID}",
+    "coordinateSystem": {"type": "wgs84", "center": {"lat": 0, "lng": 0}, "zoom": 3},
+}, TOKEN_A)
+CAP_MAP = json_field(body, ["id"])
+CAP_BASE = f"/tenants/{TENANT_A}/maps/{CAP_MAP}/nodes"
+
+# Bulk-fill 4,999 placeholder nodes via direct SQL.
+mysql_query(
+    f"INSERT INTO nodes (map_id, name, created_by) "
+    f"SELECT {CAP_MAP}, CONCAT('bulk_', seq), {USER_A_ID} "
+    f"FROM (SELECT @row := @row + 1 AS seq "
+    f"      FROM information_schema.columns t1, information_schema.columns t2, "
+    f"           (SELECT @row := 0) r LIMIT 4999) seq;")
+
+count_str = mysql_query(f"SELECT COUNT(*) FROM nodes WHERE map_id = {CAP_MAP};")
+assert_true("cap-fill seeded 4999 nodes",  count_str == "4999",
+            f"got count={count_str!r}")
+
+# 5,000th create succeeds (existing 4,999 < 5,000 cap).
+status, _ = http_post(CAP_BASE, {"name": "AtCap"}, TOKEN_A)
+assert_status("cap: create at limit-1 succeeds (becomes 5000th)", 201, status)
+
+# 5,001st create rejected.
+status, body = http_post(CAP_BASE, {"name": "OverCap"}, TOKEN_A)
+assert_status("cap: create over limit returns 400", 400, status)
+assert_true("cap: error mentions limit",
+            isinstance(body, dict) and "limit" in body.get("message", "").lower(),
+            f"got {body!r}")
+
+print("  All node-count-cap tests passed.")
 
 sys.exit(0 if report() else 1)

--- a/backend/tests/test_25_node_copy.py
+++ b/backend/tests/test_25_node_copy.py
@@ -356,4 +356,41 @@ assert_status("validate: copy under self is allowed", 201, status)
 
 print("  All validation tests passed.")
 
+# ─── Per-map node count cap on copy (#217) ───────────────────────────────────
+# Audit #46 L2: copyNode COUNTs the destination map and refuses copies
+# whose subtree size would push the destination over MAX_NODES_PER_MAP.
+# Bulk-fill the destination near the limit, attempt a 2-node copy, then
+# verify the same source copies cleanly into a fresh empty map.
+
+print("  --- Per-map node count cap on copy (#217) ---")
+
+COPY_SRC_MAP  = mkmap(TENANT_A, TOKEN_A, "Cap copy source")
+COPY_SRC_BASE = f"/tenants/{TENANT_A}/maps/{COPY_SRC_MAP}/nodes"
+COPY_SRC_ROOT = mknode(COPY_SRC_BASE, TOKEN_A, "SrcRoot")
+mknode(COPY_SRC_BASE, TOKEN_A, "SrcChild", COPY_SRC_ROOT)
+
+COPY_DST_MAP = mkmap(TENANT_A, TOKEN_A, "Cap copy dest near-full")
+mysql_query(
+    f"INSERT INTO nodes (map_id, name, created_by) "
+    f"SELECT {COPY_DST_MAP}, CONCAT('bulk_', seq), {USER_A_ID} "
+    f"FROM (SELECT @row := @row + 1 AS seq "
+    f"      FROM information_schema.columns t1, information_schema.columns t2, "
+    f"           (SELECT @row := 0) r LIMIT 4999) seq;")
+
+# 2-node subtree into a 4,999-row destination would push to 5,001 > cap.
+status, body = http_post(f"{COPY_SRC_BASE}/{COPY_SRC_ROOT}/copy",
+                         {"newMapId": COPY_DST_MAP}, TOKEN_A)
+assert_status("cap-copy: 2-node into 4999-full rejected", 400, status)
+assert_true("cap-copy: error mentions limit",
+            isinstance(body, dict) and "limit" in body.get("message", "").lower(),
+            f"got {body!r}")
+
+# Same source into an empty map works.
+COPY_DST_OK = mkmap(TENANT_A, TOKEN_A, "Cap copy dest empty")
+status, _ = http_post(f"{COPY_SRC_BASE}/{COPY_SRC_ROOT}/copy",
+                      {"newMapId": COPY_DST_OK}, TOKEN_A)
+assert_status("cap-copy: 2-node into empty map succeeds", 201, status)
+
+print("  All copy node-count-cap tests passed.")
+
 sys.exit(0 if report() else 1)

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -184,6 +184,10 @@ selected from `coordinateSystem.type` at view time.
 
 - Per-tenant map limit: 1,000 maps. Enforced on map creation.
 - Map-tree depth limit: 16. Enforced on node create and node move.
+- Per-map node count limit: 5,000 nodes. Enforced on node create and
+  node copy (a copy that would push the destination over the limit is
+  rejected before any inserts). Bounds DOS surface on a single hot map
+  that the per-tenant map cap doesn't cover.
 - Map list pagination: `pageSize` is clamped to 1–100. Invalid values
   default to 20.
 - Node subtree responses are cursor-paginated to bound payload size.


### PR DESCRIPTION
## Summary

Closes #217 (audit #46 L2). Adds \`MAX_NODES_PER_MAP\` (5,000) constant
and enforces it on \`createNode\` and \`copyNode\`. Bounds DOS surface on
a single hot map that the per-tenant 1000-map cap doesn't cover.

\`copyNode\`'s check runs **before** any INSERTs, so a partial copy
can't wedge a map past the limit.

## Files changed

- \`backend/src/controllers/NodeController.cpp\` — wrap the existing INSERT chain in \`createNode\` with a COUNT-then-check; in \`copyNode\`, hoist the post-source-load chain into a \`continueCopy\` continuation lambda and gate it on a destination-COUNT-vs-(existing + sources.size()) check.
- \`backend/src/controllers/NodeController.h\` — add \`inline constexpr int MAX_NODES_PER_MAP = 5000\` with rationale comment.
- \`backend/tests/test_14_nodes.py\` — new "node count cap" section: bulk-fill 4,999 placeholder nodes via SQL on a fresh map, verify the 5,000th create succeeds and the 5,001st returns 400.
- \`backend/tests/test_25_node_copy.py\` — new "copy node count cap" section: bulk-fill destination to 4,999, verify a 2-node copy is rejected; verify the same source copies cleanly into an empty map.
- \`docs/REQUIREMENTS.md\` — document the new per-map cap in §2.15 alongside the existing per-tenant map and tree-depth limits.

## Work breakdown

- [x] Add \`MAX_NODES_PER_MAP\` constant + comment
- [x] Gate \`createNode\` with COUNT-then-check
- [x] Hoist \`copyNode\` continuation into lambda; gate with cap check
- [x] Document in REQUIREMENTS.md §2.15
- [x] Regression test in test_14 (createNode boundary)
- [x] Regression test in test_25 (copyNode rejection + empty-map success)
- [x] Sibling suite (test_14/23/24/25) all pass

## Test plan

- [x] \`test_14_nodes.py\`: 47/47 (bulk-fill via \`information_schema.columns\` cross-join generates the 4,999 rows in ~50ms)
- [x] \`test_25_node_copy.py\`: 54/54
- [x] Sibling node tests pass (no regressions in tree-navigation, move, copy)
- [x] CI integration job (PR gate)

## Restart needs

Backend rebuild + restart required (controller change). \`docker compose build backend && docker compose up -d backend\`. No migration.

## Burst context

Burst tracking: #219 (Wave 2 audit follow-ups, PR 4 of 6). Must precede #212 (transaction wrapping wraps these handlers).