### PR TITLE
Extract TenantBootstrap helper (#218, audit #46 L3)

### DIFF
--- a/backend/src/TenantBootstrap.h
+++ b/backend/src/TenantBootstrap.h
@@ -1,0 +1,54 @@
+#pragma once
+#include <drogon/drogon.h>
+#include <functional>
+
+// TenantBootstrap (#218 / audit #46 L3)
+// ─────────────────────────────────────
+// Helper for seeding the default visibility-group state a new tenant
+// needs to be functional. Until this helper, the bootstrap was inlined
+// in AuthController::registerUser only — meaning out-of-band tenant
+// provisioning paths (DB seed, future SSO-tenant-bootstrap, internal
+// admin tools) silently shipped tenants with no "Visibility Managers"
+// group, leaving non-admin members unable to delegate visibility-group
+// management.
+//
+// What gets seeded (currently): one visibility_groups row named
+// "Visibility Managers" with `manages_visibility = TRUE`, and one
+// visibility_group_members row attaching `ownerUserId` to it.
+//
+// Async chain: INSERT visibility_groups → INSERT visibility_group_members
+// → onSuccess(). Any failure short-circuits to onError(message).
+
+namespace TenantBootstrap {
+
+inline void seedDefaults(
+    int tenantId,
+    int ownerUserId,
+    std::function<void()> onSuccess,
+    std::function<void(const std::string&)> onError) {
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "INSERT INTO visibility_groups "
+        "  (tenant_id, name, manages_visibility, created_by) "
+        "VALUES (?, 'Visibility Managers', TRUE, ?)",
+        [ownerUserId, onSuccess, onError]
+        (const drogon::orm::Result& rvg) {
+            int vgId = static_cast<int>(rvg.insertId());
+            auto db2 = drogon::app().getDbClient();
+            db2->execSqlAsync(
+                "INSERT INTO visibility_group_members "
+                "  (visibility_group_id, user_id) VALUES (?, ?)",
+                [onSuccess](const drogon::orm::Result&) { onSuccess(); },
+                [onError](const drogon::orm::DrogonDbException&) {
+                    onError("Failed to add to default visibility group");
+                },
+                vgId, ownerUserId);
+        },
+        [onError](const drogon::orm::DrogonDbException&) {
+            onError("Failed to bootstrap default visibility group");
+        },
+        tenantId, ownerUserId);
+}
+
+} // namespace TenantBootstrap

--- a/backend/src/controllers/AuthController.cpp
+++ b/backend/src/controllers/AuthController.cpp
@@ -1,6 +1,7 @@
 #include "AuthController.h"
 #include "AuditLog.h"
 #include "ErrorResponse.h"
+#include "../TenantBootstrap.h"
 #include <drogon/drogon.h>
 #include <jwt-cpp/jwt.h>
 #include <sodium.h>
