### PR TITLE
Frontend: Edge rendering layer (#198, Wave 4 PR3)

### DIFF
--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -161,6 +161,30 @@ export type NoteRecord = z.infer<typeof NoteRecordSchema>;
 export const NoteListSchema = z.array(NoteRecordSchema);
 export type NoteList = z.infer<typeof NoteListSchema>;
 
+// ─── Edges (#148, Wave 4) ────────────────────────────────────────────────────
+// Graph layer alongside the per-map node tree. Connects two nodes for
+// relational use cases (trade routes, ferry connections, quest deps).
+// Read-side schema only in #198; write methods + their request schemas
+// land in #199.
+
+export const EdgeRecordSchema = z.object({
+  id: z.number().int(),
+  mapId: z.number().int(),
+  sourceNodeId: z.number().int(),
+  destNodeId: z.number().int(),
+  directed: z.boolean(),
+  color: z.string().nullable(),
+  label: z.string().nullable(),
+  description: z.string(),
+  createdBy: z.number().int(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type EdgeRecord = z.infer<typeof EdgeRecordSchema>;
+
+export const EdgeListSchema = z.array(EdgeRecordSchema);
+export type EdgeList = z.infer<typeof EdgeListSchema>;
+
 // ─── Visibility groups (#85 / #98) ───────────────────────────────────────────
 
 export const VisibilityGroupSchema = z.object({

--- a/frontend/src/components/Map/MapView.tsx
+++ b/frontend/src/components/Map/MapView.tsx
@@ -1,17 +1,18 @@
-import { useEffect, useState } from 'react';
-import { MapContainer, TileLayer, ImageOverlay, Marker, Polyline, Polygon, Popup, useMap as useLeafletMap } from 'react-leaflet';
+import { useEffect, useMemo, useState } from 'react';
+import { MapContainer, TileLayer, ImageOverlay, Marker, Polyline, Polygon, Popup, CircleMarker, useMap as useLeafletMap } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
 import iconUrl from 'leaflet/dist/images/marker-icon.png';
 import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
 import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
-import { nodesService, nodeMediaService } from '@/services/maps';
+import { nodesService, nodeMediaService, edgesService } from '@/services/maps';
 import { useAuthStore } from '@/store/authStore';
 import type {
   MapRecord,
   NodeRecord,
   NodeMediaRecord,
   GeoJsonGeometry,
+  EdgeRecord,
 } from '@/types';
 
 // Fix for leaflet's default icon paths breaking under Vite's bundler.
@@ -147,6 +148,55 @@ function NodeLayer({ node, media, onClick }: NodeLayerProps) {
   return null;
 }
 
+// ─── Per-edge renderer (#198) ────────────────────────────────────────────────
+// Renders an edge as a Leaflet polyline from sourceNode's center to
+// destNode's center. Both endpoints must have a Point geometry (the
+// "center" of a node). Edges where either endpoint lacks a Point are
+// skipped silently — the underlying data still exists, just not
+// rendered (could be enhanced to use centroid for line/polygon nodes
+// in a follow-up).
+//
+// Z-order: rendered BEFORE node markers in the JSX tree so node
+// markers stay clickable on top.
+//
+// "Directed" indicator: a small CircleMarker at the dest endpoint.
+// A real arrowhead would need leaflet-arrowheads or hand-rolled
+// L.polylineDecorator geometry; the CircleMarker is a lightweight
+// stand-in for v1 that conveys direction without a new dependency.
+// (Filed as future polish in #199 / #200 if a real arrow is wanted.)
+
+interface EdgeLayerProps {
+  edge: EdgeRecord;
+  sourceNode: NodeRecord;
+  destNode: NodeRecord;
+}
+
+function EdgeLayer({ edge, sourceNode, destNode }: EdgeLayerProps) {
+  if (!sourceNode.geoJson || sourceNode.geoJson.type !== 'Point') return null;
+  if (!destNode.geoJson   || destNode.geoJson.type   !== 'Point') return null;
+
+  const src = pointLatLng(sourceNode.geoJson);
+  const dst = pointLatLng(destNode.geoJson);
+  if (!src || !dst) return null;
+
+  const color = edge.color ?? '#888';
+  return (
+    <>
+      <Polyline
+        positions={[src, dst]}
+        pathOptions={{ color, weight: 3, opacity: 0.85 }}
+      />
+      {edge.directed && (
+        <CircleMarker
+          center={dst}
+          radius={6}
+          pathOptions={{ color, fillColor: color, fillOpacity: 1 }}
+        />
+      )}
+    </>
+  );
+}
+
 // ─── MapView (dispatches on coordinateSystem.type) ───────────────────────────
 
 interface MapViewProps {
@@ -175,11 +225,20 @@ function PanController({ target }: { target: [number, number] | null | undefined
 
 export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
   const [nodes, setNodes] = useState<NodeRecord[]>([]);
+  const [edges, setEdges] = useState<EdgeRecord[]>([]);
   const [mediaByNode, setMediaByNode] = useState<Record<number, NodeMediaRecord[]>>({});
   const [loadError, setLoadError] = useState<string | null>(null);
   const currentUserId = useAuthStore((s) => s.user?.id);
   const isOwner = currentUserId !== undefined && currentUserId === map.ownerId;
   const xrayActive = isOwner && map.ownerXray;
+
+  // Edge → endpoint nodes lookup. Built once per (nodes, edges) change so
+  // we don't recompute per-render.
+  const nodesById = useMemo(() => {
+    const m = new Map<number, NodeRecord>();
+    for (const n of nodes) m.set(n.id, n);
+    return m;
+  }, [nodes]);
 
   useEffect(() => {
     let cancelled = false;
@@ -207,6 +266,13 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
       .catch(() => {
         if (!cancelled) setLoadError('Failed to load nodes for this map.');
       });
+
+    // Edges are best-effort — failure here doesn't block the map.
+    edgesService
+      .listEdges(map.id)
+      .then((es) => { if (!cancelled) setEdges(es); })
+      .catch(() => { /* render the map without edges; not a fatal */ });
+
     return () => {
       cancelled = true;
     };
@@ -224,6 +290,16 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
   // numbers mean (x, y) but the swap is still correct.
 
   const cs = map.coordinateSystem;
+
+  // Edges render BEFORE node markers so node clicks aren't shadowed.
+  const renderEdgeLayers = () =>
+    edges.map((e) => {
+      const src = nodesById.get(e.sourceNodeId);
+      const dst = nodesById.get(e.destNodeId);
+      if (!src || !dst) return null;  // endpoint not loaded (filtered out by visibility)
+      return <EdgeLayer key={e.id} edge={e} sourceNode={src} destNode={dst} />;
+    });
+
   const renderNodeLayers = () =>
     nodes.map((n) => (
       <NodeLayer
@@ -260,6 +336,7 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
           className="map-view-leaflet"
         >
           <ImageOverlay url={cs.image_url} bounds={bounds} />
+          {renderEdgeLayers()}
           {renderNodeLayers()}
           <PanController target={panTarget} />
         </MapContainer>
@@ -291,6 +368,7 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
           maxBounds={maxBounds}
           className="map-view-leaflet map-view-blank"
         >
+          {renderEdgeLayers()}
           {renderNodeLayers()}
           <PanController target={panTarget} />
         </MapContainer>
@@ -313,6 +391,7 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         />
+        {renderEdgeLayers()}
         {renderNodeLayers()}
         <PanController target={panTarget} />
       </MapContainer>

--- a/frontend/src/services/maps.ts
+++ b/frontend/src/services/maps.ts
@@ -18,6 +18,8 @@ import {
   PlotRecordSchema,
   PlotListSchema,
   PlotMembersSchema,
+  EdgeRecordSchema,
+  EdgeListSchema,
   type MapRecord,
   type MapList,
   type NodeRecord,
@@ -48,6 +50,8 @@ import {
   type PlotMembers,
   type CreatePlotRequest,
   type UpdatePlotRequest,
+  type EdgeRecord,
+  type EdgeList,
 } from '@/api/schemas';
 import type {
   Tenant,
@@ -568,5 +572,31 @@ export const plotsService = {
       `${tenantBase(tenantId)}/maps/${mapId}/notes/${noteId}/plots`,
     );
     return PlotListSchema.parse(res.data);
+  },
+};
+
+// ─── Edges (#148, Wave 4) ─────────────────────────────────────────────────────
+// Read-only methods for #198 (rendering layer); write methods land in #199.
+
+export const edgesService = {
+  async listEdges(mapId: number, tenantId?: number): Promise<EdgeList> {
+    const res = await apiClient.get(`${tenantBase(tenantId)}/maps/${mapId}/edges`);
+    return EdgeListSchema.parse(res.data);
+  },
+
+  async getEdge(mapId: number, edgeId: number, tenantId?: number): Promise<EdgeRecord> {
+    const res = await apiClient.get(`${tenantBase(tenantId)}/maps/${mapId}/edges/${edgeId}`);
+    return EdgeRecordSchema.parse(res.data);
+  },
+
+  async listEdgesForNode(
+    mapId: number,
+    nodeId: number,
+    tenantId?: number,
+  ): Promise<EdgeList> {
+    const res = await apiClient.get(
+      `${tenantBase(tenantId)}/maps/${mapId}/nodes/${nodeId}/edges`
+    );
+    return EdgeListSchema.parse(res.data);
   },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -42,6 +42,8 @@ export type {
   UpdateNodeRequest,
   CreateNoteRequest,
   UpdateNoteRequest,
+  EdgeRecord,
+  EdgeList,
 } from '@/api/schemas';
 
 // ─── Auth ────────────────────────────────────────────────────────────────────

--- a/frontend/tests/e2e/edges.spec.ts
+++ b/frontend/tests/e2e/edges.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import {
+  registerViaApi,
+  createMapViaApi,
+  createNodeViaApi,
+  seedAuthInBrowser,
+  API_URL,
+  type ApiUser,
+} from './helpers';
+
+/**
+ * E2E for #198 — edge rendering layer (read-only).
+ *
+ * Seeds an edge between two existing nodes via the backend API, then
+ * navigates to the map and asserts the polyline is rendered. Covers the
+ * directed-edge marker and the wgs84 coord system — the cross-coord-system
+ * lock-in (pixel + blank) is filed as part of #200's coordinate-systems-crud
+ * extension, not duplicated here.
+ *
+ * Create / edit UX lands in #199; this spec only verifies that an edge
+ * the backend already knows about renders correctly.
+ */
+
+const WGS84 = {
+  type: 'wgs84' as const,
+  center: { lat: 0, lng: 0 },
+  zoom: 3,
+};
+
+async function createEdgeViaApi(
+  request: APIRequestContext,
+  api: ApiUser,
+  mapId: number,
+  body: {
+    sourceNodeId: number;
+    destNodeId: number;
+    directed?: boolean;
+    color?: string;
+    label?: string;
+  },
+): Promise<{ id: number }> {
+  const res = await request.post(
+    `${API_URL}/tenants/${api.tenantId}/maps/${mapId}/edges`,
+    { headers: { Authorization: `Bearer ${api.token}` }, data: body },
+  );
+  if (!res.ok()) {
+    throw new Error(`createEdge failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+test.describe('Edges — rendering (#198)', () => {
+  test('an edge between two Point nodes renders as a polyline on the map', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_render');
+    const map = await createMapViaApi(request, api, 'Edge render', WGS84);
+
+    // Two nodes with Point geometry — endpoints we can connect.
+    const a = await createNodeViaApi(request, api, map.id, {
+      name: 'NodeA',
+      geoJson: { type: 'Point', coordinates: [0, 0] },
+    });
+    const b = await createNodeViaApi(request, api, map.id, {
+      name: 'NodeB',
+      geoJson: { type: 'Point', coordinates: [10, 5] },
+    });
+
+    await createEdgeViaApi(request, api, map.id, {
+      sourceNodeId: a.id,
+      destNodeId: b.id,
+      color: '#ff5500',
+    });
+
+    // Boot authenticated and navigate to the map detail page.
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // The map renders SVG paths for both polyline-like layers (edges) and
+    // any polygon nodes. We have no polygon/line nodes in this test, so
+    // every <path> in the overlay pane is an edge polyline.
+    const paths = page.locator('.leaflet-overlay-pane svg path');
+    await expect(paths).toHaveCount(1, { timeout: 10000 });
+    // Edge color is applied via the path's `stroke` attribute.
+    await expect(paths.first()).toHaveAttribute('stroke', '#ff5500');
+  });
+
+  test('a directed edge renders an extra circle marker at the destination', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_directed');
+    const map = await createMapViaApi(request, api, 'Edge directed', WGS84);
+
+    const a = await createNodeViaApi(request, api, map.id, {
+      name: 'NodeA',
+      geoJson: { type: 'Point', coordinates: [0, 0] },
+    });
+    const b = await createNodeViaApi(request, api, map.id, {
+      name: 'NodeB',
+      geoJson: { type: 'Point', coordinates: [5, 5] },
+    });
+
+    await createEdgeViaApi(request, api, map.id, {
+      sourceNodeId: a.id,
+      destNodeId: b.id,
+      directed: true,
+      color: '#3388ff',
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // Directed edges add a CircleMarker at the dest endpoint. Leaflet
+    // renders CircleMarker as an SVG <path> with a circular `d` attr —
+    // it shows up alongside the polyline path. So we expect 2 paths
+    // (1 polyline + 1 directed-marker) instead of 1.
+    const paths = page.locator('.leaflet-overlay-pane svg path');
+    await expect(paths).toHaveCount(2, { timeout: 10000 });
+  });
+
+  test('edges with non-Point endpoints are skipped (no crash, no render)', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_skip_nonpoint');
+    const map = await createMapViaApi(request, api, 'Edge skip', WGS84);
+
+    const a = await createNodeViaApi(request, api, map.id, {
+      name: 'PointNode',
+      geoJson: { type: 'Point', coordinates: [0, 0] },
+    });
+    // Tree-only node (no geoJson) — edge from this node should be skipped.
+    const b = await createNodeViaApi(request, api, map.id, { name: 'TreeOnly' });
+
+    await createEdgeViaApi(request, api, map.id, {
+      sourceNodeId: a.id,
+      destNodeId: b.id,
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // The polyline shouldn't render because TreeOnly lacks Point geometry.
+    // We expect 0 paths in the overlay pane (no edges, no polygon nodes).
+    // Wait briefly to be sure the listEdges call has finished and
+    // nothing rendered as a side effect.
+    await page.waitForTimeout(500);
+    const paths = page.locator('.leaflet-overlay-pane svg path');
+    await expect(paths).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #198. Read-only frontend rendering for edges. Adds Zod schemas, \`edgesService\` (read methods only), and Leaflet polyline rendering in MapView.

Opened in **parallel with #257** (#197 visibility filter): zero file overlap, both branch from the same wave HEAD. Either can merge first; final wave state has both.

## Files changed

- \`frontend/src/api/schemas.ts\` — \`EdgeRecordSchema\` + \`EdgeListSchema\` (read-only; write request schemas land in #199).
- \`frontend/src/components/Map/MapView.tsx\` — new \`EdgeLayer\` component (Polyline from source-Point to dest-Point, optional CircleMarker at dest for directed). Edge fetch is best-effort (failure renders the map without edges). Edges render BEFORE node markers in JSX so node clicks aren't shadowed. \`useMemo\`-backed nodes-by-id lookup feeds the per-edge endpoint resolution.
- \`frontend/src/services/maps.ts\` — \`edgesService\` with \`listEdges\` / \`getEdge\` / \`listEdgesForNode\` (read methods only).
- \`frontend/src/types/index.ts\` — re-export \`EdgeRecord\` / \`EdgeList\` so consumers can import from \`@/types\`.
- \`frontend/tests/e2e/edges.spec.ts\` — 3 specs: polyline-with-stroke renders, directed edge adds CircleMarker, non-Point endpoint silently skipped.

## Design notes

- **Arrowhead:** v1 uses a \`CircleMarker\` at the destination as a lightweight directed indicator. A real arrowhead needs \`leaflet-arrowheads\` or hand-rolled \`L.polylineDecorator\` geometry; the marker keeps deps flat. If you want the real arrow, easy follow-up after the wave merges.
- **Non-Point endpoints:** edges where either endpoint lacks Point geometry (tree-only nodes, line/polygon nodes) are skipped silently. Centroid-based rendering is possible v2 polish.
- **Edge color:** falls back to \`#888\` (distinct from any node default).
- **Z-order:** edges in JSX BEFORE nodes so the click target order matches what the user expects (click a node, not the edge passing through it).

## Work breakdown

- [x] Zod schemas + types
- [x] \`edgesService\` (read methods)
- [x] \`EdgeLayer\` component + integration in all 3 MapView coord-system branches
- [x] E2E spec covering polyline rendering, directed marker, non-Point skip
- [x] \`tsc --noEmit\` + \`npm run lint\` clean
- [x] Sibling spec sweep (tree, coordinate-systems, node-creation, maps, visibility) — all pass

## Test plan

- [x] \`edges.spec.ts\`: 3/3 passed
- [x] Sibling E2E specs: 20 passed, 5 pre-existing skips, no regressions
- [x] Frontend type-check + ESLint clean
- [x] CI on wave-4-edges (auto-trigger via wave-* glob)

## Operational impact

Frontend reload (Vite picks up changes automatically in dev). No backend changes, no migration.

## Wave context

Wave 4 PR 3 of 5. Tracker: #255. Opened in parallel with #257 (#197 visibility filter — backend, no overlap). Next sequential PRs (#199 create/edit UX → #200 detail panel + E2E) wait until #198 lands so they can build on the rendering layer.