### PR TITLE
pr-tests.yml: anchor Playwright failure regex on ✘ (#251)

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -312,7 +312,12 @@ jobs:
               }
             }
             for (const line of e2eLog.split('\n')) {
-              const m = line.match(/\[chromium\]\s+›\s+(.+)/);
+              // Anchor on Playwright's failure glyph (✘). The list reporter
+              // prints all per-test lines with "[chromium] ›" — passes (✓),
+              // fails (✘), and skips (-) — so a substring match would
+              // capture every test, not just failures, and emit a phantom
+              // Failures block on green runs (#251).
+              const m = line.match(/✘\s+\d+\s+\[chromium\]\s+›\s+(.+)/);
               if (m) failures.push('E2E: ' + m[1].trim());
             }
 


### PR DESCRIPTION
## Summary

Closes #251. One-line fix to the failure-extraction regex in the PR-test summary comment. Pre-fix, every test (passing, failing, skipped) was matched and emitted under \"Failures\" — visible on PR #250 right now: the table reads 0/0/0 but the section lists ~70 entries. Post-fix, only real failures land in the Failures block.

## Files changed

- \`.github/workflows/pr-tests.yml\` — anchor the e2eLog scan on \`✘\s+\d+\s+\[chromium\]\s+›\` so only Playwright's failure-glyph lines match. Passes (\`✓\`) and skips (\`-\`) no longer pollute the failures array. Comment block explains why.

## Work breakdown

- [x] Identify the bug (regex matches all per-test lines, not just failures)
- [x] Confirm the comment update path is correct (full body rebuild + updateComment) — only the regex was wrong
- [x] Apply one-line fix + comment

## Test plan

- [x] Local diff review: regex now requires the ✘ glyph + the index, both stable in Playwright list-reporter output.
- [x] No backend / frontend code touched.
- [ ] **Live-fire validation post-merge:** trigger a CI re-run on PR #250 (currently shows the bug) and verify the Failures block is gone from the comment.

## Operational impact

None at runtime. CI workflow change only.

## Notes

The bug surfaced on PR #250's CI rerun: that run was clean (table 0/0/0) but the comment still showed a long Failures list. This PR fixes that.