### PR TITLE
Wrap setVisibility in transaction (#212 partial; #225 tracks rest)

### DIFF
--- a/backend/src/controllers/NodeController.cpp
+++ b/backend/src/controllers/NodeController.cpp
@@ -814,55 +814,93 @@ void NodeController::setVisibility(
             callback(resp);
         };
 
-        // Step 4: replace tags. DELETE then (optionally) multi-row INSERT.
-        auto applyTags = [callback, id, hasGroupIds, groupIds, joinIds, finish]() {
-            if (!hasGroupIds) { finish(); return; }
-
-            auto dbT = drogon::app().getDbClient();
-            dbT->execSqlAsync(
-                "DELETE FROM node_visibility WHERE node_id = ?",
-                [callback, id, groupIds, joinIds, finish]
-                (const drogon::orm::Result&) {
-                    if (groupIds.empty()) { finish(); return; }
-
-                    // Multi-row INSERT, ids inlined (see joinIds note above).
-                    std::string vals;
-                    bool first = true;
-                    for (int g : groupIds) {
-                        if (!first) vals += ",";
-                        vals += "(" + std::to_string(id) + "," + std::to_string(g) + ")";
-                        first = false;
-                    }
-                    auto dbI = drogon::app().getDbClient();
-                    dbI->execSqlAsync(
-                        "INSERT INTO node_visibility "
-                        "  (node_id, visibility_group_id) VALUES " + vals,
-                        [finish](const drogon::orm::Result&) { finish(); },
-                        [callback](const drogon::orm::DrogonDbException&) {
-                            callback(errorResponse(drogon::k500InternalServerError,
-                                "db_error", "Failed to insert tags"));
-                        });
-                },
-                [callback](const drogon::orm::DrogonDbException&) {
-                    callback(errorResponse(drogon::k500InternalServerError,
-                        "db_error", "Failed to clear existing tags"));
-                },
-                id);
-        };
-
-        // Step 3: optionally update override flag, then call applyTags.
+        // Step 3+4 (#212 / audit #46 H1): override UPDATE + tag DELETE +
+        // tag INSERT all run inside a single transaction. Pre-fix, the
+        // DELETE-then-INSERT could leave the node *untagged* (visible to
+        // everyone in the tenant) on partial failure — briefly removing
+        // a security control. The transaction commits when the last
+        // TransactionPtr ref drops; we attach setCommitCallback so the
+        // HTTP 204 only fires AFTER commit confirms (otherwise a follow-
+        // up GET can race the commit and read pre-write state).
         auto applyOverrideThenTags =
-            [callback, id, hasOverride, overrideVal, applyTags]() {
-            if (!hasOverride) { applyTags(); return; }
-            auto dbO = drogon::app().getDbClient();
-            dbO->execSqlAsync(
-                "UPDATE nodes SET visibility_override = ? WHERE id = ?",
-                [applyTags](const drogon::orm::Result&) { applyTags(); },
-                [callback](const drogon::orm::DrogonDbException&) {
+            [callback, id, hasOverride, overrideVal, hasGroupIds, groupIds,
+             joinIds, finish]() {
+
+            auto db = drogon::app().getDbClient();
+            db->newTransactionAsync(
+                [callback, id, hasOverride, overrideVal, hasGroupIds, groupIds,
+                 joinIds, finish]
+                (const std::shared_ptr<drogon::orm::Transaction>& trans) {
+
+                if (!trans) {
                     callback(errorResponse(drogon::k500InternalServerError,
-                        "db_error", "Failed to set override"));
-                },
-                overrideVal, id);
+                        "db_error", "Failed to begin transaction"));
+                    return;
+                }
+
+                // Defer the HTTP response until commit confirms. Drogon
+                // calls this callback exactly once when the transaction
+                // commits (success=true) or rolls back (false).
+                trans->setCommitCallback([callback, finish](bool committed) {
+                    if (!committed) {
+                        callback(errorResponse(drogon::k500InternalServerError,
+                            "db_error", "Transaction failed to commit"));
+                        return;
+                    }
+                    finish();
+                });
+
+                // chainDone marks the in-trans work as complete. The
+                // shared_ptr<Transaction> captures inside the callbacks
+                // then start dropping; when the last drops, Drogon
+                // commits and fires setCommitCallback above.
+                auto chainDone = []() { /* no-op; commit fires response */ };
+
+                auto applyTagsTx = [trans, callback, id, hasGroupIds, groupIds,
+                                    chainDone]() {
+                    if (!hasGroupIds) { chainDone(); return; }
+
+                    trans->execSqlAsync(
+                        "DELETE FROM node_visibility WHERE node_id = ?",
+                        [trans, callback, id, groupIds, chainDone]
+                        (const drogon::orm::Result&) {
+                            if (groupIds.empty()) { chainDone(); return; }
+
+                            std::string vals;
+                            bool first = true;
+                            for (int g : groupIds) {
+                                if (!first) vals += ",";
+                                vals += "(" + std::to_string(id) + "," +
+                                        std::to_string(g) + ")";
+                                first = false;
+                            }
+                            trans->execSqlAsync(
+                                "INSERT INTO node_visibility "
+                                "  (node_id, visibility_group_id) VALUES " + vals,
+                                [chainDone](const drogon::orm::Result&) {
+                                    chainDone();
+                                },
+                                [trans](const drogon::orm::DrogonDbException&) {
+                                    trans->rollback();
+                                });
+                        },
+                        [trans](const drogon::orm::DrogonDbException&) {
+                            trans->rollback();
+                        },
+                        id);
+                };
+
+                if (!hasOverride) { applyTagsTx(); return; }
+
+                trans->execSqlAsync(
+                    "UPDATE nodes SET visibility_override = ? WHERE id = ?",
+                    [applyTagsTx](const drogon::orm::Result&) { applyTagsTx(); },
+                    [trans](const drogon::orm::DrogonDbException&) {
+                        trans->rollback();
+                    },
+                    overrideVal, id);
+            });
+            (void)joinIds;  // captured for symmetry with the read phase
         };
 
         // Step 2: verify the node exists on this map+tenant.


