### PR TITLE
Document GitHub Projects v2 traps (#249)

### DIFF
--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -252,6 +252,73 @@ gh api graphql -f query='
 When porting to another project, replace these IDs with the equivalents from
 your own GraphQL query.
 
+#### 2a. Project-board operations — destructive-mutation traps
+
+Two failure modes from a 2026-05-08 incident, captured here so the next
+agent doesn't re-discover them the hard way:
+
+**Trap 1: `updateProjectV2Field` regenerates *all* option IDs.** The mutation:
+
+```graphql
+updateProjectV2Field(input: {
+  fieldId: "..."
+  singleSelectOptions: [
+    { name: "Wave 1", color: GRAY, description: "" }
+    { name: "Wave 2", color: GRAY, description: "" }
+    ...
+    { name: "Wave 6", color: GRAY, description: "" }   # the new one
+  ]
+})
+```
+
+…regenerates the `id` of *every* option in the list, even when names
+are unchanged. Every previously-tagged item then references a stale
+option ID and shows as untagged on the board. Issues themselves are
+unaffected; only the project field-value linkage breaks. Recovery
+requires re-tagging every item from session memory or git history,
+which is a slog and lossy if the original tags weren't captured
+elsewhere.
+
+The undocumented quirk: there's no `updateProjectV2Field` variant that
+*appends* an option without rewriting the list. The safe path:
+
+- **Use the GitHub web UI** (Project settings → field → "Add option"). The web UI preserves existing IDs.
+- The CLI / GraphQL path doesn't have an additive equivalent (verified 2026-05-08).
+- If the GraphQL path is unavoidable (e.g., automated provisioning), pre-snapshot all item-tag bindings (`gh project item-list ... --jq '.items[] | "\(.content.number)|\(.fieldValues...)"'`) before the mutation, then re-apply tags from the snapshot afterward.
+
+**Trap 2: GraphQL is rate-limited at 5000/hour with a tighter
+secondary per-minute limit.** Every `gh project item-list`,
+`item-edit`, and `gh issue create` call hits the GraphQL quota. A
+burst of ~25 mutations during a recovery attempt triggered the
+secondary limit; the primary was 4/5000 remaining when checked.
+Reset window for that incident was **42 minutes**.
+
+How to stay under:
+
+- **Snapshot, then iterate.** Do one `gh project item-list` to dump
+  all item IDs into a local file, then loop edits — never re-query
+  inside the loop.
+- **Throttle destructive bursts.** If doing more than ~50 mutations
+  in a sitting, add `sleep 2` between item-edits. Each `sleep 2`
+  costs nothing; each rate-limit recovery costs ~42 minutes.
+- **Don't combine** a wave-tag refactor (or any mass re-tagging)
+  with other destructive board work in the same hour.
+- **Check before bursting:** `gh api rate_limit --jq '.resources.graphql'`
+  shows remaining + reset epoch; aim for ≥ (intended_mutations + 100) headroom.
+
+When rate-limited mid-burst, the safest move is to stop, log what
+was done, and return after the reset — cascading retries against a
+limited quota turn a 42-minute wait into a multi-hour one.
+
+**Workarounds that don't use GraphQL.** During a rate-limit window
+the following still work because they hit the REST API:
+
+- `gh issue close` / `gh issue reopen`
+- `gh issue edit --body / --title` (label edits route through GraphQL — beware)
+- `gh api -X POST repos/{owner}/{repo}/issues -f title=... -f body=...` (REST issue create — bypasses `gh issue create`'s GraphQL path; project membership has to be added later)
+- All git operations
+- All doc edits
+
 ### 3. Add every new issue to the default project
 
 > **Rule:** Whenever creating a new issue, add it to the project's default


### PR DESCRIPTION
## Summary

Closes #249. Adds §2a "Project-board operations — destructive-mutation traps" to AI-COLLABORATION-CONVENTIONS.md. Captures two failure modes from a 2026-05-08 incident so the next agent doesn't re-discover them:

1. **`updateProjectV2Field` regenerates all option IDs** even when names are unchanged. Every previously-tagged item then references a stale ID and shows as untagged. Use the GitHub web UI for additive changes.
2. **GraphQL rate limit is 5000/hour with a tighter per-minute secondary limit.** Bursts of project-board mutations need snapshot-then-iterate + `sleep 2`. Recovery if exceeded is ~42 minutes.

Memory entry updated per §8 (doc-as-master) to thin-replicate the warning + cached option IDs.

## Files changed

- `docs/AI-COLLABORATION-CONVENTIONS.md` — new §2a covering both traps with symptoms, causes, prevention, and REST workarounds available during a rate-limit window.

## Memory entry

`feedback_ticket_status_lifecycle.md` updated to reference §2a + carry the regenerated option IDs (Wave 1-6 + Deferred).

## Work breakdown

- [x] Diagnose what broke (option-ID regen)
- [x] Diagnose the second trap (rate limit during recovery)
- [x] Write §2a with both traps + recovery + prevention guidance
- [x] Add REST workarounds list for rate-limit windows
- [x] Thin-replicate memory entry

## Test plan

- [x] Doc + memory only.
- [x] No service changes.
- [x] PR body itself follows the conventions doc (Files changed, Work breakdown, Test plan, Operational impact).

## Operational impact

None.

## Notes

This PR exists because of a real incident this session: I hit Trap 1 trying to add Wave 6 to the project board, then hit Trap 2 trying to recover. Recovery of the broken wave tags is happening separately (manual re-tagging via the cached IDs and session memory) and isn't in scope here.