### PR TITLE
Frontend: Edge create + edit UX (#199, Wave 4 PR4)

### DIFF
--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -164,8 +164,6 @@ export type NoteList = z.infer<typeof NoteListSchema>;
 // ─── Edges (#148, Wave 4) ────────────────────────────────────────────────────
 // Graph layer alongside the per-map node tree. Connects two nodes for
 // relational use cases (trade routes, ferry connections, quest deps).
-// Read-side schema only in #198; write methods + their request schemas
-// land in #199.
 
 export const EdgeRecordSchema = z.object({
   id: z.number().int(),
@@ -184,6 +182,24 @@ export type EdgeRecord = z.infer<typeof EdgeRecordSchema>;
 
 export const EdgeListSchema = z.array(EdgeRecordSchema);
 export type EdgeList = z.infer<typeof EdgeListSchema>;
+
+// Write request shapes — backend immutability rule (#148): endpoints
+// (sourceNodeId, destNodeId) are immutable on update. Re-targeting an
+// edge means delete + recreate.
+export type CreateEdgeRequest = {
+  sourceNodeId: number;
+  destNodeId: number;
+  directed?: boolean;
+  color?: string;
+  label?: string;
+  description?: string;
+};
+export type UpdateEdgeRequest = {
+  directed?: boolean;
+  color?: string;
+  label?: string;
+  description?: string;
+};
 
 // ─── Visibility groups (#85 / #98) ───────────────────────────────────────────
 

--- a/frontend/src/components/Map/EdgeFormModal.tsx
+++ b/frontend/src/components/Map/EdgeFormModal.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'react';
+import { edgesService } from '@/services/maps';
+import { extractApiError } from '@/utils/errors';
+import type { EdgeRecord, NodeRecord } from '@/types';
+
+// Modal for creating a new edge or editing an existing one (#199).
+// In create mode the source/dest endpoints are immutable inputs picked
+// in the toolbar's two-step flow; in edit mode the endpoints are read-
+// only too (per #148 design — re-targeting an edge means delete +
+// recreate, keeping audit semantics simple).
+//
+// Form fields (both modes): label, description, color, directed.
+// Edit mode adds a Delete affordance.
+
+interface EdgeFormModalProps {
+  mode: 'create' | 'edit';
+  mapId: number;
+  sourceNode: NodeRecord;
+  destNode: NodeRecord;
+  /** Required in edit mode; null/undefined in create mode. */
+  initial?: EdgeRecord | null;
+  onSaved: (edge: EdgeRecord) => void;
+  /** Only invoked from edit mode. */
+  onDeleted?: () => void;
+  onClose: () => void;
+}
+
+export function EdgeFormModal({
+  mode,
+  mapId,
+  sourceNode,
+  destNode,
+  initial,
+  onSaved,
+  onDeleted,
+  onClose,
+}: EdgeFormModalProps) {
+  const [label, setLabel] = useState(initial?.label ?? '');
+  const [description, setDescription] = useState(initial?.description ?? '');
+  const [color, setColor] = useState(initial?.color ?? '#3388ff');
+  const [directed, setDirected] = useState(initial?.directed ?? false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      let saved: EdgeRecord;
+      if (mode === 'create') {
+        saved = await edgesService.createEdge(mapId, {
+          sourceNodeId: sourceNode.id,
+          destNodeId: destNode.id,
+          directed,
+          color: color || undefined,
+          label: label || undefined,
+          description: description || undefined,
+        });
+      } else if (initial) {
+        saved = await edgesService.updateEdge(mapId, initial.id, {
+          directed,
+          color,
+          label,
+          description,
+        });
+      } else {
+        throw new Error('Edit mode requires an initial edge');
+      }
+      onSaved(saved);
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to save edge.'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!initial || !onDeleted) return;
+    if (!window.confirm('Delete this edge? This cannot be undone.')) return;
+    setError(null);
+    setBusy(true);
+    try {
+      await edgesService.deleteEdge(mapId, initial.id);
+      onDeleted();
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to delete edge.'));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()} role="dialog">
+        <h2>{mode === 'create' ? 'New edge' : 'Edit edge'}</h2>
+
+        {error && <div className="alert alert-error">{error}</div>}
+
+        <div className="form-group">
+          <label>From</label>
+          <div>{sourceNode.name}</div>
+        </div>
+        <div className="form-group">
+          <label>To</label>
+          <div>{destNode.name}</div>
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="edge-label">Label</label>
+          <input
+            id="edge-label"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="optional"
+            maxLength={255}
+          />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="edge-description">Description</label>
+          <textarea
+            id="edge-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+          />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="edge-color">Color</label>
+          <input
+            id="edge-color"
+            type="color"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+          />
+        </div>
+
+        <div className="form-group-checkbox">
+          <label>
+            <input
+              type="checkbox"
+              checked={directed}
+              onChange={(e) => setDirected(e.target.checked)}
+            />
+            Directed (arrow from source to destination)
+          </label>
+        </div>
+
+        <div className="modal-actions">
+          {mode === 'edit' && (
+            <button
+              type="button"
+              className="btn btn-danger"
+              onClick={handleDelete}
+              disabled={busy}
+            >
+              Delete
+            </button>
+          )}
+          <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button type="button" className="btn btn-primary" onClick={handleSave} disabled={busy}>
+            {busy ? 'Saving…' : mode === 'create' ? 'Create' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Map/MapView.tsx
+++ b/frontend/src/components/Map/MapView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { MapContainer, TileLayer, ImageOverlay, Marker, Polyline, Polygon, Popup, CircleMarker, useMap as useLeafletMap } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
@@ -7,6 +7,7 @@ import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
 import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
 import { nodesService, nodeMediaService, edgesService } from '@/services/maps';
 import { useAuthStore } from '@/store/authStore';
+import { EdgeFormModal } from './EdgeFormModal';
 import type {
   MapRecord,
   NodeRecord,
@@ -169,9 +170,10 @@ interface EdgeLayerProps {
   edge: EdgeRecord;
   sourceNode: NodeRecord;
   destNode: NodeRecord;
+  onClick?: (edgeId: number) => void;
 }
 
-function EdgeLayer({ edge, sourceNode, destNode }: EdgeLayerProps) {
+function EdgeLayer({ edge, sourceNode, destNode, onClick }: EdgeLayerProps) {
   if (!sourceNode.geoJson || sourceNode.geoJson.type !== 'Point') return null;
   if (!destNode.geoJson   || destNode.geoJson.type   !== 'Point') return null;
 
@@ -180,17 +182,20 @@ function EdgeLayer({ edge, sourceNode, destNode }: EdgeLayerProps) {
   if (!src || !dst) return null;
 
   const color = edge.color ?? '#888';
+  const handlers = onClick ? { click: () => onClick(edge.id) } : undefined;
   return (
     <>
       <Polyline
         positions={[src, dst]}
         pathOptions={{ color, weight: 3, opacity: 0.85 }}
+        eventHandlers={handlers}
       />
       {edge.directed && (
         <CircleMarker
           center={dst}
           radius={6}
           pathOptions={{ color, fillColor: color, fillOpacity: 1 }}
+          eventHandlers={handlers}
         />
       )}
     </>
@@ -231,6 +236,23 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
   const currentUserId = useAuthStore((s) => s.user?.id);
   const isOwner = currentUserId !== undefined && currentUserId === map.ownerId;
   const xrayActive = isOwner && map.ownerXray;
+  // Edit-permission gate for the edge toolbar (#199). The MapRecord's
+  // `permission` field is the caller's effective access. Owner + edit
+  // both qualify; view-only callers don't see the toolbar.
+  const canEdit = map.permission === 'edit' || map.permission === 'owner';
+
+  // ── Edge create / edit state machine (#199) ──────────────────────────────
+  // edgeMode: idle = no special interaction; pickingSource = waiting for
+  // the user to click the source node; pickingDest = source is captured,
+  // waiting for the dest. The state transitions on each node click and
+  // resets via Esc or after a successful create.
+  type EdgeMode =
+    | { kind: 'idle' }
+    | { kind: 'pickingSource' }
+    | { kind: 'pickingDest'; sourceId: number }
+    | { kind: 'creating'; sourceId: number; destId: number }
+    | { kind: 'editing'; edge: EdgeRecord };
+  const [edgeMode, setEdgeMode] = useState<EdgeMode>({ kind: 'idle' });
 
   // Edge → endpoint nodes lookup. Built once per (nodes, edges) change so
   // we don't recompute per-render.
@@ -278,9 +300,77 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
     };
   }, [map.id]);
 
-  const handleClick = (nodeId: number) => {
+  // react-leaflet captures `eventHandlers` at marker-mount time and
+  // doesn't always re-attach when the prop's identity changes — so a
+  // closure-based handler always runs against the FIRST render's state
+  // (idle), which broke the edge create flow until this ref-based
+  // indirection. Pattern: keep a ref pointed at the latest "real"
+  // handler, expose a stable wrapper that delegates to it. The wrapper's
+  // identity never changes, so react-leaflet keeps the original binding;
+  // each call re-reads the live ref and runs against current state.
+  const handleClickRef = useRef<(nodeId: number) => void>(() => {});
+  handleClickRef.current = (nodeId: number) => {
+    // Edge create flow intercepts node clicks. In picking-source mode,
+    // the click captures the source. In picking-dest mode, it captures
+    // the dest (rejecting same-node-as-source) and opens the create
+    // modal. Outside those modes, fall through to the default
+    // selection callback.
+    if (edgeMode.kind === 'pickingSource') {
+      setEdgeMode({ kind: 'pickingDest', sourceId: nodeId });
+      return;
+    }
+    if (edgeMode.kind === 'pickingDest') {
+      if (nodeId === edgeMode.sourceId) {
+        // Self-loop attempt — backend would 400; refuse early.
+        return;
+      }
+      setEdgeMode({
+        kind: 'creating',
+        sourceId: edgeMode.sourceId,
+        destId: nodeId,
+      });
+      return;
+    }
     onNodeClick?.(nodeId);
   };
+  const handleClick = useRef((nodeId: number) => {
+    handleClickRef.current(nodeId);
+  }).current;
+
+  // Esc cancels mid-creation (any non-idle/non-modal state).
+  useEffect(() => {
+    if (edgeMode.kind !== 'pickingSource' && edgeMode.kind !== 'pickingDest') {
+      return;
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setEdgeMode({ kind: 'idle' });
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [edgeMode.kind]);
+
+  // After create / update / delete, refetch edges so the rendering
+  // layer reflects the latest state. Cheaper than splicing the local
+  // array and avoids drift if the response shape changes.
+  const refetchEdges = () => {
+    edgesService.listEdges(map.id)
+      .then((es) => setEdges(es))
+      .catch(() => { /* keep stale list; same posture as initial load */ });
+  };
+
+  // Same staleness mitigation as handleClick — the EdgeLayer's onClick
+  // is captured at first mount by react-leaflet, so without ref-stable
+  // wrapping the latest `edges` and `edgeMode` would never be visible.
+  const handleEdgeClickRef = useRef<(edgeId: number) => void>(() => {});
+  handleEdgeClickRef.current = (edgeId: number) => {
+    if (edgeMode.kind !== 'idle') return;  // mid-flow; ignore
+    if (!canEdit) return;                  // view-only; no edit modal
+    const e = edges.find((x) => x.id === edgeId);
+    if (e) setEdgeMode({ kind: 'editing', edge: e });
+  };
+  const handleEdgeClick = useRef((edgeId: number) => {
+    handleEdgeClickRef.current(edgeId);
+  }).current;
 
   // All three renderers share the same node-layer rendering; the only
   // difference is the MapContainer's CRS + base layer (or lack thereof).
@@ -292,13 +382,123 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
   const cs = map.coordinateSystem;
 
   // Edges render BEFORE node markers so node clicks aren't shadowed.
+  // Pass onClick only when canEdit AND not mid-creation — mid-creation
+  // node clicks would otherwise compete with edge clicks for the same
+  // gesture.
+  const edgeLayerOnClick = canEdit && edgeMode.kind === 'idle'
+    ? handleEdgeClick
+    : undefined;
   const renderEdgeLayers = () =>
     edges.map((e) => {
       const src = nodesById.get(e.sourceNodeId);
       const dst = nodesById.get(e.destNodeId);
       if (!src || !dst) return null;  // endpoint not loaded (filtered out by visibility)
-      return <EdgeLayer key={e.id} edge={e} sourceNode={src} destNode={dst} />;
+      return (
+        <EdgeLayer
+          key={e.id}
+          edge={e}
+          sourceNode={src}
+          destNode={dst}
+          onClick={edgeLayerOnClick}
+        />
+      );
     });
+
+  // Toolbar + status hint shown above the map. Toolbar visible only
+  // when caller has edit access; hint reflects the current mode so the
+  // user knows what to do next (mirrors MapBox / OSM iD draw flows).
+  const renderToolbar = () => {
+    if (!canEdit) return null;
+    const startEdgeCreate = () => setEdgeMode({ kind: 'pickingSource' });
+    const cancelEdgeCreate = () => setEdgeMode({ kind: 'idle' });
+    if (edgeMode.kind === 'idle') {
+      return (
+        <div className="map-view-toolbar">
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            onClick={startEdgeCreate}
+          >
+            + Edge
+          </button>
+        </div>
+      );
+    }
+    if (edgeMode.kind === 'pickingSource') {
+      return (
+        <div className="map-view-toolbar map-view-toolbar-active">
+          <span>Click the source node (Esc to cancel)</span>
+          <button type="button" className="btn btn-ghost btn-sm" onClick={cancelEdgeCreate}>
+            Cancel
+          </button>
+        </div>
+      );
+    }
+    if (edgeMode.kind === 'pickingDest') {
+      return (
+        <div className="map-view-toolbar map-view-toolbar-active">
+          <span>Click the destination node (Esc to cancel)</span>
+          <button type="button" className="btn btn-ghost btn-sm" onClick={cancelEdgeCreate}>
+            Cancel
+          </button>
+        </div>
+      );
+    }
+    return null;  // creating / editing — modal is the affordance
+  };
+
+  const renderEdgeModal = () => {
+    if (edgeMode.kind === 'creating') {
+      const src = nodesById.get(edgeMode.sourceId);
+      const dst = nodesById.get(edgeMode.destId);
+      if (!src || !dst) {
+        // Race: a node disappeared between picking and modal mount;
+        // bail back to idle.
+        setEdgeMode({ kind: 'idle' });
+        return null;
+      }
+      return (
+        <EdgeFormModal
+          mode="create"
+          mapId={map.id}
+          sourceNode={src}
+          destNode={dst}
+          onSaved={() => {
+            setEdgeMode({ kind: 'idle' });
+            refetchEdges();
+          }}
+          onClose={() => setEdgeMode({ kind: 'idle' })}
+        />
+      );
+    }
+    if (edgeMode.kind === 'editing') {
+      const src = nodesById.get(edgeMode.edge.sourceNodeId);
+      const dst = nodesById.get(edgeMode.edge.destNodeId);
+      if (!src || !dst) {
+        setEdgeMode({ kind: 'idle' });
+        return null;
+      }
+      return (
+        <EdgeFormModal
+          mode="edit"
+          mapId={map.id}
+          sourceNode={src}
+          destNode={dst}
+          initial={edgeMode.edge}
+          onSaved={() => {
+            setEdgeMode({ kind: 'idle' });
+            refetchEdges();
+          }}
+          onDeleted={() => {
+            setEdgeMode({ kind: 'idle' });
+            refetchEdges();
+          }}
+          onClose={() => setEdgeMode({ kind: 'idle' })}
+        />
+      );
+    }
+    return null;
+  };
 
   const renderNodeLayers = () =>
     nodes.map((n) => (
@@ -323,6 +523,8 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
     return (
       <div className="map-view">
         {loadError && <div className="alert alert-error">{loadError}</div>}
+        {renderToolbar()}
+        {renderEdgeModal()}
         {xrayActive && (
           <div className="alert alert-xray" role="status">
             🔍 Owner X-ray active — you can see all nodes regardless of visibility tagging.
@@ -355,6 +557,8 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
     return (
       <div className="map-view">
         {loadError && <div className="alert alert-error">{loadError}</div>}
+        {renderToolbar()}
+        {renderEdgeModal()}
         {xrayActive && (
           <div className="alert alert-xray" role="status">
             🔍 Owner X-ray active — you can see all nodes regardless of visibility tagging.
@@ -381,6 +585,8 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
   return (
     <div className="map-view">
       {loadError && <div className="alert alert-error">{loadError}</div>}
+      {renderToolbar()}
+      {renderEdgeModal()}
       {xrayActive && (
         <div className="alert alert-xray" role="status">
           🔍 Owner X-ray active — you can see all nodes regardless of visibility tagging.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -397,6 +397,24 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
 }
 .map-view-blank .leaflet-container { background: #f5f5f5; }
 
+/* Edge create/edit toolbar (#199). Sits above the leaflet container; the
+   active state (mid-creation hint) flips background to draw the eye. */
+.map-view-toolbar {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  padding: .5rem .75rem;
+  margin-bottom: .5rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-size: .875rem;
+}
+.map-view-toolbar-active {
+  background: #fff7e6;
+  border-color: #f0c060;
+}
+
 /* ─── Map detail layout (tree panel + map, #93) ────────────────────────────── */
 .map-detail-layout {
   display: flex;

--- a/frontend/src/services/maps.ts
+++ b/frontend/src/services/maps.ts
@@ -52,6 +52,8 @@ import {
   type UpdatePlotRequest,
   type EdgeRecord,
   type EdgeList,
+  type CreateEdgeRequest,
+  type UpdateEdgeRequest,
 } from '@/api/schemas';
 import type {
   Tenant,
@@ -598,5 +600,42 @@ export const edgesService = {
       `${tenantBase(tenantId)}/maps/${mapId}/nodes/${nodeId}/edges`
     );
     return EdgeListSchema.parse(res.data);
+  },
+
+  // Write methods (#199). POST/PUT return the full canonical record per
+  // §4b — same #152 pattern as plots/nodes.
+  async createEdge(
+    mapId: number,
+    data: CreateEdgeRequest,
+    tenantId?: number,
+  ): Promise<EdgeRecord> {
+    const res = await apiClient.post(
+      `${tenantBase(tenantId)}/maps/${mapId}/edges`,
+      data,
+    );
+    return EdgeRecordSchema.parse(res.data);
+  },
+
+  async updateEdge(
+    mapId: number,
+    edgeId: number,
+    data: UpdateEdgeRequest,
+    tenantId?: number,
+  ): Promise<EdgeRecord> {
+    const res = await apiClient.put(
+      `${tenantBase(tenantId)}/maps/${mapId}/edges/${edgeId}`,
+      data,
+    );
+    return EdgeRecordSchema.parse(res.data);
+  },
+
+  async deleteEdge(
+    mapId: number,
+    edgeId: number,
+    tenantId?: number,
+  ): Promise<void> {
+    await apiClient.delete(
+      `${tenantBase(tenantId)}/maps/${mapId}/edges/${edgeId}`,
+    );
   },
 };

--- a/frontend/tests/e2e/edges-create-edit.spec.ts
+++ b/frontend/tests/e2e/edges-create-edit.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import {
+  registerViaApi,
+  createMapViaApi,
+  createNodeViaApi,
+  seedAuthInBrowser,
+  API_URL,
+  type ApiUser,
+} from './helpers';
+
+/**
+ * E2E for #199 — edge create + edit UX.
+ *
+ * Read-only rendering is covered by edges.spec.ts (#198). This spec covers
+ * the toolbar-driven create flow, the click-to-edit modal, delete, and
+ * Esc cancellation. NodeDetailPanel-side edge listing is in #200's spec.
+ *
+ * The maps in these tests use a wgs84 coord system because the tests
+ * interact with Leaflet markers as the picking targets — the same DOM
+ * shape applies to pixel/blank, but cross-coord-system lock-in is
+ * #200's coordinate-systems-crud extension.
+ */
+
+const WGS84 = {
+  type: 'wgs84' as const,
+  center: { lat: 0, lng: 0 },
+  zoom: 3,
+};
+
+async function seedMapWithTwoNodes(
+  request: APIRequestContext,
+  api: ApiUser,
+  tag: string,
+): Promise<{ mapId: number; nodeAId: number; nodeBId: number }> {
+  const map = await createMapViaApi(request, api, `Edge UX ${tag}`, WGS84);
+  const a = await createNodeViaApi(request, api, map.id, {
+    name: 'NodeA',
+    geoJson: { type: 'Point', coordinates: [0, 0] },
+  });
+  const b = await createNodeViaApi(request, api, map.id, {
+    name: 'NodeB',
+    geoJson: { type: 'Point', coordinates: [10, 5] },
+  });
+  return { mapId: map.id, nodeAId: a.id, nodeBId: b.id };
+}
+
+async function createEdgeViaApi(
+  request: APIRequestContext,
+  api: ApiUser,
+  mapId: number,
+  body: { sourceNodeId: number; destNodeId: number; label?: string; color?: string; directed?: boolean },
+): Promise<{ id: number }> {
+  const res = await request.post(
+    `${API_URL}/tenants/${api.tenantId}/maps/${mapId}/edges`,
+    { headers: { Authorization: `Bearer ${api.token}` }, data: body },
+  );
+  if (!res.ok()) throw new Error(`createEdge failed: ${res.status()}`);
+  return res.json();
+}
+
+test.describe('Edges — create + edit UX (#199)', () => {
+  test('toolbar two-step pick → modal → create renders the polyline', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_ux_create');
+    const { mapId } = await seedMapWithTwoNodes(request, api, 'create');
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${mapId}`);
+
+    // Toolbar shows when caller has edit perm (owner here).
+    await page.getByRole('button', { name: /\+ edge/i }).click();
+    await expect(page.getByText(/click the source node/i)).toBeVisible();
+
+    // Click the two markers to pick source then dest. Leaflet renders
+    // each Point node as a `.leaflet-marker-icon`; first() / nth(1) by
+    // creation order in our seed. Use dispatchEvent because Leaflet's
+    // L.DomEvent listens for real native events; Playwright's synthetic
+    // click sometimes goes through actionability checks but doesn't
+    // trigger Leaflet's underlying click binding.
+    const clickMarker = (idx: number) =>
+      page.locator('.leaflet-marker-icon').nth(idx).evaluate((el) =>
+        el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      );
+    await clickMarker(0);
+    await expect(page.getByText(/click the destination node/i)).toBeVisible();
+    await clickMarker(1);
+
+    // Modal opens with both endpoints prefilled.
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.getByLabel(/^label/i).fill('Trade route');
+    await page.getByRole('button', { name: /^create$/i }).click();
+
+    // Modal closes, polyline appears in the overlay pane.
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+    const paths = page.locator('.leaflet-overlay-pane svg path');
+    await expect(paths).toHaveCount(1, { timeout: 10000 });
+  });
+
+  test('clicking an existing edge opens the edit modal and saves changes that persist on reload', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_ux_edit');
+    const { mapId, nodeAId, nodeBId } = await seedMapWithTwoNodes(request, api, 'edit');
+    await createEdgeViaApi(request, api, mapId, {
+      sourceNodeId: nodeAId,
+      destNodeId: nodeBId,
+      label: 'Initial',
+      color: '#3388ff',
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${mapId}`);
+
+    // Click the polyline (only path in the overlay pane for this test).
+    // Same dispatchEvent trick as marker clicks — Leaflet's path uses
+    // its own event binding, not the React synthetic event chain.
+    const clickPolyline = () =>
+      page.locator('.leaflet-overlay-pane svg path').first().evaluate((el) =>
+        el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      );
+    await clickPolyline();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    // Label field reflects the existing value, then we change it.
+    const label = page.getByLabel(/^label/i);
+    await expect(label).toHaveValue('Initial');
+    await label.fill('Updated');
+    await page.getByRole('button', { name: /^save$/i }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    // Reload and re-open to confirm the new value round-trips through the API.
+    await page.reload();
+    await clickPolyline();
+    await expect(page.getByLabel(/^label/i)).toHaveValue('Updated');
+  });
+
+  test('delete from the edit modal removes the edge and survives reload', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_ux_delete');
+    const { mapId, nodeAId, nodeBId } = await seedMapWithTwoNodes(request, api, 'delete');
+    await createEdgeViaApi(request, api, mapId, { sourceNodeId: nodeAId, destNodeId: nodeBId });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${mapId}`);
+
+    // Polyline visible pre-delete.
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(1, { timeout: 10000 });
+
+    page.once('dialog', (d) => d.accept());  // confirm() prompt
+    await page.locator('.leaflet-overlay-pane svg path').first().evaluate((el) =>
+      el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    );
+    await page.getByRole('button', { name: /^delete$/i }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    // Polyline gone after refetch.
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(0);
+
+    // Reload — still gone (DELETE was real, not just optimistic).
+    await page.reload();
+    await page.waitForTimeout(500);
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(0);
+  });
+
+  test('Esc cancels edge-create mid-flow without creating an edge', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_ux_cancel');
+    const { mapId } = await seedMapWithTwoNodes(request, api, 'cancel');
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${mapId}`);
+
+    await page.getByRole('button', { name: /\+ edge/i }).click();
+    await expect(page.getByText(/click the source node/i)).toBeVisible();
+
+    await page.locator('.leaflet-marker-icon').nth(0).evaluate((el) =>
+      el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    );
+    await expect(page.getByText(/click the destination node/i)).toBeVisible();
+
+    // Esc — modal should NOT open and toolbar returns to idle.
+    await page.keyboard.press('Escape');
+    await expect(page.getByText(/click the destination node/i)).not.toBeVisible();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    // No polyline created.
+    await page.waitForTimeout(500);
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #199. Adds toolbar-driven create flow + click-to-edit modal on top of #198's read-only rendering. Two-step source-then-dest picking, Esc cancellation, edit modal for existing edges with Delete affordance.

## Files changed

- \`frontend/src/api/schemas.ts\` — \`CreateEdgeRequest\` / \`UpdateEdgeRequest\` type aliases (request-side only; no Zod since responses re-parse through \`EdgeRecordSchema\`).
- \`frontend/src/components/Map/EdgeFormModal.tsx\` — new dual-mode (create / edit) modal. Endpoints are read-only display (immutable per #148); mutable fields are label / description / color / directed. Edit mode adds Delete (with \`confirm()\`).
- \`frontend/src/components/Map/MapView.tsx\` — edge create/edit state machine (\`idle → pickingSource → pickingDest → creating | editing\`), toolbar with status hint, Esc handler, edit-permission gate. Plus the **stale-closure mitigation** described below. EdgeLayer gets an optional \`onClick\` prop for the click-to-edit gesture; passes through CircleMarker too so directed-edge markers are clickable.
- \`frontend/src/index.css\` — minor styles for the toolbar (\`.map-view-toolbar\` + active state).
- \`frontend/src/services/maps.ts\` — \`createEdge\` / \`updateEdge\` / \`deleteEdge\` added to \`edgesService\`.
- \`frontend/tests/e2e/edges-create-edit.spec.ts\` — 4 specs covering create / edit / delete / cancel flows.

## Stale-closure mitigation (worth flagging)

react-leaflet captures \`eventHandlers\` at marker-mount time and doesn't reliably re-attach when the prop's identity changes — closure-based handlers ran against the **first render's** state machine (idle), which silently broke the create flow until ref-based indirection. Pattern applied to both the node-click handler (\`handleClickRef\` → stable \`handleClick\`) and the edge-click handler (\`handleEdgeClickRef\` → stable \`handleEdgeClick\`). Stable wrappers preserve handler identity for react-leaflet; each call delegates to the live ref, which always points at the latest state-aware closure.

## Test plan

- [x] \`edges-create-edit.spec.ts\`: 4/4 passed (create / edit / delete / cancel).
- [x] \`edges.spec.ts\` (#198 read-only spec): still passes.
- [x] Sibling specs (maps, node-creation, node-edit-delete, tree, visibility, coordinate-systems): 30 passed, 5 pre-existing skips, no regressions.
- [x] \`tsc --noEmit\` + ESLint: both clean.
- [x] CI on wave-4-edges (auto-trigger via wave-* glob).

## Operational impact

Frontend reload (Vite HMR picks up automatically). No backend changes, no migration.

## Test infrastructure note

E2E marker / polyline clicks use \`dispatchEvent(new MouseEvent('click'))\` rather than Playwright's synthetic \`.click()\`. Leaflet's \`L.DomEvent\` listens for real native events; the synthetic click passes Playwright's actionability check but doesn't trigger Leaflet's underlying click binding. Worth borrowing in any future Leaflet-interaction spec.

## Wave context

Wave 4 PR 4 of 5. Tracker: #255. Final PR (#200 — NodeDetailPanel "Edges" section + epic E2E lock-in) waits on this merge.