### PR TITLE
Backend: Edge visibility filter (#197, Wave 4 PR2)

### DIFF
--- a/backend/src/controllers/EdgeController.cpp
+++ b/backend/src/controllers/EdgeController.cpp
@@ -1,14 +1,18 @@
 #include "EdgeController.h"
 #include "AuditLog.h"
 #include "ErrorResponse.h"
+#include "NodeController.h"  // MAX_NODE_DEPTH for the resolve CTE
 #include <drogon/drogon.h>
 
-// Phase 1 of the edges epic (#148). Schema + unfiltered CRUD; the
-// visibility filter (edge visible iff BOTH endpoints visible) lands in
-// #197 as a follow-up. Edges connect two nodes within a single map and
-// are scoped to that map's permissions for read + write.
+// Edges connect two nodes within a single map for relational use cases.
 //
-// Read authorization: caller must have view-level access to the map.
+// Read authorization is two-layered (#197):
+//   1. Map permission: caller must have view-level access to the map.
+//   2. Edge visibility: an edge is visible iff BOTH endpoints are
+//      visible to the caller under the per-node #99 effective-visibility
+//      rules. Tenant admins bypass layer 2; map owners with
+//      owner_xray = TRUE also bypass.
+//
 // Write authorization: caller must have edit-level access to the map
 // (or be the owner) AND tenant role admin or editor.
 //
@@ -23,12 +27,53 @@ int callerUserId(const drogon::HttpRequestPtr& req) {
     catch (...) { return 0; }
 }
 
+bool isTenantAdmin(const drogon::HttpRequestPtr& req) {
+    try {
+        return req->getAttributes()->get<std::string>("tenantRole") == "admin";
+    } catch (...) { return false; }
+}
+
 bool isTenantEditorOrAdmin(const drogon::HttpRequestPtr& req) {
     try {
         const auto role = req->getAttributes()->get<std::string>("tenantRole");
         return role == "admin" || role == "editor";
     } catch (...) { return false; }
 }
+
+// Effective-visibility CTE — same shape as NodeController's, restated
+// locally so EdgeController doesn't take a private dependency on the
+// other controller's anonymous-namespace constants.
+//
+// Binds: (mapId, userId).
+const std::string VISIBILITY_RESOLVE_CTE =
+    "WITH RECURSIVE resolve AS ("
+    "  SELECT n.id AS start_id, n.id AS cur_id, n.parent_id, "
+    "         n.visibility_override, 0 AS depth "
+    "  FROM nodes n WHERE n.map_id = ? "
+    "  UNION ALL "
+    "  SELECT r.start_id, p.id, p.parent_id, p.visibility_override, r.depth + 1 "
+    "  FROM resolve r JOIN nodes p ON p.id = r.parent_id "
+    "  WHERE r.visibility_override = FALSE AND r.depth < " +
+        std::to_string(MAX_NODE_DEPTH) +
+    "), visible_starts AS ( "
+    "  SELECT DISTINCT r.start_id FROM resolve r "
+    "  JOIN node_visibility nv "
+    "       ON nv.node_id = r.cur_id AND r.visibility_override = TRUE "
+    "  JOIN visibility_group_members vgm "
+    "       ON vgm.visibility_group_id = nv.visibility_group_id "
+    "  WHERE vgm.user_id = ? "
+    ") ";
+
+// Edge-visibility predicate — both endpoints must be visible OR the
+// caller is the map owner with owner_xray=TRUE.
+// Binds: (userId).
+//
+// JOIN expectations: caller must have JOINed `maps m ON m.id = e.map_id`
+// for the owner_id / owner_xray check.
+const std::string EDGE_VISIBILITY_PREDICATE =
+    " AND ((m.owner_id = ? AND m.owner_xray = TRUE) "
+    "      OR (e.source_node_id IN (SELECT start_id FROM visible_starts) "
+    "          AND e.dest_node_id IN (SELECT start_id FROM visible_starts))) ";
 
 Json::Value rowToEdge(const drogon::orm::Row& row) {
     Json::Value e;
@@ -64,12 +109,12 @@ void EdgeController::listEdges(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId, int mapId) {
 
-    int userId = callerUserId(req);
+    int userId  = callerUserId(req);
+    bool isAdmin = isTenantAdmin(req);
 
     // First verify the caller has view access on the map; on success,
-    // fetch the edges. Splitting the read makes 403/empty-array
-    // distinguishable (map missing or hidden → 403; map visible but no
-    // edges → 200 []).
+    // fetch the edges. Admins skip the visibility CTE; non-admins get
+    // the both-endpoints-visible filter applied.
     auto db = drogon::app().getDbClient();
     db->execSqlAsync(
         "SELECT m.id FROM maps m "
@@ -80,27 +125,47 @@ void EdgeController::listEdges(
         "  AND (m.owner_id = ? "
         "       OR mp.level IN ('view','comment','edit','moderate','admin') "
         "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
-        [callback, mapId](const drogon::orm::Result& rAccess) {
+        [callback, mapId, userId, isAdmin](const drogon::orm::Result& rAccess) {
             if (rAccess.empty()) {
                 callback(errorResponse(drogon::k403Forbidden,
                     "forbidden", "Map not found or insufficient permissions"));
                 return;
             }
+
             auto db2 = drogon::app().getDbClient();
-            db2->execSqlAsync(
-                "SELECT " + EDGE_COLUMNS +
-                " FROM node_edges WHERE map_id = ? "
-                " ORDER BY created_at ASC, id ASC",
-                [callback](const drogon::orm::Result& r) {
-                    Json::Value arr(Json::arrayValue);
-                    for (const auto& row : r) arr.append(rowToEdge(row));
-                    callback(drogon::HttpResponse::newHttpJsonResponse(arr));
-                },
-                [callback](const drogon::orm::DrogonDbException&) {
-                    callback(errorResponse(drogon::k500InternalServerError,
-                        "db_error", "Failed to fetch edges"));
-                },
-                mapId);
+            auto onRows = [callback](const drogon::orm::Result& r) {
+                Json::Value arr(Json::arrayValue);
+                for (const auto& row : r) arr.append(rowToEdge(row));
+                callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+            };
+            auto onErr = [callback](const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Failed to fetch edges"));
+            };
+
+            if (isAdmin) {
+                db2->execSqlAsync(
+                    "SELECT " + EDGE_COLUMNS +
+                    " FROM node_edges WHERE map_id = ? "
+                    " ORDER BY created_at ASC, id ASC",
+                    onRows, onErr,
+                    mapId);
+            } else {
+                std::string sql = VISIBILITY_RESOLVE_CTE +
+                    "SELECT " +
+                    "  e.id, e.map_id, e.source_node_id, e.dest_node_id, "
+                    "  e.directed, e.color, e.label, e.description, "
+                    "  e.created_by, e.created_at, e.updated_at "
+                    "FROM node_edges e "
+                    "JOIN maps m ON m.id = e.map_id "
+                    "WHERE e.map_id = ? " +
+                    EDGE_VISIBILITY_PREDICATE +
+                    " ORDER BY e.created_at ASC, e.id ASC";
+                db2->execSqlAsync(sql, onRows, onErr,
+                    mapId, userId,            // CTE
+                    mapId,                    // WHERE e.map_id
+                    userId);                  // xray (m.owner_id = ?)
+            }
         },
         [callback](const drogon::orm::DrogonDbException&) {
             callback(errorResponse(drogon::k500InternalServerError,
@@ -249,12 +314,13 @@ void EdgeController::getEdge(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId, int mapId, int id) {
 
-    int userId = callerUserId(req);
+    int userId  = callerUserId(req);
+    bool isAdmin = isTenantAdmin(req);
 
     // Verify view access on the map first; on success, fetch the edge.
-    // Returns 404 (not 403) if the edge doesn't exist on this map — the
-    // caller proved they could see the map, so distinguishing missing
-    // from hidden is fine here.
+    // For non-admins, the edge fetch additionally enforces the
+    // both-endpoints-visible filter — a hidden edge returns 404, never
+    // 403, to avoid leaking edge existence (per #197 acceptance).
     auto db = drogon::app().getDbClient();
     db->execSqlAsync(
         "SELECT m.id FROM maps m "
@@ -265,29 +331,46 @@ void EdgeController::getEdge(
         "  AND (m.owner_id = ? "
         "       OR mp.level IN ('view','comment','edit','moderate','admin') "
         "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
-        [callback, mapId, id](const drogon::orm::Result& rAcc) {
+        [callback, mapId, id, userId, isAdmin](const drogon::orm::Result& rAcc) {
             if (rAcc.empty()) {
                 callback(errorResponse(drogon::k403Forbidden,
                     "forbidden", "Map not found or insufficient permissions"));
                 return;
             }
             auto db2 = drogon::app().getDbClient();
-            db2->execSqlAsync(
-                "SELECT " + EDGE_COLUMNS +
-                " FROM node_edges WHERE id = ? AND map_id = ?",
-                [callback](const drogon::orm::Result& r) {
-                    if (r.empty()) {
-                        callback(errorResponse(drogon::k404NotFound,
-                            "not_found", "Edge not found"));
-                        return;
-                    }
-                    callback(drogon::HttpResponse::newHttpJsonResponse(rowToEdge(r[0])));
-                },
-                [callback](const drogon::orm::DrogonDbException&) {
-                    callback(errorResponse(drogon::k500InternalServerError,
-                        "db_error", "Failed to fetch edge"));
-                },
-                id, mapId);
+            auto onRow = [callback](const drogon::orm::Result& r) {
+                if (r.empty()) {
+                    callback(errorResponse(drogon::k404NotFound,
+                        "not_found", "Edge not found"));
+                    return;
+                }
+                callback(drogon::HttpResponse::newHttpJsonResponse(rowToEdge(r[0])));
+            };
+            auto onErr = [callback](const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Failed to fetch edge"));
+            };
+
+            if (isAdmin) {
+                db2->execSqlAsync(
+                    "SELECT " + EDGE_COLUMNS +
+                    " FROM node_edges WHERE id = ? AND map_id = ?",
+                    onRow, onErr, id, mapId);
+            } else {
+                std::string sql = VISIBILITY_RESOLVE_CTE +
+                    "SELECT " +
+                    "  e.id, e.map_id, e.source_node_id, e.dest_node_id, "
+                    "  e.directed, e.color, e.label, e.description, "
+                    "  e.created_by, e.created_at, e.updated_at "
+                    "FROM node_edges e "
+                    "JOIN maps m ON m.id = e.map_id "
+                    "WHERE e.id = ? AND e.map_id = ? " +
+                    EDGE_VISIBILITY_PREDICATE;
+                db2->execSqlAsync(sql, onRow, onErr,
+                    mapId, userId,            // CTE
+                    id, mapId,                // WHERE e.id, e.map_id
+                    userId);                  // xray
+            }
         },
         [callback](const drogon::orm::DrogonDbException&) {
             callback(errorResponse(drogon::k500InternalServerError,
@@ -569,10 +652,17 @@ void EdgeController::listEdgesForNode(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId, int mapId, int nodeId) {
 
-    int userId = callerUserId(req);
+    int userId  = callerUserId(req);
+    bool isAdmin = isTenantAdmin(req);
 
-    // Same map-view check as listEdges. Visibility filter on the *other*
-    // endpoint comes in #197.
+    // Map view check, then node-on-map existence check, then edge fetch.
+    // For non-admins the edge fetch enforces both-endpoints-visible —
+    // the starting node MUST be in `visible_starts` (otherwise the
+    // `source_node_id IN ...` half of the predicate fails for any edge
+    // touching it), so a hidden starting node yields an empty array
+    // post-filter. To match NodeController's "hidden node looks
+    // missing" pattern, also gate visibility of the starting node
+    // up-front and 404 on hidden.
     auto db = drogon::app().getDbClient();
     db->execSqlAsync(
         "SELECT m.id FROM maps m "
@@ -583,45 +673,89 @@ void EdgeController::listEdgesForNode(
         "  AND (m.owner_id = ? "
         "       OR mp.level IN ('view','comment','edit','moderate','admin') "
         "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
-        [callback, mapId, nodeId](const drogon::orm::Result& rAcc) {
+        [callback, mapId, nodeId, userId, isAdmin](const drogon::orm::Result& rAcc) {
             if (rAcc.empty()) {
                 callback(errorResponse(drogon::k403Forbidden,
                     "forbidden", "Map not found or insufficient permissions"));
                 return;
             }
-            // Verify the node is on this map (cheap; avoids returning
-            // an empty array when the caller passed a bogus nodeId).
+            // Verify the node is on this map (cheap; for admins this
+            // doubles as the only visibility check needed). For
+            // non-admins, also confirm the node itself is visible —
+            // hidden node returns 404 (matches NodeController pattern).
             auto dbN = drogon::app().getDbClient();
-            dbN->execSqlAsync(
-                "SELECT 1 FROM nodes WHERE id = ? AND map_id = ?",
-                [callback, mapId, nodeId](const drogon::orm::Result& rN) {
-                    if (rN.empty()) {
-                        callback(errorResponse(drogon::k404NotFound,
-                            "not_found", "Node not found on this map"));
-                        return;
-                    }
-                    auto db2 = drogon::app().getDbClient();
+            std::string nodeCheckSql;
+            if (isAdmin) {
+                nodeCheckSql = "SELECT 1 FROM nodes WHERE id = ? AND map_id = ?";
+            } else {
+                // Recursive CTE walks the parent chain for visibility.
+                // 1 if visible (xray bypass OR in visible_starts), 0 otherwise.
+                nodeCheckSql = VISIBILITY_RESOLVE_CTE +
+                    "SELECT 1 FROM nodes n "
+                    "JOIN maps m ON m.id = n.map_id "
+                    "WHERE n.id = ? AND n.map_id = ? "
+                    "  AND ((m.owner_id = ? AND m.owner_xray = TRUE) "
+                    "       OR n.id IN (SELECT start_id FROM visible_starts))";
+            }
+
+            auto onNodeChecked = [callback, mapId, nodeId, userId, isAdmin]
+                (const drogon::orm::Result& rN) {
+                if (rN.empty()) {
+                    callback(errorResponse(drogon::k404NotFound,
+                        "not_found", "Node not found on this map"));
+                    return;
+                }
+                auto db2 = drogon::app().getDbClient();
+                auto onRows = [callback](const drogon::orm::Result& r) {
+                    Json::Value arr(Json::arrayValue);
+                    for (const auto& row : r) arr.append(rowToEdge(row));
+                    callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+                };
+                auto onErr = [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to fetch edges"));
+                };
+
+                if (isAdmin) {
                     db2->execSqlAsync(
                         "SELECT " + EDGE_COLUMNS +
                         " FROM node_edges "
                         "WHERE map_id = ? AND (source_node_id = ? OR dest_node_id = ?) "
                         "ORDER BY created_at ASC, id ASC",
-                        [callback](const drogon::orm::Result& r) {
-                            Json::Value arr(Json::arrayValue);
-                            for (const auto& row : r) arr.append(rowToEdge(row));
-                            callback(drogon::HttpResponse::newHttpJsonResponse(arr));
-                        },
-                        [callback](const drogon::orm::DrogonDbException&) {
-                            callback(errorResponse(drogon::k500InternalServerError,
-                                "db_error", "Failed to fetch edges"));
-                        },
+                        onRows, onErr,
                         mapId, nodeId, nodeId);
-                },
-                [callback](const drogon::orm::DrogonDbException&) {
-                    callback(errorResponse(drogon::k500InternalServerError,
-                        "db_error", "Database error"));
-                },
-                nodeId, mapId);
+                } else {
+                    std::string sql = VISIBILITY_RESOLVE_CTE +
+                        "SELECT " +
+                        "  e.id, e.map_id, e.source_node_id, e.dest_node_id, "
+                        "  e.directed, e.color, e.label, e.description, "
+                        "  e.created_by, e.created_at, e.updated_at "
+                        "FROM node_edges e "
+                        "JOIN maps m ON m.id = e.map_id "
+                        "WHERE e.map_id = ? "
+                        "  AND (e.source_node_id = ? OR e.dest_node_id = ?) " +
+                        EDGE_VISIBILITY_PREDICATE +
+                        " ORDER BY e.created_at ASC, e.id ASC";
+                    db2->execSqlAsync(sql, onRows, onErr,
+                        mapId, userId,                  // CTE
+                        mapId, nodeId, nodeId,           // WHERE e.map_id, source/dest
+                        userId);                         // xray
+                }
+            };
+            auto onNodeErr = [callback](const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Database error"));
+            };
+
+            if (isAdmin) {
+                dbN->execSqlAsync(nodeCheckSql, onNodeChecked, onNodeErr,
+                    nodeId, mapId);
+            } else {
+                dbN->execSqlAsync(nodeCheckSql, onNodeChecked, onNodeErr,
+                    mapId, userId,    // CTE
+                    nodeId, mapId,    // WHERE n.id, n.map_id
+                    userId);          // xray
+            }
         },
         [callback](const drogon::orm::DrogonDbException&) {
             callback(errorResponse(drogon::k500InternalServerError,

--- a/backend/tests/test_29_edges.py
+++ b/backend/tests/test_29_edges.py
@@ -259,13 +259,19 @@ status, _ = http_post(EDGES_BASE,
     {"sourceNodeId": NODE_X, "destNodeId": NODE_Y}, TOKEN_C)
 assert_status("auth: cross-tenant create 403", 403, status)
 
-# B is a viewer of TENANT_A with view perm on MAP_ID — can read
+# B is a viewer of TENANT_A with view perm on MAP_ID — read endpoint
+# returns 200 (the visibility filter applies — see Visibility filter
+# section below for the per-edge expectations). EDGE_1 / EDGE_2's
+# endpoints (NODE_X / NODE_Y / NODE_Z) are untagged in this section,
+# which under the existing visibility model means admin-only — so B
+# gets back an empty list and a 404 on direct get.
 status, body = http_get(EDGES_BASE, TOKEN_B)
 assert_status("auth: viewer can list 200", 200, status)
-assert_true("auth: viewer sees both edges", len(body) == 2)
+assert_true("auth: viewer sees no untagged-endpoint edges (vis filter)",
+            isinstance(body, list) and len(body) == 0)
 
-status, body = http_get(f"{EDGES_BASE}/{EDGE_1}", TOKEN_B)
-assert_status("auth: viewer can get 200", 200, status)
+status, _ = http_get(f"{EDGES_BASE}/{EDGE_1}", TOKEN_B)
+assert_status("auth: viewer get untagged-endpoint edge 404 (hidden, not 403)", 404, status)
 
 # Viewer cannot write — tenant role 'viewer' fails the editor/admin gate
 status, _ = http_post(EDGES_BASE,
@@ -314,5 +320,131 @@ assert_true("cascade: edge gone after map delete",  remaining == "0",
             f"got remaining={remaining!r}")
 
 print("  All cascade tests passed.")
+
+# ─── Visibility filter (#197) ───────────────────────────────────────────────
+# An edge is visible iff BOTH endpoints are visible to the caller.
+# Owner-xray and tenant-admin bypass.
+
+print("  --- Visibility filter (#197) ---")
+
+# Fresh map for the visibility tests (the earlier MAP_ID has all edges
+# from the CRUD section + a new node count near the end). Easier reasoning
+# with a clean slate.
+_, body = http_post(f"/tenants/{TENANT_A}/maps", {
+    "title": "Edge Visibility Map",
+    "coordinateSystem": {"type": "wgs84", "center": {"lat": 0, "lng": 0}, "zoom": 3},
+}, TOKEN_A)
+VMAP = json_field(body, ["id"])
+mysql_query(
+    f"INSERT INTO map_permissions (map_id, user_id, level) "
+    f"VALUES ({VMAP}, {USER_B_ID}, 'view');")
+
+VBASE     = f"/tenants/{TENANT_A}/maps/{VMAP}/nodes"
+VEDGES    = f"/tenants/{TENANT_A}/maps/{VMAP}/edges"
+
+# Two visibility groups; B is in Players.
+VGB = f"/tenants/{TENANT_A}/visibility-groups"
+_, body = http_post(VGB, {"name": "EdgePlayers"}, TOKEN_A)
+VG_PLAYERS = json_field(body, ["id"])
+_, body = http_post(VGB, {"name": "EdgeGMs"}, TOKEN_A)
+VG_GMS = json_field(body, ["id"])
+http_post(f"{VGB}/{VG_PLAYERS}/members", {"userId": USER_B_ID}, TOKEN_A)
+
+# Per the existing visibility model (test_20 fixture comment): untagged
+# nodes are admin-only — there is no "publicly visible" default for
+# non-admins. To make a node visible to a non-admin, tag it with a group
+# they belong to. So the fixtures use:
+#   VPNODE_A, VPNODE_B: Players-tagged → visible to B (Players member)
+#   VGNODE:             GMs-tagged     → hidden from B (not in GMs)
+#   VUNTAGGED:          no tags        → admin-only (hidden from B)
+
+VPNODE_A = mknode(VBASE, "PlayersA")
+http_post(f"{VBASE}/{VPNODE_A}/visibility",
+          {"override": True, "groupIds": [VG_PLAYERS]}, TOKEN_A)
+VPNODE_B = mknode(VBASE, "PlayersB")
+http_post(f"{VBASE}/{VPNODE_B}/visibility",
+          {"override": True, "groupIds": [VG_PLAYERS]}, TOKEN_A)
+VGNODE = mknode(VBASE, "GMsOnly")
+http_post(f"{VBASE}/{VGNODE}/visibility",
+          {"override": True, "groupIds": [VG_GMS]}, TOKEN_A)
+VUNTAGGED = mknode(VBASE, "Untagged")  # admin-only
+
+# Edges:
+#   E_PVIS:   PlayersA ↔ PlayersB  → both visible to B → visible
+#   E_MIXED:  PlayersA ↔ GMsOnly   → B sees A but not GMsOnly → hidden
+#   E_GHIDDEN:GMsOnly  ↔ Untagged  → B sees neither → hidden
+#   E_UNTAG:  PlayersA ↔ Untagged  → B sees A but not Untagged → hidden
+def mkedge(s, d):
+    _, b = http_post(VEDGES, {"sourceNodeId": s, "destNodeId": d}, TOKEN_A)
+    return json_field(b, ["id"])
+E_PVIS    = mkedge(VPNODE_A, VPNODE_B)
+E_MIXED   = mkedge(VPNODE_A, VGNODE)
+E_GHIDDEN = mkedge(VGNODE,   VUNTAGGED)
+E_UNTAG   = mkedge(VPNODE_A, VUNTAGGED)
+
+# Admin (A) sees all 4
+status, body = http_get(VEDGES, TOKEN_A)
+assert_status("vis: admin list 200", 200, status)
+ids = {e["id"] for e in body}
+assert_true("vis: admin sees all 4 edges",
+            ids == {E_PVIS, E_MIXED, E_GHIDDEN, E_UNTAG})
+
+# B (Players member, no GMs) sees only edges where BOTH endpoints visible
+status, body = http_get(VEDGES, TOKEN_B)
+assert_status("vis: B list 200", 200, status)
+ids = {e["id"] for e in body}
+assert_true("vis: B sees only E_PVIS",
+            ids == {E_PVIS},
+            f"got {ids}")
+
+# B getting visible edge → 200; getting any hidden → 404 (never 403)
+status, _ = http_get(f"{VEDGES}/{E_PVIS}", TOKEN_B)
+assert_status("vis: B get visible edge 200", 200, status)
+status, _ = http_get(f"{VEDGES}/{E_MIXED}", TOKEN_B)
+assert_status("vis: B get mixed-vis edge 404 (hidden, not 403)", 404, status)
+status, _ = http_get(f"{VEDGES}/{E_GHIDDEN}", TOKEN_B)
+assert_status("vis: B get fully-hidden edge 404", 404, status)
+status, _ = http_get(f"{VEDGES}/{E_UNTAG}", TOKEN_B)
+assert_status("vis: B get untagged-endpoint edge 404", 404, status)
+
+# listEdgesForNode from a visible-to-B node — only edges where the OTHER
+# endpoint is also visible
+status, body = http_get(f"{VBASE}/{VPNODE_A}/edges", TOKEN_B)
+assert_status("vis: listForNode visible-source 200", 200, status)
+ids = {e["id"] for e in body}
+assert_true("vis: listForNode VPNODE_A → only E_PVIS",
+            ids == {E_PVIS},
+            f"got {ids}")
+
+# listEdgesForNode from a HIDDEN node → 404 (hidden node looks missing)
+status, _ = http_get(f"{VBASE}/{VGNODE}/edges", TOKEN_B)
+assert_status("vis: listForNode hidden node 404", 404, status)
+status, _ = http_get(f"{VBASE}/{VUNTAGGED}/edges", TOKEN_B)
+assert_status("vis: listForNode untagged node 404 (admin-only)", 404, status)
+
+# Owner-xray bypass: temporarily hand the map to B with xray=TRUE.
+# B should now see ALL 4 edges regardless of tags.
+mysql_query(f"UPDATE maps SET owner_id={USER_B_ID}, owner_xray=TRUE "
+            f"WHERE id={VMAP};")
+status, body = http_get(VEDGES, TOKEN_B)
+ids = {e["id"] for e in body}
+assert_true("vis: xray=TRUE B sees all 4 edges",
+            ids == {E_PVIS, E_MIXED, E_GHIDDEN, E_UNTAG},
+            f"got {ids}")
+
+# xray=FALSE → back to filtered
+mysql_query(f"UPDATE maps SET owner_xray=FALSE WHERE id={VMAP};")
+status, body = http_get(VEDGES, TOKEN_B)
+ids = {e["id"] for e in body}
+assert_true("vis: xray=FALSE B back to filtered set",
+            ids == {E_PVIS})
+
+# Restore A as owner
+mysql_query(f"UPDATE maps SET owner_id={USER_A_ID} WHERE id={VMAP};")
+
+# Restore A as owner
+mysql_query(f"UPDATE maps SET owner_id={USER_A_ID} WHERE id={VMAP};")
+
+print("  All visibility-filter tests passed.")
 
 sys.exit(0 if report() else 1)


### PR DESCRIPTION
## Summary

Closes #197. Adds the both-endpoints-visible filter to all three edge read endpoints. Pattern mirrors NodeController's existing visibility CTE.

## Files changed

- \`backend/src/controllers/EdgeController.cpp\` — add VISIBILITY_RESOLVE_CTE + EDGE_VISIBILITY_PREDICATE + isTenantAdmin helper. Apply the filter in listEdges, getEdge, listEdgesForNode for non-admins. Owner-xray and tenant-admin bypass. Hidden edges return 404 (never 403). Hidden source node in listEdgesForNode also returns 404.
- \`backend/tests/test_29_edges.py\` — new "Visibility filter" section (14 assertions) covering admin-bypass, both-visible-shows, mixed-vis-hides, fully-hidden-hides, untagged-as-admin-only, 404-not-403 leakage prevention, owner_xray round-trip. Updated existing "auth: viewer can list/get" assertions to reflect that untagged-endpoint edges are hidden from non-admins (was incorrect under the new filter).

## Work breakdown

- [x] Add visibility CTE + predicate constants to EdgeController.cpp (mirroring NodeController.cpp's pattern)
- [x] Apply filter to listEdges (admins bypass, non-admins get both-endpoints check)
- [x] Apply filter to getEdge (404 on hidden, never 403)
- [x] Apply filter to listEdgesForNode (also gate on starting node visibility for the 404)
- [x] Extend test_29 with visibility section + fix existing auth-section assumptions
- [x] Sibling sweep (test_14/18/19/20/21/22/23/24/25/28/29) — all pass

## Test plan

- [x] \`test_29_edges.py\`: 67/67 assertions.
- [x] Sibling visibility/node/plot tests — all green.
- [x] CI on wave-4-edges (auto-trigger via wave-* glob).

## Operational impact

Backend rebuild + restart. \`docker compose build backend && docker compose up -d backend\`. No new migration.

## Wave context

Wave 4 PR 2 of 5. Tracker: #255. Next up: #198 (frontend rendering — opening in parallel since it's purely frontend, no file overlap with #197).