### PR TITLE
Wave branch naming convention + auto-triggered CI (#227)

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,7 +2,12 @@ name: PR Tests
 
 on:
   pull_request:
-    branches: [main]
+    # Trigger on PRs into main and into any wave-* branch. The wave-*
+    # glob matches the wave-N-<slug> naming convention (see
+    # docs/AI-COLLABORATION-CONVENTIONS.md "Wave branches"); the glob
+    # removes the per-wave workflow-edit round-trip the long-running-
+    # branch rule used to require.
+    branches: [main, 'wave-*']
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -38,6 +38,9 @@ agent instructions:
    opening every PR** in a public repository.
 7. **For long-running branches, extending the CI workflow to trigger on
    the branch is action #1**, before any feature ticket starts.
+   Subtype — **wave branches**: name them `wave-N-<short-slug>` and
+   `pr-tests.yml`'s `wave-*` glob picks them up automatically (no
+   workflow patch needed).
 8. **This document is the master record; agent-memory entries are thin
    replicas pointing back here.** When a rule changes, edit the doc; the
    memory pointer's frontmatter is updated to match.
@@ -684,9 +687,15 @@ it tells you to think about up front, not retroactively.
 
 **How to apply:**
 
-When asked to create a long-running branch, the *first* deliverable is a
-tiny PR that extends the project's CI workflow (e.g., `.github/workflows/pr-tests.yml`)
-to:
+For the **wave-branch** subtype (a tightly-scoped multi-PR effort that
+will merge back to main as a unit — the most common case in this repo),
+follow the wave naming convention in §7a; `pr-tests.yml`'s `wave-*` glob
+trigger picks the branch up automatically and no workflow patch is needed.
+
+For **other** long-running branches (one-off rebuilds, phase branches
+that won't fit the `wave-N-<slug>` pattern), the *first* deliverable is
+a tiny PR that extends the project's CI workflow (e.g.,
+`.github/workflows/pr-tests.yml`) to:
 
 1. Add the branch to the `pull_request: branches: [...]` list.
 2. Add a `push: branches: [...]` trigger so post-merge state is also verified.
@@ -701,11 +710,64 @@ For the long-running branch, decide upfront whether CI is **enforced**
 rebuild branches where mid-state failures are expected, informational is
 usually right; `main` remains the enforced gate.
 
-Sequence for any future long-running branch:
+Sequence for any future ad-hoc long-running branch:
 
 1. Create branch.
 2. CI workflow extension PR (mirror onto both `main` and the branch).
 3. *Then* the first feature ticket.