@@ -143,25 +144,13 @@ void AuthController::registerUser(
                                         "VALUES (?,?,?)",
                                         [callback, req, newId, username, email, orgId, tenantId, this]
                                         (const drogon::orm::Result&) {
-                                    // Step 6: Bootstrap a default "Visibility Managers"
-                                    // group for the new tenant, with manages_visibility=TRUE
-                                    // and the registering user as the sole member. Lets
-                                    // the user delegate visibility-group management without
-                                    // promoting someone to full tenant admin (Phase 2b.i.b).
-                                    auto db6 = drogon::app().getDbClient();
-                                    db6->execSqlAsync(
-                                        "INSERT INTO visibility_groups "
-                                        "  (tenant_id, name, manages_visibility, created_by) "
-                                        "VALUES (?, 'Visibility Managers', TRUE, ?)",
-                                        [callback, req, newId, username, email, orgId, tenantId, this]
-                                        (const drogon::orm::Result& rvg) {
-                                    int vgId = static_cast<int>(rvg.insertId());
-                                    auto db7 = drogon::app().getDbClient();
-                                    db7->execSqlAsync(
-                                        "INSERT INTO visibility_group_members "
-                                        "  (visibility_group_id, user_id) VALUES (?, ?)",
-                                        [callback, req, newId, username, email, orgId, tenantId, this]
-                                        (const drogon::orm::Result&) {
+                                    // Step 6: Bootstrap default visibility-group state for
+                                    // the new tenant via TenantBootstrap::seedDefaults
+                                    // (#218 / audit #46 L3). Other tenant-provisioning
+                                    // paths should call the same helper.
+                                    TenantBootstrap::seedDefaults(
+                                        tenantId, newId,
+                                        [callback, req, newId, username, email, orgId, tenantId, this]() {
                                     AuditLog::record("register", req, newId);
                                     std::string token = issueToken(newId, username, orgId);
 
@@ -188,21 +177,12 @@ void AuthController::registerUser(
                                     httpResp->setStatusCode(drogon::k201Created);
                                     callback(httpResp);
                                         },
-                                        [callback](const drogon::orm::DrogonDbException&) {
+                                        [callback](const std::string& msg) {
                                             auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                                                errorJson("db_error", "Failed to add to default visibility group"));
+                                                errorJson("db_error", msg));
                                             resp->setStatusCode(drogon::k500InternalServerError);
                                             callback(resp);
-                                        },
-                                        vgId, newId);
-                                        },
-                                        [callback](const drogon::orm::DrogonDbException&) {
-                                            auto resp = drogon::HttpResponse::newHttpJsonResponse(
-                                                errorJson("db_error", "Failed to bootstrap default visibility group"));
-                                            resp->setStatusCode(drogon::k500InternalServerError);
-                                            callback(resp);
-                                        },
-                                        tenantId, newId);
+                                        });
                                         },
                                         [callback](const drogon::orm::DrogonDbException&) {
                                             auto resp = drogon::HttpResponse::newHttpJsonResponse(

--- a/docs/SETUP-LOCAL-DEV.md
+++ b/docs/SETUP-LOCAL-DEV.md
@@ -214,6 +214,40 @@ docker compose exec mysql mysql -uroot -prootpassword annotated_maps
 
 ---
 
+## 6a. Provisioning tenants out-of-band
+
+Most tenants are created automatically — the registration flow
+(`POST /auth/register`) provisions a personal org+tenant for the new
+user, and the seed script in §3 creates the demo orgs/tenants for
+local development.
+
+If you ever provision a tenant by hand (DB seed for an integration
+fixture, an admin tool that hasn't been written yet, a future
+SSO-org-bootstrap flow), the tenant **must** also have its default
+"Visibility Managers" group seeded. Without it, only tenant admins can
+manage visibility groups — non-admins can never be granted manager
+status because there's no `manages_visibility = TRUE` group to add
+them to.
+
+The backend exposes `TenantBootstrap::seedDefaults(tenantId,
+ownerUserId, onSuccess, onError)` in `backend/src/TenantBootstrap.h`
+for this purpose; new code paths that create tenants should call it
+right after the `tenant_members` insert. If you must do the equivalent
+work in raw SQL (e.g., a migration backfill), the two-statement
+template is:
+
+```sql
+INSERT INTO visibility_groups (tenant_id, name, manages_visibility, created_by)
+VALUES (<tenantId>, 'Visibility Managers', TRUE, <ownerUserId>);
+
+INSERT INTO visibility_group_members (visibility_group_id, user_id)
+VALUES (LAST_INSERT_ID(), <ownerUserId>);
+```
+
+Tracked under audit follow-up #218 (security audit #46 L3).
+
+---
+
 ## 7. Resource usage
 
 | Resource | Approximate usage |


### PR DESCRIPTION
## Summary

Closes #218 (audit #46 L3). Extracts the inline "Visibility Managers"
bootstrap from \`AuthController::registerUser\` into
\`TenantBootstrap::seedDefaults()\` so any tenant-provisioning path can
seed a tenant correctly with one call. Adds documentation of the SQL
equivalent for code paths that can't link the helper.

Pre-fix: only the registration flow seeded the bootstrap group.
Out-of-band tenant provisioning (DB seeds, admin tools, future
SSO-org-bootstrap endpoints) silently shipped tenants without it,
leaving non-admins unable to delegate visibility-group management on
those tenants.

## Files changed

- \`backend/src/TenantBootstrap.h\` — new header. Inline \`TenantBootstrap::seedDefaults(tenantId, ownerUserId, onSuccess, onError)\`. Async chain: INSERT \`visibility_groups\` ('Visibility Managers', \`manages_visibility = TRUE\`) → INSERT \`visibility_group_members\` → onSuccess; first failure short-circuits to onError(message).
- \`backend/src/controllers/AuthController.cpp\` — replace the inlined Step 6 (visibility-group INSERT) and Step 7 (visibility_group_members INSERT) with a single call to \`TenantBootstrap::seedDefaults\`. Removes ~30 lines of nested async-callback duplication.
- \`docs/SETUP-LOCAL-DEV.md\` — new §6a "Provisioning tenants out-of-band" with a pointer to the helper and a raw-SQL equivalent for migration backfills.

## Work breakdown

- [x] Create \`TenantBootstrap.h\` with \`seedDefaults\`
- [x] Migrate \`AuthController::registerUser\` to use the helper
- [x] Document the helper + SQL equivalent in SETUP-LOCAL-DEV.md
- [x] Verify existing bootstrap coverage in \`test_18_visibility_groups.py\` still passes (it routes through the helper now)
- [x] Sibling auth/visibility tests (1, 2, 8, 9, 18, 19, 20, 21) all pass

## Test plan

- [x] \`test_18_visibility_groups.py\`: 57/57 (existing bootstrap assertions exercise the helper-routed path)
- [x] Sibling auth/visibility/security tests pass (no regressions in register, login, group CRUD, or visibility filtering)
- [x] CI integration job (PR gate)

## Restart needs

Backend rebuild + restart required (controller change). \`docker compose build backend && docker compose up -d backend\`. No migration. New header is included via existing controller — no CMakeLists change.

## Burst context

Burst tracking: #219 (Wave 2 audit follow-ups, PR 5 of 6). Must precede #212 (transaction wrapping wraps \`registerUser\`'s multi-step flow).