### PR TITLE
Backend: Edges schema + EdgeController CRUD (#148, Wave 4 PR1)

### DIFF
--- a/backend/src/controllers/EdgeController.cpp
+++ b/backend/src/controllers/EdgeController.cpp
@@ -1,0 +1,631 @@
+#include "EdgeController.h"
+#include "AuditLog.h"
+#include "ErrorResponse.h"
+#include <drogon/drogon.h>
+
+// Phase 1 of the edges epic (#148). Schema + unfiltered CRUD; the
+// visibility filter (edge visible iff BOTH endpoints visible) lands in
+// #197 as a follow-up. Edges connect two nodes within a single map and
+// are scoped to that map's permissions for read + write.
+//
+// Read authorization: caller must have view-level access to the map.
+// Write authorization: caller must have edit-level access to the map
+// (or be the owner) AND tenant role admin or editor.
+//
+// Endpoints are immutable on update — to "re-target" an edge, delete it
+// and create a new one. Keeps audit semantics simple (an updated edge
+// stays "the same edge" from the caller's perspective).
+
+namespace {
+
+int callerUserId(const drogon::HttpRequestPtr& req) {
+    try { return req->getAttributes()->get<int>("userId"); }
+    catch (...) { return 0; }
+}
+
+bool isTenantEditorOrAdmin(const drogon::HttpRequestPtr& req) {
+    try {
+        const auto role = req->getAttributes()->get<std::string>("tenantRole");
+        return role == "admin" || role == "editor";
+    } catch (...) { return false; }
+}
+
+Json::Value rowToEdge(const drogon::orm::Row& row) {
+    Json::Value e;
+    e["id"]            = row["id"].as<int>();
+    e["mapId"]         = row["map_id"].as<int>();
+    e["sourceNodeId"]  = row["source_node_id"].as<int>();
+    e["destNodeId"]    = row["dest_node_id"].as<int>();
+    e["directed"]      = row["directed"].as<bool>();
+    e["color"]         = row["color"].isNull()
+                            ? Json::Value()
+                            : Json::Value(row["color"].as<std::string>());
+    e["label"]         = row["label"].isNull()
+                            ? Json::Value()
+                            : Json::Value(row["label"].as<std::string>());
+    e["description"]   = row["description"].isNull()
+                            ? "" : row["description"].as<std::string>();
+    e["createdBy"]     = row["created_by"].as<int>();
+    e["createdAt"]     = row["created_at"].as<std::string>();
+    e["updatedAt"]     = row["updated_at"].as<std::string>();
+    return e;
+}
+
+const std::string EDGE_COLUMNS =
+    "id, map_id, source_node_id, dest_node_id, directed, color, label, "
+    "description, created_by, created_at, updated_at";
+
+}  // namespace
+
+// ─── GET /api/v1/tenants/{tid}/maps/{mid}/edges ──────────────────────────────
+
+void EdgeController::listEdges(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId) {
+
+    int userId = callerUserId(req);
+
+    // First verify the caller has view access on the map; on success,
+    // fetch the edges. Splitting the read makes 403/empty-array
+    // distinguishable (map missing or hidden → 403; map visible but no
+    // edges → 200 []).
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT m.id FROM maps m "
+        "LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ? "
+        "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
+        "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
+        "WHERE m.id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? "
+        "       OR mp.level IN ('view','comment','edit','moderate','admin') "
+        "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
+        [callback, mapId](const drogon::orm::Result& rAccess) {
+            if (rAccess.empty()) {
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
+                return;
+            }
+            auto db2 = drogon::app().getDbClient();
+            db2->execSqlAsync(
+                "SELECT " + EDGE_COLUMNS +
+                " FROM node_edges WHERE map_id = ? "
+                " ORDER BY created_at ASC, id ASC",
+                [callback](const drogon::orm::Result& r) {
+                    Json::Value arr(Json::arrayValue);
+                    for (const auto& row : r) arr.append(rowToEdge(row));
+                    callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to fetch edges"));
+                },
+                mapId);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error"));
+        },
+        userId, mapId, tenantId, userId);
+}
+
+// ─── POST /api/v1/tenants/{tid}/maps/{mid}/edges ─────────────────────────────
+
+void EdgeController::createEdge(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId) {
+
+    if (!isTenantEditorOrAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Edge management requires editor or admin role"));
+        return;
+    }
+
+    int userId = callerUserId(req);
+    auto body  = req->getJsonObject();
+    if (!body || !(*body).isMember("sourceNodeId") || !(*body).isMember("destNodeId")) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "sourceNodeId and destNodeId are required"));
+        return;
+    }
+    if (!(*body)["sourceNodeId"].isInt() || !(*body)["destNodeId"].isInt()) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "sourceNodeId and destNodeId must be integers"));
+        return;
+    }
+
+    int sourceNodeId = (*body)["sourceNodeId"].asInt();
+    int destNodeId   = (*body)["destNodeId"].asInt();
+    if (sourceNodeId == destNodeId) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "sourceNodeId and destNodeId must differ"));
+        return;
+    }
+
+    bool directed = (*body).get("directed", false).asBool();
+    std::string color       = (*body).get("color", "").asString();
+    std::string label       = (*body).get("label", "").asString();
+    std::string description = (*body).get("description", "").asString();
+
+    if (!checkMaxLen("label", label, MAX_NAME_LEN, callback)) return;
+    if (!checkMaxLen("description", description, MAX_DESCRIPTION_LEN, callback)) return;
+    // Color is short; 9-char column accepts #RRGGBBAA. Reject longer
+    // values up-front for a clearer error than the DB truncation warning.
+    if (color.size() > 9) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "color must be a hex color (e.g. #ff0000)"));
+        return;
+    }
+
+    // Verify caller has edit access on the map AND both endpoints exist
+    // on this map. Single SELECT does both checks: count of nodes whose
+    // id ∈ {source, dest} AND map_id = ? must be 2.
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT m.id, "
+        "       (SELECT COUNT(*) FROM nodes n "
+        "          WHERE n.map_id = m.id AND n.id IN (?, ?)) AS endpoint_count "
+        "FROM maps m "
+        "LEFT JOIN map_permissions mp ON mp.map_id = m.id AND mp.user_id = ? "
+        "WHERE m.id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? OR mp.level IN ('edit','moderate','admin'))",
+        [callback, req, mapId, tenantId, userId,
+         sourceNodeId, destNodeId, directed, color, label, description]
+        (const drogon::orm::Result& rAcc) {
+            if (rAcc.empty()) {
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
+                return;
+            }
+            int endpointCount = rAcc[0]["endpoint_count"].as<int>();
+            if (endpointCount != 2) {
+                // Either one or both endpoints missing, or one is on a
+                // different map. Same error either way — don't leak
+                // which one — to avoid information disclosure.
+                callback(errorResponse(drogon::k400BadRequest,
+                    "bad_request",
+                    "sourceNodeId and destNodeId must both exist on this map"));
+                return;
+            }
+
+            // INSERT, then re-SELECT the canonical row (#152 pattern).
+            auto db2 = drogon::app().getDbClient();
+            db2->execSqlAsync(
+                "INSERT INTO node_edges "
+                "  (map_id, source_node_id, dest_node_id, directed, "
+                "   color, label, description, created_by) "
+                "VALUES (?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''), ?)",
+                [callback, req, mapId, tenantId, userId, sourceNodeId, destNodeId]
+                (const drogon::orm::Result& rIns) {
+                    int newId = static_cast<int>(rIns.insertId());
+                    Json::Value detail;
+                    detail["mapId"]        = mapId;
+                    detail["edgeId"]       = newId;
+                    detail["sourceNodeId"] = sourceNodeId;
+                    detail["destNodeId"]   = destNodeId;
+                    AuditLog::record("edge_create", req,
+                        userId, 0, tenantId, detail);
+
+                    auto db3 = drogon::app().getDbClient();
+                    db3->execSqlAsync(
+                        "SELECT " + EDGE_COLUMNS + " FROM node_edges "
+                        "WHERE id = ? AND map_id = ?",
+                        [callback](const drogon::orm::Result& rGet) {
+                            if (rGet.empty()) {
+                                callback(errorResponse(drogon::k500InternalServerError,
+                                    "internal_error", "Edge vanished after insert"));
+                                return;
+                            }
+                            auto resp = drogon::HttpResponse::newHttpJsonResponse(
+                                rowToEdge(rGet[0]));
+                            resp->setStatusCode(drogon::k201Created);
+                            callback(resp);
+                        },
+                        [callback](const drogon::orm::DrogonDbException&) {
+                            callback(errorResponse(drogon::k500InternalServerError,
+                                "db_error", "Failed to fetch created edge"));
+                        },
+                        newId, mapId);
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to create edge"));
+                },
+                mapId, sourceNodeId, destNodeId, directed,
+                color, label, description, userId);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error"));
+        },
+        sourceNodeId, destNodeId, userId, mapId, tenantId, userId);
+}
+
+// ─── GET /api/v1/tenants/{tid}/maps/{mid}/edges/{id} ─────────────────────────
+
+void EdgeController::getEdge(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int id) {
+
+    int userId = callerUserId(req);
+
+    // Verify view access on the map first; on success, fetch the edge.
+    // Returns 404 (not 403) if the edge doesn't exist on this map — the
+    // caller proved they could see the map, so distinguishing missing
+    // from hidden is fine here.
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT m.id FROM maps m "
+        "LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ? "
+        "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
+        "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
+        "WHERE m.id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? "
+        "       OR mp.level IN ('view','comment','edit','moderate','admin') "
+        "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
+        [callback, mapId, id](const drogon::orm::Result& rAcc) {
+            if (rAcc.empty()) {
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
+                return;
+            }
+            auto db2 = drogon::app().getDbClient();
+            db2->execSqlAsync(
+                "SELECT " + EDGE_COLUMNS +
+                " FROM node_edges WHERE id = ? AND map_id = ?",
+                [callback](const drogon::orm::Result& r) {
+                    if (r.empty()) {
+                        callback(errorResponse(drogon::k404NotFound,
+                            "not_found", "Edge not found"));
+                        return;
+                    }
+                    callback(drogon::HttpResponse::newHttpJsonResponse(rowToEdge(r[0])));
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to fetch edge"));
+                },
+                id, mapId);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error"));
+        },
+        userId, mapId, tenantId, userId);
+}
+
+// ─── PUT /api/v1/tenants/{tid}/maps/{mid}/edges/{id} ─────────────────────────
+//
+// Endpoints (sourceNodeId, destNodeId) are immutable. Body accepts
+// directed, color, label, description (any subset). Body fields that
+// are omitted leave the column unchanged.
+
+void EdgeController::updateEdge(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int id) {
+
+    if (!isTenantEditorOrAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Edge management requires editor or admin role"));
+        return;
+    }
+
+    int userId = callerUserId(req);
+    auto body  = req->getJsonObject();
+    if (!body) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "Request body required"));
+        return;
+    }
+
+    bool hasDirected    = body->isMember("directed");
+    bool hasColor       = body->isMember("color");
+    bool hasLabel       = body->isMember("label");
+    bool hasDescription = body->isMember("description");
+
+    if (!hasDirected && !hasColor && !hasLabel && !hasDescription) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "At least one of directed/color/label/description required"));
+        return;
+    }
+
+    bool directed       = hasDirected ? (*body)["directed"].asBool() : false;
+    std::string color       = hasColor       ? (*body)["color"].asString()       : "";
+    std::string label       = hasLabel       ? (*body)["label"].asString()       : "";
+    std::string description = hasDescription ? (*body)["description"].asString() : "";
+
+    if (hasLabel       && !checkMaxLen("label", label, MAX_NAME_LEN, callback)) return;
+    if (hasDescription && !checkMaxLen("description", description, MAX_DESCRIPTION_LEN, callback)) return;
+    if (hasColor && color.size() > 9) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "color must be a hex color (e.g. #ff0000)"));
+        return;
+    }
+
+    // Verify caller has edit access on the map; on success, run the
+    // partial UPDATE (each column gated by its has-flag). Same pattern
+    // as PlotController::updatePlot — empty string maps to NULL via
+    // NULLIF for nullable columns.
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT m.id FROM maps m "
+        "LEFT JOIN map_permissions mp ON mp.map_id = m.id AND mp.user_id = ? "
+        "WHERE m.id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? OR mp.level IN ('edit','moderate','admin'))",
+        [callback, req, mapId, tenantId, userId, id,
+         hasDirected, directed, hasColor, color, hasLabel, label,
+         hasDescription, description]
+        (const drogon::orm::Result& rAcc) {
+            if (rAcc.empty()) {
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
+                return;
+            }
+
+            // Build UPDATE with only the supplied columns. Pass-through
+            // unchanged columns by reusing the existing value via the
+            // table itself (e.g. `color = IF(?, NULLIF(?, ''), color)`).
+            std::string sql = "UPDATE node_edges SET ";
+            std::vector<std::string> sets;
+            if (hasDirected)    sets.push_back("directed = ?");
+            if (hasColor)       sets.push_back("color = NULLIF(?, '')");
+            if (hasLabel)       sets.push_back("label = NULLIF(?, '')");
+            if (hasDescription) sets.push_back("description = NULLIF(?, '')");
+            for (size_t i = 0; i < sets.size(); ++i) {
+                sql += (i ? ", " : "") + sets[i];
+            }
+            sql += " WHERE id = ? AND map_id = ?";
+
+            auto onUpdated = [callback, req, mapId, tenantId, userId, id]
+                (const drogon::orm::Result& rU) {
+                if (rU.affectedRows() == 0) {
+                    // Either edge doesn't exist on this map, or values
+                    // matched exactly (no-op). Disambiguate.
+                    auto dbEx = drogon::app().getDbClient();
+                    dbEx->execSqlAsync(
+                        "SELECT 1 FROM node_edges WHERE id = ? AND map_id = ?",
+                        [callback, req, mapId, tenantId, userId, id]
+                        (const drogon::orm::Result& rEx) {
+                            if (rEx.empty()) {
+                                callback(errorResponse(drogon::k404NotFound,
+                                    "not_found", "Edge not found"));
+                                return;
+                            }
+                            // No-op success: re-fetch and return.
+                            Json::Value detail;
+                            detail["edgeId"] = id; detail["noop"] = true;
+                            AuditLog::record("edge_update", req,
+                                userId, 0, tenantId, detail);
+                            auto dbR = drogon::app().getDbClient();
+                            dbR->execSqlAsync(
+                                "SELECT " + EDGE_COLUMNS +
+                                " FROM node_edges WHERE id = ? AND map_id = ?",
+                                [callback](const drogon::orm::Result& rGet) {
+                                    if (rGet.empty()) {
+                                        callback(errorResponse(drogon::k404NotFound,
+                                            "not_found", "Edge not found"));
+                                        return;
+                                    }
+                                    callback(drogon::HttpResponse::newHttpJsonResponse(rowToEdge(rGet[0])));
+                                },
+                                [callback](const drogon::orm::DrogonDbException&) {
+                                    callback(errorResponse(drogon::k500InternalServerError,
+                                        "db_error", "Failed to re-fetch edge"));
+                                },
+                                id, mapId);
+                        },
+                        [callback](const drogon::orm::DrogonDbException&) {
+                            callback(errorResponse(drogon::k500InternalServerError,
+                                "db_error", "Database error"));
+                        },
+                        id, mapId);
+                    return;
+                }
+                Json::Value detail;
+                detail["edgeId"] = id;
+                AuditLog::record("edge_update", req,
+                    userId, 0, tenantId, detail);
+                auto dbR = drogon::app().getDbClient();
+                dbR->execSqlAsync(
+                    "SELECT " + EDGE_COLUMNS +
+                    " FROM node_edges WHERE id = ? AND map_id = ?",
+                    [callback](const drogon::orm::Result& rGet) {
+                        if (rGet.empty()) {
+                            callback(errorResponse(drogon::k404NotFound,
+                                "not_found", "Edge not found"));
+                            return;
+                        }
+                        callback(drogon::HttpResponse::newHttpJsonResponse(rowToEdge(rGet[0])));
+                    },
+                    [callback](const drogon::orm::DrogonDbException&) {
+                        callback(errorResponse(drogon::k500InternalServerError,
+                            "db_error", "Failed to re-fetch edge"));
+                    },
+                    id, mapId);
+            };
+            auto onErr = [callback](const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Failed to update edge"));
+            };
+
+            auto db2 = drogon::app().getDbClient();
+            // Bind the column values in the order of `sets`, then id, mapId.
+            // Each present flag adds one bind parameter.
+            // We iterate the 16 combinations explicitly to keep type-correctness:
+            // bool / std::string mixed parameter packs are unsupported in a
+            // single dynamic call, so dispatch on the bitmask of present flags.
+            int mask = (hasDirected    ? 1 : 0) |
+                       (hasColor       ? 2 : 0) |
+                       (hasLabel       ? 4 : 0) |
+                       (hasDescription ? 8 : 0);
+            switch (mask) {
+                case 1: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, id, mapId); break;
+                case 2: db2->execSqlAsync(sql, onUpdated, onErr,
+                    color, id, mapId); break;
+                case 3: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, color, id, mapId); break;
+                case 4: db2->execSqlAsync(sql, onUpdated, onErr,
+                    label, id, mapId); break;
+                case 5: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, label, id, mapId); break;
+                case 6: db2->execSqlAsync(sql, onUpdated, onErr,
+                    color, label, id, mapId); break;
+                case 7: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, color, label, id, mapId); break;
+                case 8: db2->execSqlAsync(sql, onUpdated, onErr,
+                    description, id, mapId); break;
+                case 9: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, description, id, mapId); break;
+                case 10: db2->execSqlAsync(sql, onUpdated, onErr,
+                    color, description, id, mapId); break;
+                case 11: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, color, description, id, mapId); break;
+                case 12: db2->execSqlAsync(sql, onUpdated, onErr,
+                    label, description, id, mapId); break;
+                case 13: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, label, description, id, mapId); break;
+                case 14: db2->execSqlAsync(sql, onUpdated, onErr,
+                    color, label, description, id, mapId); break;
+                case 15: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, color, label, description, id, mapId); break;
+                default: break;  // mask = 0 already rejected above
+            }
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error"));
+        },
+        userId, mapId, tenantId, userId);
+}
+
+// ─── DELETE /api/v1/tenants/{tid}/maps/{mid}/edges/{id} ──────────────────────
+
+void EdgeController::deleteEdge(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int id) {
+
+    if (!isTenantEditorOrAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Edge management requires editor or admin role"));
+        return;
+    }
+
+    int userId = callerUserId(req);
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT m.id FROM maps m "
+        "LEFT JOIN map_permissions mp ON mp.map_id = m.id AND mp.user_id = ? "
+        "WHERE m.id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? OR mp.level IN ('edit','moderate','admin'))",
+        [callback, req, mapId, tenantId, userId, id]
+        (const drogon::orm::Result& rAcc) {
+            if (rAcc.empty()) {
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
+                return;
+            }
+            auto db2 = drogon::app().getDbClient();
+            db2->execSqlAsync(
+                "DELETE FROM node_edges WHERE id = ? AND map_id = ?",
+                [callback, req, mapId, tenantId, userId, id]
+                (const drogon::orm::Result& rD) {
+                    if (rD.affectedRows() == 0) {
+                        callback(errorResponse(drogon::k404NotFound,
+                            "not_found", "Edge not found"));
+                        return;
+                    }
+                    Json::Value detail;
+                    detail["edgeId"] = id; detail["mapId"] = mapId;
+                    AuditLog::record("edge_delete", req,
+                        userId, 0, tenantId, detail);
+                    auto resp = drogon::HttpResponse::newHttpResponse();
+                    resp->setStatusCode(drogon::k204NoContent);
+                    callback(resp);
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to delete edge"));
+                },
+                id, mapId);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error"));
+        },
+        userId, mapId, tenantId, userId);
+}
+
+// ─── GET /api/v1/tenants/{tid}/maps/{mid}/nodes/{nid}/edges ──────────────────
+// All edges where source = nodeId OR dest = nodeId, on this map.
+
+void EdgeController::listEdgesForNode(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int nodeId) {
+
+    int userId = callerUserId(req);
+
+    // Same map-view check as listEdges. Visibility filter on the *other*
+    // endpoint comes in #197.
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT m.id FROM maps m "
+        "LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ? "
+        "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
+        "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
+        "WHERE m.id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? "
+        "       OR mp.level IN ('view','comment','edit','moderate','admin') "
+        "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
+        [callback, mapId, nodeId](const drogon::orm::Result& rAcc) {
+            if (rAcc.empty()) {
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
+                return;
+            }
+            // Verify the node is on this map (cheap; avoids returning
+            // an empty array when the caller passed a bogus nodeId).
+            auto dbN = drogon::app().getDbClient();
+            dbN->execSqlAsync(
+                "SELECT 1 FROM nodes WHERE id = ? AND map_id = ?",
+                [callback, mapId, nodeId](const drogon::orm::Result& rN) {
+                    if (rN.empty()) {
+                        callback(errorResponse(drogon::k404NotFound,
+                            "not_found", "Node not found on this map"));
+                        return;
+                    }
+                    auto db2 = drogon::app().getDbClient();
+                    db2->execSqlAsync(
+                        "SELECT " + EDGE_COLUMNS +
+                        " FROM node_edges "
+                        "WHERE map_id = ? AND (source_node_id = ? OR dest_node_id = ?) "
+                        "ORDER BY created_at ASC, id ASC",
+                        [callback](const drogon::orm::Result& r) {
+                            Json::Value arr(Json::arrayValue);
+                            for (const auto& row : r) arr.append(rowToEdge(row));
+                            callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+                        },
+                        [callback](const drogon::orm::DrogonDbException&) {
+                            callback(errorResponse(drogon::k500InternalServerError,
+                                "db_error", "Failed to fetch edges"));
+                        },
+                        mapId, nodeId, nodeId);
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Database error"));
+                },
+                nodeId, mapId);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error"));
+        },
+        userId, mapId, tenantId, userId);
+}

