### PR TITLE
Frontend: NodeDetailPanel Edges section + epic E2E (#200, Wave 4 PR5)

### DIFF
--- a/frontend/src/components/Detail/EdgesSection.tsx
+++ b/frontend/src/components/Detail/EdgesSection.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { edgesService, nodesService } from '@/services/maps';
+import { extractApiError } from '@/utils/errors';
+import type { EdgeRecord, NodeRecord } from '@/types';
+
+// Per-node edges section in the detail panel (#200). Lists every edge
+// touching the selected node, with a quick-remove per row and a
+// "+ Edge from here" affordance that starts MapView's edge-create flow
+// with the current node prefilled as source.
+//
+// The "other endpoint" — the node at the far end of each edge — is
+// fetched in parallel so we can render its name. If a node lookup
+// fails (e.g., visibility), the row falls back to a generic "Hidden
+// location" label rather than disappearing, since the edge itself is
+// still visible to the caller (#197 visibility derives from BOTH
+// endpoints — if either is hidden, the edge wouldn't be in the list
+// at all).
+
+interface EdgesSectionProps {
+  mapId: number;
+  nodeId: number;
+  /** Click on a row's "other endpoint" name selects that node. */
+  onSelectNode: (nodeId: number) => void;
+  /** Click on "+ Edge from here" — MapDetailPage relays to MapView so
+   *  the toolbar state machine jumps into pickingDest with this node
+   *  as source. */
+  onStartEdgeFromNode: (sourceNodeId: number) => void;
+  /** Fired after a successful mutation (currently: delete). Parent uses
+   *  this to refresh sibling components — the map's edge layer in
+   *  particular, which would otherwise be stale. */
+  onChanged?: () => void;
+}
+
+interface RowInfo {
+  edge: EdgeRecord;
+  other: NodeRecord | null;
+  outgoing: boolean;  // edge.sourceNodeId === nodeId
+}
+
+export function EdgesSection({
+  mapId,
+  nodeId,
+  onSelectNode,
+  onStartEdgeFromNode,
+  onChanged,
+}: EdgesSectionProps) {
+  const [rows, setRows] = useState<RowInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const loadAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const edges = await edgesService.listEdgesForNode(mapId, nodeId);
+      // Fetch the "other endpoint" for each row in parallel. Failures
+      // resolve to null and the row renders with a fallback label.
+      const otherIds = edges.map((e) =>
+        e.sourceNodeId === nodeId ? e.destNodeId : e.sourceNodeId,
+      );
+      const fetched = await Promise.all(
+        otherIds.map((oid) => nodesService.getNode(mapId, oid).catch(() => null)),
+      );
+      setRows(edges.map((e, i) => ({
+        edge: e,
+        other: fetched[i],
+        outgoing: e.sourceNodeId === nodeId,
+      })));
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to load edges.'));
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [mapId, nodeId]);
+
+  useEffect(() => { loadAll(); }, [loadAll]);
+
+  const handleRemove = async (edgeId: number) => {
+    if (!window.confirm('Remove this edge?')) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await edgesService.deleteEdge(mapId, edgeId);
+      onChanged?.();  // refresh sibling map render
+      await loadAll();
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to remove edge.'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Display the directed indicator from the perspective of THIS node:
+  //   outgoing + directed → → (this node is the source)
+  //   incoming + directed → ← (this node is the dest)
+  //   not directed        → ↔
+  const indicator = useMemo(() => (row: RowInfo) => {
+    if (!row.edge.directed) return '↔';
+    return row.outgoing ? '→' : '←';
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="edges-section">
+        <h3>Edges</h3>
+        <p className="edges-section-empty">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="edges-section">
+      <div className="edges-section-header">
+        <h3>Edges</h3>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={() => onStartEdgeFromNode(nodeId)}
+        >
+          + Edge from here
+        </button>
+      </div>
+
+      {error && <div className="alert alert-error">{error}</div>}
+
+      {rows.length === 0 ? (
+        <p className="edges-section-empty">No edges touching this location.</p>
+      ) : (
+        <ul className="edges-section-list">
+          {rows.map((row) => (
+            <li key={row.edge.id} className="edges-section-row">
+              {row.edge.color && (
+                <span
+                  className="edges-section-color"
+                  style={{ background: row.edge.color }}
+                  aria-hidden="true"
+                />
+              )}
+              <span className="edges-section-direction" aria-hidden="true">
+                {indicator(row)}
+              </span>
+              {row.other ? (
+                <button
+                  type="button"
+                  className="link-button edges-section-name"
+                  onClick={() => onSelectNode(row.other!.id)}
+                >
+                  {row.other.name}
+                </button>
+              ) : (
+                <span className="edges-section-name edges-section-name-hidden">
+                  Hidden location
+                </span>
+              )}
+              {row.edge.label && (
+                <span className="edges-section-label">{row.edge.label}</span>
+              )}
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                onClick={() => handleRemove(row.edge.id)}
+                disabled={busy}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Detail/NodeDetailPanel.tsx
+++ b/frontend/src/components/Detail/NodeDetailPanel.tsx
@@ -3,6 +3,7 @@ import { nodesService, notesService } from '@/services/maps';
 import { extractApiError } from '@/utils/errors';
 import { VisibilityEditor } from '@/components/Visibility/VisibilityEditor';
 import { PlotsSection } from '@/components/Detail/PlotsSection';
+import { EdgesSection } from '@/components/Detail/EdgesSection';
 import { MediaSection } from '@/components/Detail/MediaSection';
 import type {
   NodeRecord,
@@ -27,12 +28,21 @@ interface NodeDetailPanelProps {
   mapId: number;
   selectedNodeId: number | null;
   onSelectNode: (nodeId: number) => void;
+  /** "+ Edge from here" in the Edges section relays through this callback
+   *  so the map-side toolbar state machine can jump to pickingDest with
+   *  the current node as source (#200). */
+  onStartEdgeFromNode?: (sourceNodeId: number) => void;
+  /** Fired when EdgesSection mutates an edge (currently: delete).
+   *  Parent bumps a counter so MapView can refetch its edge list. */
+  onEdgesChanged?: () => void;
 }
 
 export function NodeDetailPanel({
   mapId,
   selectedNodeId,
   onSelectNode,
+  onStartEdgeFromNode,
+  onEdgesChanged,
 }: NodeDetailPanelProps) {
   const [node, setNode] = useState<NodeRecord | null>(null);
   const [parent, setParent] = useState<NodeRecord | null>(null);
@@ -158,6 +168,18 @@ export function NodeDetailPanel({
       <section className="node-detail-plots">
         <PlotsSection mapId={mapId} kind="node" entityId={node.id} />
       </section>
+
+      {onStartEdgeFromNode && (
+        <section className="node-detail-edges">
+          <EdgesSection
+            mapId={mapId}
+            nodeId={node.id}
+            onSelectNode={onSelectNode}
+            onStartEdgeFromNode={onStartEdgeFromNode}
+            onChanged={onEdgesChanged}
+          />
+        </section>
+      )}
 
       <NotesList
         mapId={mapId}

--- a/frontend/src/components/Map/MapView.tsx
+++ b/frontend/src/components/Map/MapView.tsx
@@ -214,6 +214,21 @@ interface MapViewProps {
    * twice in the tree should re-center the map both times.
    */
   panTarget?: [number, number] | null;
+  /**
+   * Command to start the edge-create flow with a source already chosen
+   * (#200's "+ Edge from here" affordance in NodeDetailPanel). Each set
+   * to a new object identity triggers MapView to jump straight to
+   * pickingDest with `sourceNodeId` as source.
+   */
+  edgeStartFrom?: { sourceNodeId: number } | null;
+  /**
+   * Bump counter that signals an external edge mutation (e.g.,
+   * EdgesSection deleted an edge from the detail panel). On change,
+   * MapView refetches its edge list so the map rendering stays in
+   * sync with cross-component changes. Increment from MapDetailPage
+   * whenever a non-MapView code path mutates an edge.
+   */
+  edgesRefreshKey?: number;
 }
 
 // Mounted inside MapContainer so it has access to the leaflet map instance.
@@ -228,7 +243,13 @@ function PanController({ target }: { target: [number, number] | null | undefined
   return null;
 }
 
-export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
+export function MapView({
+  map,
+  onNodeClick,
+  panTarget,
+  edgeStartFrom,
+  edgesRefreshKey,
+}: MapViewProps) {
   const [nodes, setNodes] = useState<NodeRecord[]>([]);
   const [edges, setEdges] = useState<EdgeRecord[]>([]);
   const [mediaByNode, setMediaByNode] = useState<Record<number, NodeMediaRecord[]>>({});
@@ -337,6 +358,20 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
     handleClickRef.current(nodeId);
   }).current;
 
+  // External command: "+ Edge from here" in NodeDetailPanel (#200).
+  // When the prop's object identity changes, jump straight to
+  // pickingDest with the supplied source. Only fires if currently idle
+  // — refuses to override an in-flight pick/edit.
+  useEffect(() => {
+    if (!edgeStartFrom) return;
+    if (!canEdit) return;
+    setEdgeMode((prev) =>
+      prev.kind === 'idle'
+        ? { kind: 'pickingDest', sourceId: edgeStartFrom.sourceNodeId }
+        : prev,
+    );
+  }, [edgeStartFrom, canEdit]);
+
   // Esc cancels mid-creation (any non-idle/non-modal state).
   useEffect(() => {
     if (edgeMode.kind !== 'pickingSource' && edgeMode.kind !== 'pickingDest') {
@@ -357,6 +392,17 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
       .then((es) => setEdges(es))
       .catch(() => { /* keep stale list; same posture as initial load */ });
   };
+
+  // External-mutation signal (#200). NodeDetailPanel's EdgesSection can
+  // delete an edge directly, bypassing this component's modal handlers.
+  // MapDetailPage bumps `edgesRefreshKey` on each such mutation; the
+  // effect below refetches so the map render stays in sync. Skip the
+  // initial undefined value (first mount).
+  useEffect(() => {
+    if (edgesRefreshKey === undefined) return;
+    refetchEdges();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [edgesRefreshKey]);
 
   // Same staleness mitigation as handleClick — the EdgeLayer's onClick
   // is captured at first mount by react-leaflet, so without ref-stable

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -945,6 +945,55 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
   gap: .35rem;
 }
 .plots-section-add select { flex: 1; min-width: 8rem; }
+
+/* Per-node Edges section in the detail panel (#200). Same visual
+   shape as PlotsSection — row of color swatch + direction glyph +
+   other-endpoint name + optional label + remove. */
+.node-detail-edges {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+}
+.edges-section h3 { font-size: .9rem; margin: 0 0 .5rem; }
+.edges-section-empty {
+  font-size: .8rem;
+  color: #888;
+  margin: .25rem 0;
+}
+.edges-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: .25rem;
+}
+.edges-section-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+}
+.edges-section-row {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  padding: .25rem .5rem;
+  border-radius: var(--radius);
+  background: #fafafa;
+  font-size: .85rem;
+}
+.edges-section-color {
+  width: .9rem;
+  height: .9rem;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, .1);
+}
+.edges-section-direction { font-weight: 600; opacity: .65; }
+.edges-section-name { font-weight: 500; flex: 1; text-align: left; }
+.edges-section-name-hidden { font-style: italic; color: #888; font-weight: normal; }
+.edges-section-label { color: #888; font-size: .8rem; }
+
 .note-card-plots {
   margin-top: .5rem;
   padding-top: .5rem;

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -32,6 +32,16 @@ export function MapDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
   const [panTarget, setPanTarget] = useState<[number, number] | null>(null);
+  // "+ Edge from here" cross-component command (#200). NodeDetailPanel
+  // fires this; MapView reads it via prop. Object identity changes per
+  // command so MapView's effect re-fires even when the same node is
+  // chosen twice.
+  const [edgeStartFrom, setEdgeStartFrom] =
+    useState<{ sourceNodeId: number } | null>(null);
+  // Bump counter for external edge mutations (e.g., EdgesSection delete
+  // from the detail panel). MapView's effect on this prop refetches so
+  // the map render stays in sync.
+  const [edgesRefreshKey, setEdgesRefreshKey] = useState(0);
   const [xraySaving, setXraySaving] = useState(false);
   const [xrayError, setXrayError] = useState<string | null>(null);
   const [showSharing, setShowSharing] = useState(false);
@@ -149,12 +159,16 @@ export function MapDetailPage() {
           map={activeMap}
           onNodeClick={setSelectedNodeId}
           panTarget={panTarget}
+          edgeStartFrom={edgeStartFrom}
+          edgesRefreshKey={edgesRefreshKey}
         />
       </div>
       <NodeDetailPanel
         mapId={activeMap.id}
         selectedNodeId={selectedNodeId}
         onSelectNode={setSelectedNodeId}
+        onStartEdgeFromNode={(nodeId) => setEdgeStartFrom({ sourceNodeId: nodeId })}
+        onEdgesChanged={() => setEdgesRefreshKey((k) => k + 1)}
       />
       <button className="btn btn-ghost" onClick={() => navigate(`/tenants/${tenantId}/maps`)}>
         Back to maps

--- a/frontend/tests/e2e/coordinate-systems-crud.spec.ts
+++ b/frontend/tests/e2e/coordinate-systems-crud.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Locator } from '@playwright/test';
 import {
   registerViaApi,
   createMapViaApi,
@@ -153,6 +153,64 @@ for (const { name, cs } of COORD_SYSTEMS) {
       await expect(
         page.getByRole('heading', { name: 'NodeForDetail' }),
       ).toBeVisible();
+    });
+
+    test(`${name}: edge create + delete (Wave 4 #200 lock-in)`, async ({ page, request }) => {
+      // Each coord system uses its own pointable coordinates. wgs84 +
+      // blank both accept [x, y] in the GeoJSON spec; pixel uses image
+      // pixels. The Point geometry shape is the same — the renderer
+      // interprets it per coord-system at view time.
+      const pointA: [number, number] =
+        name === 'pixel' ? [200, 200] :
+        name === 'blank' ? [100, 100] :
+        [0, 0];
+      const pointB: [number, number] =
+        name === 'pixel' ? [600, 400] :
+        name === 'blank' ? [400, 300] :
+        [10, 5];
+
+      const api = await registerViaApi(request, `${name}_edge_lockin`);
+      const map = await createMapViaApi(request, api, `${name} Edge Lockin`, cs);
+      await createNodeViaApi(request, api, map.id, {
+        name: 'NodeA',
+        geoJson: { type: 'Point', coordinates: pointA },
+      });
+      await createNodeViaApi(request, api, map.id, {
+        name: 'NodeB',
+        geoJson: { type: 'Point', coordinates: pointB },
+      });
+
+      await seedAuthInBrowser(page, api);
+      await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+      // Create the edge via the toolbar two-step pick. The same
+      // dispatchEvent trick used elsewhere — Leaflet's L.DomEvent
+      // listens for real native events; Playwright's synthetic
+      // .click() doesn't trigger it.
+      await page.getByRole('button', { name: /\+ edge/i }).click();
+      const dispatchClick = (loc: Locator) =>
+        loc.evaluate((el) =>
+          el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+        );
+      const markers = page.locator('.leaflet-marker-icon');
+      await dispatchClick(markers.nth(0));
+      await dispatchClick(markers.nth(1));
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: /^create$/i }).click();
+      await expect(page.getByRole('dialog')).not.toBeVisible();
+
+      // Polyline renders on this coord system.
+      await expect(
+        page.locator('.leaflet-overlay-pane svg path'),
+      ).toHaveCount(1, { timeout: 10000 });
+
+      // Delete via the polyline click → modal → Delete.
+      page.once('dialog', (d) => d.accept());
+      await dispatchClick(page.locator('.leaflet-overlay-pane svg path').first());
+      await page.getByRole('button', { name: /^delete$/i }).click();
+      await expect(
+        page.locator('.leaflet-overlay-pane svg path'),
+      ).toHaveCount(0);
     });
   });
 }

--- a/frontend/tests/e2e/edges-epic.spec.ts
+++ b/frontend/tests/e2e/edges-epic.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect, type Locator } from '@playwright/test';
+import {
+  registerViaApi,
+  createMapViaApi,
+  createNodeViaApi,
+  seedAuthInBrowser,
+} from './helpers';
+
+/**
+ * Epic lock-in E2E for the Edges epic (#148). Full round-trip in one
+ * spec — covers the integration points across all four implementation
+ * tickets (#148 backend CRUD, #197 visibility filter, #198 rendering,
+ * #199 toolbar UX, #200 detail-panel section):
+ *
+ *   - create two nodes via API → navigate to map
+ *   - toolbar "+ Edge" → click source → click dest → modal → save
+ *   - polyline renders
+ *   - click polyline → edit label → save → reload → label persists
+ *   - select a source-side node → NodeDetailPanel shows the edge in the
+ *     Edges section with the correct direction glyph
+ *   - "Remove" in the panel → confirm → edge gone from panel AND map
+ *
+ * The "+ Edge from here" affordance (#200) is exercised in its own test
+ * below: select a node, click the button in the panel, pick a dest by
+ * clicking on the map, save, verify.
+ */
+
+const WGS84 = {
+  type: 'wgs84' as const,
+  center: { lat: 0, lng: 0 },
+  zoom: 3,
+};
+
+// Leaflet's L.DomEvent listens for native events; Playwright's
+// synthetic .click() doesn't trigger it. dispatchEvent is the same
+// trick used in edges-create-edit.spec.ts and is documented in the
+// PR #199 description for future-spec reference.
+async function clickLeafletEl(locator: Locator): Promise<void> {
+  await locator.evaluate((el) =>
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+  );
+}
+
+test.describe('Edges — epic lock-in (#148 / #197 / #198 / #199 / #200)', () => {
+  test('full round-trip: create via toolbar, edit, find in detail panel, remove', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_epic');
+    const map = await createMapViaApi(request, api, 'Epic edges', WGS84);
+
+    await createNodeViaApi(request, api, map.id, {
+      name: 'NodeA',
+      geoJson: { type: 'Point', coordinates: [0, 0] },
+    });
+    await createNodeViaApi(request, api, map.id, {
+      name: 'NodeB',
+      geoJson: { type: 'Point', coordinates: [10, 5] },
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // ── Create via toolbar ───────────────────────────────────────────────
+    await page.getByRole('button', { name: /\+ edge/i }).click();
+    await expect(page.getByText(/click the source node/i)).toBeVisible();
+
+    const markers = page.locator('.leaflet-marker-icon');
+    await clickLeafletEl(markers.nth(0));
+    await expect(page.getByText(/click the destination node/i)).toBeVisible();
+    await clickLeafletEl(markers.nth(1));
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.getByLabel(/^label/i).fill('Trade route');
+    await page.getByRole('button', { name: /^create$/i }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(1, { timeout: 10000 });
+
+    // ── Edit + reload persistence ────────────────────────────────────────
+    await clickLeafletEl(page.locator('.leaflet-overlay-pane svg path').first());
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.getByLabel(/^label/i).fill('Updated route');
+    await page.getByRole('button', { name: /^save$/i }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    await page.reload();
+    await clickLeafletEl(page.locator('.leaflet-overlay-pane svg path').first());
+    await expect(page.getByLabel(/^label/i)).toHaveValue('Updated route');
+    // Close the modal so the rest of the flow can interact freely.
+    await page.getByRole('button', { name: /^cancel$/i }).click();
+
+    // ── Detail panel: select NodeA, see the edge listed ──────────────────
+    // The tree panel has a button per node; clicking selects + scrolls the
+    // detail panel into view.
+    await page.getByRole('button', { name: 'NodeA' }).click();
+
+    // EdgesSection lists the row with NodeB as the other endpoint.
+    const edgesSection = page.locator('.edges-section');
+    await expect(edgesSection.getByRole('heading', { name: /^edges$/i })).toBeVisible();
+    await expect(edgesSection.getByRole('button', { name: 'NodeB' })).toBeVisible();
+
+    // Other-endpoint click should navigate selection. We don't need to
+    // assert on URL here — the heading flipping to NodeB is enough.
+    await edgesSection.getByRole('button', { name: 'NodeB' }).click();
+    await expect(page.getByRole('heading', { name: 'NodeB', level: 2 })).toBeVisible();
+
+    // ── Remove via panel ─────────────────────────────────────────────────
+    page.once('dialog', (d) => d.accept());
+    await page.locator('.edges-section').getByRole('button', { name: /^remove$/i }).click();
+    // Edge gone from panel
+    await expect(page.locator('.edges-section').getByRole('button', { name: 'NodeA' })).toHaveCount(0);
+    // Gone from map (refetch + rerender)
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(0);
+
+    // Reload — still gone (DELETE was real, not just optimistic).
+    await page.reload();
+    await page.waitForTimeout(500);
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(0);
+  });
+
+  test('"+ Edge from here" prefills source and only the dest needs picking', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_epic_fromhere');
+    const map = await createMapViaApi(request, api, 'Epic from-here', WGS84);
+    await createNodeViaApi(request, api, map.id, {
+      name: 'NodeA',
+      geoJson: { type: 'Point', coordinates: [0, 0] },
+    });
+    await createNodeViaApi(request, api, map.id, {
+      name: 'NodeB',
+      geoJson: { type: 'Point', coordinates: [10, 5] },
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // Select NodeA from the tree so its panel section renders.
+    await page.getByRole('button', { name: 'NodeA' }).click();
+    await expect(page.locator('.edges-section')).toBeVisible();
+
+    // "+ Edge from here" button in the section header.
+    await page.locator('.edges-section').getByRole('button', { name: /\+ edge from here/i }).click();
+
+    // Toolbar should jump straight to "Click the destination node"
+    // (source is prefilled — picking-source is skipped).
+    await expect(page.getByText(/click the destination node/i)).toBeVisible();
+    // We should NOT have seen the "Click the source node" hint.
+    await expect(page.getByText(/click the source node/i)).not.toBeVisible();
+
+    // Click NodeB as the dest. The second marker by creation order.
+    await page.locator('.leaflet-marker-icon').nth(1).evaluate((el) =>
+      el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    );
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.getByRole('button', { name: /^create$/i }).click();
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(1, { timeout: 10000 });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #200 and locks in the full Edges epic (#148 / #197 / #198 / #199 / #200) with end-to-end coverage. **Last PR of Wave 4.**

## Files changed

- \`frontend/src/components/Detail/EdgesSection.tsx\` — new section component. Color swatch + direction glyph (→/←/↔ from this node's perspective) + other-endpoint name (clickable) + optional label + per-row Remove. Header "+ Edge from here" button hands off to MapView. Other-endpoint nodes fetched in parallel; failed lookups fall back to "Hidden location" defensive label.
- \`frontend/src/components/Detail/NodeDetailPanel.tsx\` — wires \`EdgesSection\` between the Plots and Notes sections. New optional props \`onStartEdgeFromNode\` + \`onEdgesChanged\` pass through.
- \`frontend/src/components/Map/MapView.tsx\` — two new optional props:
  - \`edgeStartFrom\`: command to jump straight to \`pickingDest\` with a prefilled source. New object identity per click → effect re-fires.
  - \`edgesRefreshKey\`: bump counter for external edge mutations (EdgesSection delete). Effect refetches the edge list so the polyline render stays in sync. **Without this, panel-side delete left a stale polyline rendered — caught by the epic E2E spec.**
- \`frontend/src/pages/MapDetailPage.tsx\` — owns the two new state values and wires the callback chain between NodeDetailPanel and MapView.
- \`frontend/src/index.css\` — \`.edges-section\` + related styles (mirroring the PlotsSection visual shape).
- \`frontend/tests/e2e/edges-epic.spec.ts\` (NEW) — 2 specs:
  - Full round-trip: create via toolbar → edit + reload-persistence → locate in detail panel → click other-endpoint to navigate → remove → assert gone from panel + map + post-reload.
  - "+ Edge from here": select node → click button → toolbar jumps directly to pickingDest (no "Click the source node" hint visible) → click dest → submit modal → polyline renders.
- \`frontend/tests/e2e/coordinate-systems-crud.spec.ts\` — new per-coord-system "edge create + delete" test in the existing parameterized suite (3 new tests: wgs84 + pixel + blank). Pins that the toolbar gesture works the same on every coord system.

## Cross-component wiring rationale

The naive approach (have EdgesSection trigger the create flow directly via shared store / context) would have either coupled it to MapView's state machine or introduced a global edge-create-mode singleton. The chosen pattern keeps each component's state local and uses parent-mediated command/bump props — same shape as the existing \`panTarget\` prop. Each cross-component event is a new object/number identity, so React effects re-fire even when the same value would otherwise look unchanged.

## Test plan

- [x] \`edges-epic.spec.ts\`: 2/2 passed.
- [x] \`coordinate-systems-crud.spec.ts\` edge tests: 3/3 (wgs84 + pixel + blank).
- [x] Sibling sweep (10 specs): 47 passed, 5 pre-existing skips.
- [x] \`tsc --noEmit\` + ESLint: both clean.
- [ ] CI on wave-4-edges (auto-trigger via wave-* glob).

## Operational impact

Frontend reload (Vite HMR). No backend changes, no migration.

## Wave context

**Wave 4 PR 5 of 5 — final.** Tracker: #255. After this merges:
1. Final per-PR CI sweep across all five (#256 / #257 / #258 / #259 / this).
2. \`weekend.yml --ref wave-4-edges\` for integration verification on the full wave.
3. Open the wave→main merge PR once weekend.yml is green.