### PR DESCRIPTION
## Summary

Partial close of #212 (audit #46 H1). Wraps the most security-critical
of the four handlers the audit flagged — \`NodeController::setVisibility\` —
in a Drogon transaction. Override UPDATE + tag DELETE + tag INSERT now
all-or-nothing.

The other three handlers (\`moveNode\`, \`copyNode\`, \`registerUser\`)
are tracked in follow-up #225 — bundling all four into one PR would
produce a too-large diff. setVisibility was the highest-risk: pre-fix,
its DELETE-then-INSERT could leave the node *untagged* (visible to
everyone in the tenant) on partial failure, briefly removing a
security control. The other three corrupt structural state but don't
weaken authorization.

## Files changed

- \`backend/src/controllers/NodeController.cpp\` — restructure \`setVisibility\`'s write phase: \`db->newTransactionAsync(...)\` wraps the override-UPDATE + tag-DELETE + tag-INSERT chain. \`Transaction::setCommitCallback\` defers the HTTP 204 until commit confirms (without it, the response races Drogon's auto-commit and follow-up reads can see pre-write state — test_19 caught this on the first attempt). Inner failures call \`trans->rollback()\`, which fires \`setCommitCallback\` with \`committed=false\` and surfaces a 500 instead of leaving partial state.

## Work breakdown

- [x] Wrap \`setVisibility\` write phase in transaction
- [x] Use \`setCommitCallback\` to defer HTTP response until post-commit
- [x] Sibling visibility/node tests pass (test_14/18/19/20/21/22/23/24/25)
- [x] File follow-up #225 for moveNode/copyNode/registerUser with the working pattern

## Test plan

- [x] \`test_19_node_visibility.py\`: 27/27 (the 5 setVisibility-write assertions all pass through the transaction now)
- [x] Sibling node + visibility tests: all pass
- [x] CI integration job (PR gate)

## Restart needs

Backend rebuild + restart required (controller change). \`docker compose build backend && docker compose up -d backend\`. No migration.

## Burst context

Burst tracking: #219 (Wave 2 audit follow-ups, PR 6 of 6 — final).
End-of-burst CI sweep + \`weekend.yml --ref main\` will follow once all six PRs in the burst are merged.

## Notes

The \`setCommitCallback\` pattern is documented in the #225 ticket for the remaining handlers to follow.