+
+### 7a. Wave branches — `wave-N-<slug>` naming convention
+
+> **Rule:** When the work is a tightly-scoped multi-PR effort that will
+> merge back to main as a unit (the typical "wave" pattern in this repo),
+> name the branch `wave-N-<short-slug>` so `pr-tests.yml`'s `wave-*` glob
+> trigger picks it up automatically — no workflow patch round-trip
+> required.
+
+**Why:** The previous version of this rule (§7) required a workflow-edit
+PR before any wave work could start. The pattern fired correctly, but the
+edit was identical every time except for the branch name, and it cost a
+round-trip. Adding a `wave-*` glob to `pr-tests.yml` (PR #228) made the
+naming convention sufficient on its own. Wave branches now JustWork
+without per-wave plumbing; only ad-hoc one-off long-running branches
+(things that won't fit `wave-N-<slug>`) still need §7's manual extension.
+
+**How to apply:**
+
+Naming pattern: `wave-N-<short-slug>` where:
+
+- `N` is the wave number (matches the project board's "Wave" custom field
+  — Wave 2 → `wave-2-...`, Wave 3 → `wave-3-...`).
+- `<short-slug>` is a kebab-case description of the wave's theme. Pick
+  the same shape used for issue titles: a few words, no punctuation
+  beyond hyphens, no trailing slash.
+
+Examples:
+
+- `wave-2-audit-followups`
+- `wave-3-edges-epic`
+- `wave-4-search`
+
+`pr-tests.yml` already triggers on `branches: [main, 'wave-*']`, so PRs
+into any matching branch fire the full lint + security + compile +
+integration suite automatically. No workflow patch needed.
+
+Sequence for a new wave:
+
+1. Create the wave branch off `main`: `git checkout -b wave-N-<slug>`.
+2. Open feature PRs against the wave branch (`gh pr create --base wave-N-<slug>`).
+   Existing in-flight PRs against main can be re-targeted with
+   `gh pr edit <num> --base wave-N-<slug>`.
+3. Run `weekend.yml` against the wave branch once the wave's PRs have all
+   merged into it: `gh workflow run weekend.yml --ref wave-N-<slug>`.
+   This is the integration-verification step that justifies the wave
+   pattern in the first place.
+4. Open the final merge PR `wave-N-<slug>` → `main` once weekend.yml is
+   green.
+
+If `weekend.yml` fails on the wave branch, fix on the wave branch (open
+a new PR into it) and re-run; this is the whole point — main stays at
+last-known-stable until the wave is integration-verified.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #227. Adds a \`wave-*\` glob trigger to \`pr-tests.yml\` and
codifies the \`wave-N-<short-slug>\` naming convention in
\`AI-COLLABORATION-CONVENTIONS.md\` §7a. Removes the per-wave
workflow-edit round-trip the original §7 long-running-branch rule
required.

After this lands: any branch named \`wave-N-<slug>\` (e.g.
\`wave-2-audit-followups\`) gets full lint + security + compile +
integration CI on PRs into it, automatically. Ad-hoc one-off
long-running branches that don't fit the convention still follow §7's
manual extension pattern.

## Files changed

- \`.github/workflows/pr-tests.yml\` — add \`'wave-*'\` to \`on.pull_request.branches\` (now \`[main, 'wave-*']\`). Comment cross-references §7a so the why is discoverable from the workflow.
- \`docs/AI-COLLABORATION-CONVENTIONS.md\` — add §7a "Wave branches" with naming pattern, examples (\`wave-2-audit-followups\`, \`wave-3-edges-epic\`, \`wave-4-search\`), the auto-CI guarantee, and the wave sequence (create branch → re-target PRs with \`gh pr edit --base\` → run \`weekend.yml --ref wave-N-<slug>\` once integrated → final merge PR to main). Update §7's "how to apply" to dispatch waves to §7a; non-wave long-running branches still use §7's manual flow. Add bullet to the Quick reference (rule 7) so the convention is portable.

## Memory entry update

\`feedback_long_running_branch_ci.md\` rewritten as a thin replica per §8: now points at §7 + §7a and reflects the wave-vs-other decision rule. Memory description updated so the relevance matcher fires on both subtypes.

## Work breakdown

- [x] Extend \`pr-tests.yml\` with \`wave-*\` glob
- [x] Add §7a to AI-COLLABORATION-CONVENTIONS.md
- [x] Update §7 "how to apply" to dispatch to §7a for waves
- [x] Update Quick reference rule 7 with the wave subtype note
- [x] Rewrite memory entry to thin-replica style pointing at §7+§7a
- [x] Verify CI on this PR (lint + integration suite still fires for main-targeted PRs)

## Test plan

- [x] Doc + workflow change only; no service changes.
- [x] CI on this PR will exercise the existing trigger (\`branches: [main]\`); the new \`wave-*\` glob takes effect for any future PR into a \`wave-*\` branch.
- [ ] After merge: smoke-test by creating \`wave-2-audit-followups\` and re-targeting an audit follow-up PR — confirm CI fires automatically with no further workflow edits. (This is the in-flight follow-up work from issue #219; will land separately.)

## Operational impact

None (workflow + doc + memory). No service restart, no migration.

## Notes

The §7a "Why" paragraph references this PR's number — it should land as #228 (next sequential after #227); will fix in a tiny follow-up if the actual number differs.