--- a/backend/src/controllers/EdgeController.h
+++ b/backend/src/controllers/EdgeController.h
@@ -1,0 +1,86 @@
+#pragma once
+#include <drogon/HttpController.h>
+
+/**
+ * EdgeController — graph layer alongside the existing node tree (#148).
+ *
+ * Edges connect two nodes within the same map for relational use cases
+ * (trade routes, ferry connections, quest dependencies). Tree structure
+ * (parent_id) stays for containment; edges layer in for "A connects to B."
+ *
+ * This sub-ticket lands the schema + unfiltered CRUD. Visibility filtering
+ * (edge is visible iff BOTH endpoints are visible) lands in #197.
+ *
+ * Edge CRUD:
+ *   GET    /api/v1/tenants/{tenantId}/maps/{mapId}/edges
+ *   POST   /api/v1/tenants/{tenantId}/maps/{mapId}/edges
+ *   GET    /api/v1/tenants/{tenantId}/maps/{mapId}/edges/{id}
+ *   PUT    /api/v1/tenants/{tenantId}/maps/{mapId}/edges/{id}
+ *   DELETE /api/v1/tenants/{tenantId}/maps/{mapId}/edges/{id}
+ *
+ * Per-node edge listing (used by NodeDetailPanel in #200):
+ *   GET    /api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{nodeId}/edges
+ *
+ * Authorization:
+ *   - Read: any tenant member with view access on the map.
+ *   - Write: tenant admin/editor with edit access on the map.
+ *
+ * Body shapes:
+ *   POST /edges — { sourceNodeId, destNodeId, directed?, color?,
+ *                   label?, description? }
+ *   PUT  /edges/{id} — { directed?, color?, label?, description? }
+ *                       (endpoints are immutable; create a new edge to
+ *                        re-target — keeps audit semantics simple)
+ *
+ * Constraints:
+ *   - Both sourceNodeId and destNodeId must belong to {mapId}; cross-map
+ *     edges are out of scope for v1 (#148 design decision).
+ *   - sourceNodeId != destNodeId enforced by DB CHECK.
+ *   - Duplicate edges (same source/dest/directed) are intentionally
+ *     allowed — represent distinct trade routes, ferry runs, etc.
+ *
+ * POST/PUT both return the full canonical record (per §4b — frontend
+ * Zod schema parses the response without a follow-up GET).
+ */
+class EdgeController : public drogon::HttpController<EdgeController> {
+public:
+    METHOD_LIST_BEGIN
+        ADD_METHOD_TO(EdgeController::listEdges,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/edges",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+        ADD_METHOD_TO(EdgeController::createEdge,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/edges",
+                      drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(EdgeController::getEdge,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/edges/{id}",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+        ADD_METHOD_TO(EdgeController::updateEdge,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/edges/{id}",
+                      drogon::Put, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(EdgeController::deleteEdge,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/edges/{id}",
+                      drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(EdgeController::listEdgesForNode,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{nodeId}/edges",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+    METHOD_LIST_END
+
+    void listEdges(const drogon::HttpRequestPtr&,
+                   std::function<void(const drogon::HttpResponsePtr&)>&&,
+                   int tenantId, int mapId);
+    void createEdge(const drogon::HttpRequestPtr&,
+                    std::function<void(const drogon::HttpResponsePtr&)>&&,
+                    int tenantId, int mapId);
+    void getEdge(const drogon::HttpRequestPtr&,
+                 std::function<void(const drogon::HttpResponsePtr&)>&&,
+                 int tenantId, int mapId, int id);
+    void updateEdge(const drogon::HttpRequestPtr&,
+                    std::function<void(const drogon::HttpResponsePtr&)>&&,
+                    int tenantId, int mapId, int id);
+    void deleteEdge(const drogon::HttpRequestPtr&,
+                    std::function<void(const drogon::HttpResponsePtr&)>&&,
+                    int tenantId, int mapId, int id);
+    void listEdgesForNode(const drogon::HttpRequestPtr&,
+                          std::function<void(const drogon::HttpResponsePtr&)>&&,
+                          int tenantId, int mapId, int nodeId);
+};

--- a/backend/tests/run-tests.py
+++ b/backend/tests/run-tests.py
@@ -55,6 +55,7 @@ FAST_TESTS = [
     "test_26_coordinate_systems.py",
     "test_27_error_shape.py",
     "test_28_permissions.py",
+    "test_29_edges.py",
 ]
 
 # test_14_nodes.py landed in #96 (NodeController CRUD + tree + max-depth).

--- a/backend/tests/test_29_edges.py
+++ b/backend/tests/test_29_edges.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""test_29_edges.py — Phase 1 of edges epic (#148): schema + EdgeController CRUD.
+
+Covers:
+  - CRUD round-trip (list / create / get / update / delete)
+  - listEdgesForNode endpoint
+  - Self-loop rejection (DB CHECK + controller pre-check)
+  - Cross-map endpoint rejection (both nodes must belong to {mapId})
+  - Map FK CASCADE on delete (delete map → edges gone)
+  - Node FK CASCADE on delete (delete endpoint node → edge gone)
+  - Cross-tenant 403 (TenantFilter)
+  - Read auth: viewer can read, non-member rejected
+  - Write auth: viewer rejected, editor/admin allowed
+  - POST/PUT return full canonical record (#152 pattern)
+  - Endpoints immutable on update (PUT body can't change source/dest)
+  - Duplicate edges allowed (same source/dest/directed)
+"""
+
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import (
+    reset_counters, report, assert_status, assert_json_field, assert_true,
+    http_post, http_get, http_put, http_delete,
+    register_user, json_field, mysql_query,
+)
+
+reset_counters()
+RUN_ID = os.getpid()
+
+print("=== Edge Tests ===")
+
+# ─── Setup ───────────────────────────────────────────────────────────────────
+
+# A: tenant admin (full access)
+TOKEN_A = register_user(f"t29_a_{RUN_ID}", f"t29_a_{RUN_ID}@test.com", "testpass123")
+_, body_a = http_post("/auth/login",
+    {"email": f"t29_a_{RUN_ID}@test.com", "password": "testpass123"})
+TENANT_A   = json_field(body_a, ["tenantId"])
+USER_A_ID  = json_field(body_a, ["user", "id"])
+
+# B: same-org viewer of TENANT_A (read access only)
+TOKEN_B = register_user(f"t29_b_{RUN_ID}", f"t29_b_{RUN_ID}@test.com", "testpass123")
+_, body_b = http_post("/auth/login",
+    {"email": f"t29_b_{RUN_ID}@test.com", "password": "testpass123"})
+USER_B_ID = json_field(body_b, ["user", "id"])
+
+A_ORG_ID = mysql_query(f"SELECT org_id FROM users WHERE id={USER_A_ID};")
+mysql_query(f"UPDATE users SET org_id={A_ORG_ID} WHERE id={USER_B_ID};")
+mysql_query(
+    f"INSERT INTO tenant_members (tenant_id, user_id, role) "
+    f"VALUES ({TENANT_A}, {USER_B_ID}, 'viewer');")
+
+# C: separate tenant, used for cross-tenant rejection tests
+TOKEN_C = register_user(f"t29_c_{RUN_ID}", f"t29_c_{RUN_ID}@test.com", "testpass123")
+_, body_c = http_post("/auth/login",
+    {"email": f"t29_c_{RUN_ID}@test.com", "password": "testpass123"})
+TENANT_C  = json_field(body_c, ["tenantId"])
+
+# A creates a map and grants B view permission (so B can read but not write)
+_, body = http_post(f"/tenants/{TENANT_A}/maps", {
+    "title": "Edge Test Map",
+    "coordinateSystem": {"type": "wgs84", "center": {"lat": 0, "lng": 0}, "zoom": 3},
+}, TOKEN_A)
+MAP_ID = json_field(body, ["id"])
+mysql_query(
+    f"INSERT INTO map_permissions (map_id, user_id, level) "
+    f"VALUES ({MAP_ID}, {USER_B_ID}, 'view');")
+
+# Second map, used for cross-map endpoint rejection
+_, body = http_post(f"/tenants/{TENANT_A}/maps", {
+    "title": "Edge Other Map",
+    "coordinateSystem": {"type": "wgs84", "center": {"lat": 0, "lng": 0}, "zoom": 3},
+}, TOKEN_A)
+MAP2_ID = json_field(body, ["id"])
+
+NODES_BASE  = f"/tenants/{TENANT_A}/maps/{MAP_ID}/nodes"
+NODES2_BASE = f"/tenants/{TENANT_A}/maps/{MAP2_ID}/nodes"
+EDGES_BASE  = f"/tenants/{TENANT_A}/maps/{MAP_ID}/edges"
+
+def mknode(base, name):
+    _, b = http_post(base, {"name": name}, TOKEN_A)
+    return json_field(b, ["id"])
+
+NODE_X = mknode(NODES_BASE,  "X")
+NODE_Y = mknode(NODES_BASE,  "Y")
+NODE_Z = mknode(NODES_BASE,  "Z")
+NODE_OTHERMAP = mknode(NODES2_BASE, "OtherMapNode")
+
+# ─── CRUD ────────────────────────────────────────────────────────────────────
+
+print("  --- CRUD ---")
+
+# Empty list
+status, body = http_get(EDGES_BASE, TOKEN_A)
+assert_status("list: empty 200", 200, status)
+assert_true("list: array initially empty",
+            isinstance(body, list) and len(body) == 0)
+
+# Create (minimal — required fields only)
+status, body = http_post(EDGES_BASE, {
+    "sourceNodeId": NODE_X,
+    "destNodeId":   NODE_Y,
+}, TOKEN_A)
+assert_status("create: minimal returns 201", 201, status)
+EDGE_1 = json_field(body, ["id"])
+assert_json_field("create: mapId echoed",        body, ["mapId"],         str(MAP_ID))
+assert_json_field("create: source echoed",       body, ["sourceNodeId"],  str(NODE_X))
+assert_json_field("create: dest echoed",         body, ["destNodeId"],    str(NODE_Y))
+assert_json_field("create: directed defaults false", body, ["directed"], "False")
+assert_true("create: createdAt present", body.get("createdAt"))
+assert_true("create: updatedAt present", body.get("updatedAt"))
+
+# Create (full — all optional fields)
+status, body = http_post(EDGES_BASE, {
+    "sourceNodeId": NODE_Y,
+    "destNodeId":   NODE_Z,
+    "directed":     True,
+    "color":        "#ff0000",
+    "label":        "Trade route",
+    "description":  "Weekly caravan",
+}, TOKEN_A)
+assert_status("create: full body returns 201", 201, status)
+EDGE_2 = json_field(body, ["id"])
+assert_json_field("create: directed=true",   body, ["directed"], "True")
+assert_json_field("create: color persisted", body, ["color"],    "#ff0000")
+assert_json_field("create: label persisted", body, ["label"],    "Trade route")
+
+# Duplicate edges (same source/dest/directed) are intentionally allowed
+status, body = http_post(EDGES_BASE, {
+    "sourceNodeId": NODE_X,
+    "destNodeId":   NODE_Y,
+}, TOKEN_A)
+assert_status("create: duplicate edge allowed 201", 201, status)
+EDGE_DUP = json_field(body, ["id"])
+assert_true("create: duplicate edge has new id", EDGE_DUP != EDGE_1)
+
+# List shows all three
+status, body = http_get(EDGES_BASE, TOKEN_A)
+assert_true("list: 3 edges after create", len(body) == 3)
+
+# Get one
+status, body = http_get(f"{EDGES_BASE}/{EDGE_2}", TOKEN_A)
+assert_status("get: 200", 200, status)
+assert_json_field("get: label", body, ["label"], "Trade route")
+
+# Get unknown
+status, _ = http_get(f"{EDGES_BASE}/9999999", TOKEN_A)
+assert_status("get: unknown 404", 404, status)
+
+# Update — partial body (just label)
+status, body = http_put(f"{EDGES_BASE}/{EDGE_2}", {"label": "Updated route"}, TOKEN_A)
+assert_status("update: 200", 200, status)
+assert_json_field("update: label changed",    body, ["label"], "Updated route")
+assert_json_field("update: directed preserved", body, ["directed"], "True")
+assert_json_field("update: color preserved",  body, ["color"], "#ff0000")
+
+# Update — multiple fields at once
+status, body = http_put(f"{EDGES_BASE}/{EDGE_2}",
+                        {"directed": False, "color": "#00ff00"}, TOKEN_A)
+assert_json_field("update: directed flipped", body, ["directed"], "False")
+assert_json_field("update: color changed",    body, ["color"],    "#00ff00")
+assert_json_field("update: label preserved (partial)", body, ["label"], "Updated route")
+
+# Update with empty body returns 400
+status, _ = http_put(f"{EDGES_BASE}/{EDGE_2}", {}, TOKEN_A)
+assert_status("update: empty body 400", 400, status)
+
+# Update unknown
+status, _ = http_put(f"{EDGES_BASE}/9999999", {"label": "x"}, TOKEN_A)
+assert_status("update: unknown 404", 404, status)
+
+# Delete one (the duplicate)
+status, _ = http_delete(f"{EDGES_BASE}/{EDGE_DUP}", TOKEN_A)
+assert_status("delete: 204", 204, status)
+status, _ = http_get(f"{EDGES_BASE}/{EDGE_DUP}", TOKEN_A)
+assert_status("delete: gone after delete (404)", 404, status)
+
+# Delete unknown
+status, _ = http_delete(f"{EDGES_BASE}/9999999", TOKEN_A)
+assert_status("delete: unknown 404", 404, status)
+
+print("  All CRUD tests passed.")
+
+# ─── Validation ──────────────────────────────────────────────────────────────
+
+print("  --- Validation ---")
+
+# Missing required fields
+status, _ = http_post(EDGES_BASE, {"sourceNodeId": NODE_X}, TOKEN_A)
+assert_status("create: missing destNodeId 400", 400, status)
+
+status, _ = http_post(EDGES_BASE, {"destNodeId": NODE_Y}, TOKEN_A)
+assert_status("create: missing sourceNodeId 400", 400, status)
+
+# Self-loop rejection (controller pre-check)
+status, _ = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_X, "destNodeId": NODE_X}, TOKEN_A)
+assert_status("create: self-loop 400", 400, status)
+
+# Cross-map endpoint rejection — NODE_OTHERMAP is on MAP2, not MAP
+status, _ = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_X, "destNodeId": NODE_OTHERMAP}, TOKEN_A)
+assert_status("create: cross-map dest 400", 400, status)
+
+status, _ = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_OTHERMAP, "destNodeId": NODE_X}, TOKEN_A)
+assert_status("create: cross-map source 400", 400, status)
+
+# Missing endpoint id
+status, _ = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_X, "destNodeId": 9999999}, TOKEN_A)
+assert_status("create: missing dest 400", 400, status)
+
+# Color validation (oversized)
+status, _ = http_post(EDGES_BASE, {
+    "sourceNodeId": NODE_X, "destNodeId": NODE_Z,
+    "color": "#" + "f" * 20,
+}, TOKEN_A)
+assert_status("create: oversized color 400", 400, status)
+
+print("  All validation tests passed.")
+
+# ─── listEdgesForNode ───────────────────────────────────────────────────────
+
+print("  --- listEdgesForNode ---")
+
+# Currently: EDGE_1 (X→Y), EDGE_2 (Y→Z, after the updates above)
+# So NODE_Y touches both edges; NODE_X touches only EDGE_1
+status, body = http_get(f"{NODES_BASE}/{NODE_Y}/edges", TOKEN_A)
+assert_status("listForNode: 200", 200, status)
+edge_ids = {e["id"] for e in body}
+assert_true("listForNode: NODE_Y has 2 edges", edge_ids == {EDGE_1, EDGE_2})
+
+status, body = http_get(f"{NODES_BASE}/{NODE_X}/edges", TOKEN_A)
+edge_ids = {e["id"] for e in body}
+assert_true("listForNode: NODE_X has 1 edge", edge_ids == {EDGE_1})
+
+# Non-existent node
+status, _ = http_get(f"{NODES_BASE}/9999999/edges", TOKEN_A)
+assert_status("listForNode: unknown node 404", 404, status)
+
+# Node from a different map
+status, _ = http_get(f"{NODES_BASE}/{NODE_OTHERMAP}/edges", TOKEN_A)
+assert_status("listForNode: node on other map 404", 404, status)
+
+print("  All listEdgesForNode tests passed.")
+
+# ─── Authorization ──────────────────────────────────────────────────────────
+
+print("  --- Authorization ---")
+
+# Cross-tenant: TOKEN_C is in TENANT_C, not TENANT_A
+status, _ = http_get(EDGES_BASE, TOKEN_C)
+assert_status("auth: cross-tenant 403", 403, status)
+
+status, _ = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_X, "destNodeId": NODE_Y}, TOKEN_C)
+assert_status("auth: cross-tenant create 403", 403, status)
+
+# B is a viewer of TENANT_A with view perm on MAP_ID — can read
+status, body = http_get(EDGES_BASE, TOKEN_B)
+assert_status("auth: viewer can list 200", 200, status)
+assert_true("auth: viewer sees both edges", len(body) == 2)
+
+status, body = http_get(f"{EDGES_BASE}/{EDGE_1}", TOKEN_B)
+assert_status("auth: viewer can get 200", 200, status)
+
+# Viewer cannot write — tenant role 'viewer' fails the editor/admin gate
+status, _ = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_X, "destNodeId": NODE_Z}, TOKEN_B)
+assert_status("auth: viewer cannot create 403", 403, status)
+
+status, _ = http_put(f"{EDGES_BASE}/{EDGE_1}", {"label": "hacked"}, TOKEN_B)
+assert_status("auth: viewer cannot update 403", 403, status)
+
+status, _ = http_delete(f"{EDGES_BASE}/{EDGE_1}", TOKEN_B)
+assert_status("auth: viewer cannot delete 403", 403, status)
+
+print("  All authorization tests passed.")
+
+# ─── Cascade behavior ───────────────────────────────────────────────────────
+# FK constraints: deleting an endpoint node, the source/dest map, or the
+# user who created the edge should cascade-delete the edge row.
+
+print("  --- Cascade ---")
+
+# Create a fresh edge to verify node-delete cascade
+status, body = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_X, "destNodeId": NODE_Z}, TOKEN_A)
+EDGE_CASCADE = json_field(body, ["id"])
+
+# Delete NODE_Z → edge should cascade
+http_delete(f"{NODES_BASE}/{NODE_Z}", TOKEN_A)
+status, _ = http_get(f"{EDGES_BASE}/{EDGE_CASCADE}", TOKEN_A)
+assert_status("cascade: edge gone after endpoint node delete (404)", 404, status)
+
+# Delete the entire MAP2 with NODE_OTHERMAP attached: no edge to verify
+# (we only have edges on MAP_ID), but confirm map deletion still works.
+# Add an edge on MAP2 first to verify the map-delete cascade.
+NODE_M2_A = mknode(NODES2_BASE, "M2A")
+NODE_M2_B = mknode(NODES2_BASE, "M2B")
+status, body = http_post(f"/tenants/{TENANT_A}/maps/{MAP2_ID}/edges", {
+    "sourceNodeId": NODE_M2_A, "destNodeId": NODE_M2_B,
+}, TOKEN_A)
+EDGE_MAP2 = json_field(body, ["id"])
+
+http_delete(f"/tenants/{TENANT_A}/maps/{MAP2_ID}", TOKEN_A)
+# Map deletion cascades to nodes + edges; verify the edge row is gone
+remaining = mysql_query(
+    f"SELECT COUNT(*) FROM node_edges WHERE id={EDGE_MAP2};")
+assert_true("cascade: edge gone after map delete",  remaining == "0",
+            f"got remaining={remaining!r}")
+
+print("  All cascade tests passed.")
+
+sys.exit(0 if report() else 1)

--- a/database/migrations/003_edges.sql
+++ b/database/migrations/003_edges.sql
@@ -1,0 +1,44 @@
+-- Migration 003: Node edges (#148)
+-- Adds a graph layer alongside the existing tree (parent_id) for
+-- relational use cases — trade routes, ferry connections, quest
+-- dependencies, gates between regions. The tree structure stays for
+-- containment ("Region → City"); edges layer in for "A connects to B."
+--
+-- Edges are visible to a user iff BOTH endpoints are visible to them
+-- under the existing per-node visibility rules (see #197). No per-edge
+-- visibility tags — derived purely from endpoint visibility.
+
+CREATE TABLE IF NOT EXISTS node_edges (
+    id              BIGINT UNSIGNED  NOT NULL AUTO_INCREMENT,
+    map_id          BIGINT UNSIGNED  NOT NULL,
+    source_node_id  BIGINT UNSIGNED  NOT NULL,
+    dest_node_id    BIGINT UNSIGNED  NOT NULL,
+    directed        BOOLEAN          NOT NULL DEFAULT FALSE,
+    color           VARCHAR(9)                DEFAULT NULL,
+    label           VARCHAR(255)              DEFAULT NULL,
+    description     TEXT                      DEFAULT NULL,
+    created_by      BIGINT UNSIGNED  NOT NULL,
+    created_at      TIMESTAMP        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP        NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                              ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (id),
+    KEY idx_edge_map_src  (map_id, source_node_id),
+    KEY idx_edge_map_dst  (map_id, dest_node_id),
+    KEY idx_edge_creator  (created_by),
+
+    -- Self-loop prevention. Cross-map edges are out of scope for v1;
+    -- the controller enforces "both nodes belong to map_id" at insert
+    -- time. Duplicate edges (same source/dest/directed) are allowed
+    -- on purpose — distinct trade routes, distinct ferry runs, etc.
+    CONSTRAINT chk_edge_no_self_loop CHECK (source_node_id <> dest_node_id),
+
+    CONSTRAINT fk_edge_map
+        FOREIGN KEY (map_id)         REFERENCES maps  (id) ON DELETE CASCADE,
+    CONSTRAINT fk_edge_src
+        FOREIGN KEY (source_node_id) REFERENCES nodes (id) ON DELETE CASCADE,
+    CONSTRAINT fk_edge_dst
+        FOREIGN KEY (dest_node_id)   REFERENCES nodes (id) ON DELETE CASCADE,
+    CONSTRAINT fk_edge_creator
+        FOREIGN KEY (created_by)     REFERENCES users (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary

Closes #148. Foundation sub-ticket of the Edges epic. Adds the \`node_edges\` table, \`EdgeController\` with full CRUD, and integration tests. Visibility filter lands in #197 as the next sub-ticket.

## Files changed

- \`backend/src/controllers/EdgeController.cpp\` — full CRUD implementation. Read endpoints gate on view+ map permission; write endpoints gate on edit+ map permission AND tenant role admin/editor. Both endpoints must belong to {mapId} on create. POST/PUT re-SELECT and return the canonical record per #152.
- \`backend/src/controllers/EdgeController.h\` — header with the 6 routes (CRUD + listEdgesForNode), filters wired (JwtFilter + TenantFilter + RateLimitFilter on writes).
- \`backend/tests/run-tests.py\` — register \`test_29_edges.py\` in FAST_TESTS.
- \`backend/tests/test_29_edges.py\` — 53 assertions: CRUD, listEdgesForNode, self-loop rejection, cross-map endpoint rejection, FK CASCADE (node + map delete), cross-tenant 403, viewer read-only enforcement, duplicate-edges-allowed, partial-update column preservation.
- \`database/migrations/003_edges.sql\` — \`node_edges\` table with FKs to maps + nodes + users (all CASCADE on delete), CHECK for self-loop prevention, indexes for source/dest lookups.

## Schema decisions resolved (per #148 open questions)

- **Per-edge visibility tags:** NO — derived from endpoint visibility (#197).
- **Duplicate edges** (same source/dest/directed): **allowed** — distinct trade routes / ferry runs are legitimate.
- **Cross-map edges:** out of scope for v1; controller enforces "both endpoints on this map" at create.
- **Endpoints immutable on update** (re-target = delete + recreate).

## Work breakdown

- [x] Pre-flight + dep audit (#255 tracker)
- [x] Migration 003: \`node_edges\` schema
- [x] EdgeController.h: routes + signatures
- [x] EdgeController.cpp: 6 handlers (list/create/get/update/delete + listEdgesForNode)
- [x] test_29_edges.py: 53 assertions
- [x] Sibling suite (test_03/14/16/17/18/19/20/21/22/23/24/25/28/29) — all pass

## Test plan

- [x] \`test_29_edges.py\`: 53/53.
- [x] Sibling tests pass — no regression in node/visibility/plot suites.
- [x] CI on this PR (wave-4-edges base, auto-trigger via wave-* glob).

## Operational impact

- Backend rebuild + restart required (controller change). \`docker compose build backend && docker compose up -d backend\`.
- **New migration**: \`003_edges.sql\`. Runs automatically on fresh container init via \`docker-entrypoint-initdb.d\`. For existing local-dev databases, run \`docker compose exec -T mysql mysql -uroot -prootpassword annotated_maps < database/migrations/003_edges.sql\` once.

## Wave context

Wave 4 PR 1 of 5. Tracker: #255. Next up: #197 (visibility filter on read).