### PR TITLE
Wave 4: Edges epic (#148 → #200)

### DIFF
--- a/backend/src/controllers/EdgeController.cpp
+++ b/backend/src/controllers/EdgeController.cpp
@@ -1,14 +1,18 @@
 #include "EdgeController.h"
 #include "AuditLog.h"
 #include "ErrorResponse.h"
+#include "NodeController.h"  // MAX_NODE_DEPTH for the resolve CTE
 #include <drogon/drogon.h>
 
-// Phase 1 of the edges epic (#148). Schema + unfiltered CRUD; the
-// visibility filter (edge visible iff BOTH endpoints visible) lands in
-// #197 as a follow-up. Edges connect two nodes within a single map and
-// are scoped to that map's permissions for read + write.
+// Edges connect two nodes within a single map for relational use cases.
 //
-// Read authorization: caller must have view-level access to the map.
+// Read authorization is two-layered (#197):
+//   1. Map permission: caller must have view-level access to the map.
+//   2. Edge visibility: an edge is visible iff BOTH endpoints are
+//      visible to the caller under the per-node #99 effective-visibility
+//      rules. Tenant admins bypass layer 2; map owners with
+//      owner_xray = TRUE also bypass.
+//
 // Write authorization: caller must have edit-level access to the map
 // (or be the owner) AND tenant role admin or editor.
 //
@@ -23,12 +27,53 @@ int callerUserId(const drogon::HttpRequestPtr& req) {
     catch (...) { return 0; }
 }
 
+bool isTenantAdmin(const drogon::HttpRequestPtr& req) {
+    try {
+        return req->getAttributes()->get<std::string>("tenantRole") == "admin";
+    } catch (...) { return false; }
+}
+
 bool isTenantEditorOrAdmin(const drogon::HttpRequestPtr& req) {
     try {
         const auto role = req->getAttributes()->get<std::string>("tenantRole");
         return role == "admin" || role == "editor";
     } catch (...) { return false; }
 }
+
+// Effective-visibility CTE — same shape as NodeController's, restated
+// locally so EdgeController doesn't take a private dependency on the
+// other controller's anonymous-namespace constants.
+//
+// Binds: (mapId, userId).
+const std::string VISIBILITY_RESOLVE_CTE =
+    "WITH RECURSIVE resolve AS ("
+    "  SELECT n.id AS start_id, n.id AS cur_id, n.parent_id, "
+    "         n.visibility_override, 0 AS depth "
+    "  FROM nodes n WHERE n.map_id = ? "
+    "  UNION ALL "
+    "  SELECT r.start_id, p.id, p.parent_id, p.visibility_override, r.depth + 1 "
+    "  FROM resolve r JOIN nodes p ON p.id = r.parent_id "
+    "  WHERE r.visibility_override = FALSE AND r.depth < " +
+        std::to_string(MAX_NODE_DEPTH) +
+    "), visible_starts AS ( "
+    "  SELECT DISTINCT r.start_id FROM resolve r "
+    "  JOIN node_visibility nv "
+    "       ON nv.node_id = r.cur_id AND r.visibility_override = TRUE "
+    "  JOIN visibility_group_members vgm "
+    "       ON vgm.visibility_group_id = nv.visibility_group_id "
+    "  WHERE vgm.user_id = ? "
+    ") ";
+
+// Edge-visibility predicate — both endpoints must be visible OR the
+// caller is the map owner with owner_xray=TRUE.
+// Binds: (userId).
+//
+// JOIN expectations: caller must have JOINed `maps m ON m.id = e.map_id`
+// for the owner_id / owner_xray check.
+const std::string EDGE_VISIBILITY_PREDICATE =
+    " AND ((m.owner_id = ? AND m.owner_xray = TRUE) "
+    "      OR (e.source_node_id IN (SELECT start_id FROM visible_starts) "
+    "          AND e.dest_node_id IN (SELECT start_id FROM visible_starts))) ";
 
 Json::Value rowToEdge(const drogon::orm::Row& row) {
     Json::Value e;
@@ -64,12 +109,12 @@ void EdgeController::listEdges(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId, int mapId) {
 
-    int userId = callerUserId(req);
+    int userId  = callerUserId(req);
+    bool isAdmin = isTenantAdmin(req);
 
     // First verify the caller has view access on the map; on success,
-    // fetch the edges. Splitting the read makes 403/empty-array
-    // distinguishable (map missing or hidden → 403; map visible but no
-    // edges → 200 []).
+    // fetch the edges. Admins skip the visibility CTE; non-admins get
+    // the both-endpoints-visible filter applied.
     auto db = drogon::app().getDbClient();
     db->execSqlAsync(
         "SELECT m.id FROM maps m "
@@ -80,27 +125,47 @@ void EdgeController::listEdges(
         "  AND (m.owner_id = ? "
         "       OR mp.level IN ('view','comment','edit','moderate','admin') "
         "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
-        [callback, mapId](const drogon::orm::Result& rAccess) {
+        [callback, mapId, userId, isAdmin](const drogon::orm::Result& rAccess) {
             if (rAccess.empty()) {
                 callback(errorResponse(drogon::k403Forbidden,
                     "forbidden", "Map not found or insufficient permissions"));
                 return;
             }
+
             auto db2 = drogon::app().getDbClient();
-            db2->execSqlAsync(
-                "SELECT " + EDGE_COLUMNS +
-                " FROM node_edges WHERE map_id = ? "
-                " ORDER BY created_at ASC, id ASC",
-                [callback](const drogon::orm::Result& r) {
-                    Json::Value arr(Json::arrayValue);
-                    for (const auto& row : r) arr.append(rowToEdge(row));
-                    callback(drogon::HttpResponse::newHttpJsonResponse(arr));
-                },
-                [callback](const drogon::orm::DrogonDbException&) {
-                    callback(errorResponse(drogon::k500InternalServerError,
-                        "db_error", "Failed to fetch edges"));
-                },
-                mapId);
+            auto onRows = [callback](const drogon::orm::Result& r) {
+                Json::Value arr(Json::arrayValue);
+                for (const auto& row : r) arr.append(rowToEdge(row));
+                callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+            };
+            auto onErr = [callback](const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Failed to fetch edges"));
+            };
+
+            if (isAdmin) {
+                db2->execSqlAsync(
+                    "SELECT " + EDGE_COLUMNS +
+                    " FROM node_edges WHERE map_id = ? "
+                    " ORDER BY created_at ASC, id ASC",
+                    onRows, onErr,
+                    mapId);
+            } else {
+                std::string sql = VISIBILITY_RESOLVE_CTE +
+                    "SELECT " +
+                    "  e.id, e.map_id, e.source_node_id, e.dest_node_id, "
+                    "  e.directed, e.color, e.label, e.description, "
+                    "  e.created_by, e.created_at, e.updated_at "
+                    "FROM node_edges e "
+                    "JOIN maps m ON m.id = e.map_id "
+                    "WHERE e.map_id = ? " +
+                    EDGE_VISIBILITY_PREDICATE +
+                    " ORDER BY e.created_at ASC, e.id ASC";
+                db2->execSqlAsync(sql, onRows, onErr,
+                    mapId, userId,            // CTE
+                    mapId,                    // WHERE e.map_id
+                    userId);                  // xray (m.owner_id = ?)
+            }
         },
         [callback](const drogon::orm::DrogonDbException&) {
             callback(errorResponse(drogon::k500InternalServerError,
@@ -249,12 +314,13 @@ void EdgeController::getEdge(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId, int mapId, int id) {
 
-    int userId = callerUserId(req);
+    int userId  = callerUserId(req);
+    bool isAdmin = isTenantAdmin(req);
 
     // Verify view access on the map first; on success, fetch the edge.
-    // Returns 404 (not 403) if the edge doesn't exist on this map — the
-    // caller proved they could see the map, so distinguishing missing
-    // from hidden is fine here.
+    // For non-admins, the edge fetch additionally enforces the
+    // both-endpoints-visible filter — a hidden edge returns 404, never
+    // 403, to avoid leaking edge existence (per #197 acceptance).
     auto db = drogon::app().getDbClient();
     db->execSqlAsync(
         "SELECT m.id FROM maps m "
@@ -265,29 +331,46 @@ void EdgeController::getEdge(
         "  AND (m.owner_id = ? "
         "       OR mp.level IN ('view','comment','edit','moderate','admin') "
         "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
-        [callback, mapId, id](const drogon::orm::Result& rAcc) {
+        [callback, mapId, id, userId, isAdmin](const drogon::orm::Result& rAcc) {
             if (rAcc.empty()) {
                 callback(errorResponse(drogon::k403Forbidden,
                     "forbidden", "Map not found or insufficient permissions"));
                 return;
             }
             auto db2 = drogon::app().getDbClient();
-            db2->execSqlAsync(
-                "SELECT " + EDGE_COLUMNS +
-                " FROM node_edges WHERE id = ? AND map_id = ?",
-                [callback](const drogon::orm::Result& r) {
-                    if (r.empty()) {
-                        callback(errorResponse(drogon::k404NotFound,
-                            "not_found", "Edge not found"));
-                        return;
-                    }
-                    callback(drogon::HttpResponse::newHttpJsonResponse(rowToEdge(r[0])));
-                },
-                [callback](const drogon::orm::DrogonDbException&) {
-                    callback(errorResponse(drogon::k500InternalServerError,
-                        "db_error", "Failed to fetch edge"));
-                },
-                id, mapId);
+            auto onRow = [callback](const drogon::orm::Result& r) {
+                if (r.empty()) {
+                    callback(errorResponse(drogon::k404NotFound,
+                        "not_found", "Edge not found"));
+                    return;
+                }
+                callback(drogon::HttpResponse::newHttpJsonResponse(rowToEdge(r[0])));
+            };
+            auto onErr = [callback](const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Failed to fetch edge"));
+            };
+
+            if (isAdmin) {
+                db2->execSqlAsync(
+                    "SELECT " + EDGE_COLUMNS +
+                    " FROM node_edges WHERE id = ? AND map_id = ?",
+                    onRow, onErr, id, mapId);
+            } else {
+                std::string sql = VISIBILITY_RESOLVE_CTE +
+                    "SELECT " +
+                    "  e.id, e.map_id, e.source_node_id, e.dest_node_id, "
+                    "  e.directed, e.color, e.label, e.description, "
+                    "  e.created_by, e.created_at, e.updated_at "
+                    "FROM node_edges e "
+                    "JOIN maps m ON m.id = e.map_id "
+                    "WHERE e.id = ? AND e.map_id = ? " +
+                    EDGE_VISIBILITY_PREDICATE;
+                db2->execSqlAsync(sql, onRow, onErr,
+                    mapId, userId,            // CTE
+                    id, mapId,                // WHERE e.id, e.map_id
+                    userId);                  // xray
+            }
         },
         [callback](const drogon::orm::DrogonDbException&) {
             callback(errorResponse(drogon::k500InternalServerError,
@@ -569,10 +652,17 @@ void EdgeController::listEdgesForNode(
     std::function<void(const drogon::HttpResponsePtr&)>&& callback,
     int tenantId, int mapId, int nodeId) {
 
-    int userId = callerUserId(req);
+    int userId  = callerUserId(req);
+    bool isAdmin = isTenantAdmin(req);
 
-    // Same map-view check as listEdges. Visibility filter on the *other*
-    // endpoint comes in #197.
+    // Map view check, then node-on-map existence check, then edge fetch.
+    // For non-admins the edge fetch enforces both-endpoints-visible —
+    // the starting node MUST be in `visible_starts` (otherwise the
+    // `source_node_id IN ...` half of the predicate fails for any edge
+    // touching it), so a hidden starting node yields an empty array
+    // post-filter. To match NodeController's "hidden node looks
+    // missing" pattern, also gate visibility of the starting node
+    // up-front and 404 on hidden.
     auto db = drogon::app().getDbClient();
     db->execSqlAsync(
         "SELECT m.id FROM maps m "
@@ -583,45 +673,89 @@ void EdgeController::listEdgesForNode(
         "  AND (m.owner_id = ? "
         "       OR mp.level IN ('view','comment','edit','moderate','admin') "
         "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
-        [callback, mapId, nodeId](const drogon::orm::Result& rAcc) {
+        [callback, mapId, nodeId, userId, isAdmin](const drogon::orm::Result& rAcc) {
             if (rAcc.empty()) {
                 callback(errorResponse(drogon::k403Forbidden,
                     "forbidden", "Map not found or insufficient permissions"));
                 return;
             }
-            // Verify the node is on this map (cheap; avoids returning
-            // an empty array when the caller passed a bogus nodeId).
+            // Verify the node is on this map (cheap; for admins this
+            // doubles as the only visibility check needed). For
+            // non-admins, also confirm the node itself is visible —
+            // hidden node returns 404 (matches NodeController pattern).
             auto dbN = drogon::app().getDbClient();
-            dbN->execSqlAsync(
-                "SELECT 1 FROM nodes WHERE id = ? AND map_id = ?",
-                [callback, mapId, nodeId](const drogon::orm::Result& rN) {
-                    if (rN.empty()) {
-                        callback(errorResponse(drogon::k404NotFound,
-                            "not_found", "Node not found on this map"));
-                        return;
-                    }
-                    auto db2 = drogon::app().getDbClient();
+            std::string nodeCheckSql;
+            if (isAdmin) {
+                nodeCheckSql = "SELECT 1 FROM nodes WHERE id = ? AND map_id = ?";
+            } else {
+                // Recursive CTE walks the parent chain for visibility.
+                // 1 if visible (xray bypass OR in visible_starts), 0 otherwise.
+                nodeCheckSql = VISIBILITY_RESOLVE_CTE +
+                    "SELECT 1 FROM nodes n "
+                    "JOIN maps m ON m.id = n.map_id "
+                    "WHERE n.id = ? AND n.map_id = ? "
+                    "  AND ((m.owner_id = ? AND m.owner_xray = TRUE) "
+                    "       OR n.id IN (SELECT start_id FROM visible_starts))";
+            }
+
+            auto onNodeChecked = [callback, mapId, nodeId, userId, isAdmin]
+                (const drogon::orm::Result& rN) {
+                if (rN.empty()) {
+                    callback(errorResponse(drogon::k404NotFound,
+                        "not_found", "Node not found on this map"));
+                    return;
+                }
+                auto db2 = drogon::app().getDbClient();
+                auto onRows = [callback](const drogon::orm::Result& r) {
+                    Json::Value arr(Json::arrayValue);
+                    for (const auto& row : r) arr.append(rowToEdge(row));
+                    callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+                };
+                auto onErr = [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to fetch edges"));
+                };
+
+                if (isAdmin) {
                     db2->execSqlAsync(
                         "SELECT " + EDGE_COLUMNS +
                         " FROM node_edges "
                         "WHERE map_id = ? AND (source_node_id = ? OR dest_node_id = ?) "
                         "ORDER BY created_at ASC, id ASC",
-                        [callback](const drogon::orm::Result& r) {
-                            Json::Value arr(Json::arrayValue);
-                            for (const auto& row : r) arr.append(rowToEdge(row));
-                            callback(drogon::HttpResponse::newHttpJsonResponse(arr));
-                        },
-                        [callback](const drogon::orm::DrogonDbException&) {
-                            callback(errorResponse(drogon::k500InternalServerError,
-                                "db_error", "Failed to fetch edges"));
-                        },
+                        onRows, onErr,
                         mapId, nodeId, nodeId);
-                },
-                [callback](const drogon::orm::DrogonDbException&) {
-                    callback(errorResponse(drogon::k500InternalServerError,
-                        "db_error", "Database error"));
-                },
-                nodeId, mapId);
+                } else {
+                    std::string sql = VISIBILITY_RESOLVE_CTE +
+                        "SELECT " +
+                        "  e.id, e.map_id, e.source_node_id, e.dest_node_id, "
+                        "  e.directed, e.color, e.label, e.description, "
+                        "  e.created_by, e.created_at, e.updated_at "
+                        "FROM node_edges e "
+                        "JOIN maps m ON m.id = e.map_id "
+                        "WHERE e.map_id = ? "
+                        "  AND (e.source_node_id = ? OR e.dest_node_id = ?) " +
+                        EDGE_VISIBILITY_PREDICATE +
+                        " ORDER BY e.created_at ASC, e.id ASC";
+                    db2->execSqlAsync(sql, onRows, onErr,
+                        mapId, userId,                  // CTE
+                        mapId, nodeId, nodeId,           // WHERE e.map_id, source/dest
+                        userId);                         // xray
+                }
+            };
+            auto onNodeErr = [callback](const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Database error"));
+            };
+
+            if (isAdmin) {
+                dbN->execSqlAsync(nodeCheckSql, onNodeChecked, onNodeErr,
+                    nodeId, mapId);
+            } else {
+                dbN->execSqlAsync(nodeCheckSql, onNodeChecked, onNodeErr,
+                    mapId, userId,    // CTE
+                    nodeId, mapId,    // WHERE n.id, n.map_id
+                    userId);          // xray
+            }
         },
         [callback](const drogon::orm::DrogonDbException&) {
             callback(errorResponse(drogon::k500InternalServerError,

--- a/backend/src/controllers/EdgeController.cpp
+++ b/backend/src/controllers/EdgeController.cpp
@@ -1,0 +1,631 @@
+#include "EdgeController.h"
+#include "AuditLog.h"
+#include "ErrorResponse.h"
+#include <drogon/drogon.h>
+
+// Phase 1 of the edges epic (#148). Schema + unfiltered CRUD; the
+// visibility filter (edge visible iff BOTH endpoints visible) lands in
+// #197 as a follow-up. Edges connect two nodes within a single map and
+// are scoped to that map's permissions for read + write.
+//
+// Read authorization: caller must have view-level access to the map.
+// Write authorization: caller must have edit-level access to the map
+// (or be the owner) AND tenant role admin or editor.
+//
+// Endpoints are immutable on update — to "re-target" an edge, delete it
+// and create a new one. Keeps audit semantics simple (an updated edge
+// stays "the same edge" from the caller's perspective).
+
+namespace {
+
+int callerUserId(const drogon::HttpRequestPtr& req) {
+    try { return req->getAttributes()->get<int>("userId"); }
+    catch (...) { return 0; }
+}
+
+bool isTenantEditorOrAdmin(const drogon::HttpRequestPtr& req) {
+    try {
+        const auto role = req->getAttributes()->get<std::string>("tenantRole");
+        return role == "admin" || role == "editor";
+    } catch (...) { return false; }
+}
+
+Json::Value rowToEdge(const drogon::orm::Row& row) {
+    Json::Value e;
+    e["id"]            = row["id"].as<int>();
+    e["mapId"]         = row["map_id"].as<int>();
+    e["sourceNodeId"]  = row["source_node_id"].as<int>();
+    e["destNodeId"]    = row["dest_node_id"].as<int>();
+    e["directed"]      = row["directed"].as<bool>();
+    e["color"]         = row["color"].isNull()
+                            ? Json::Value()
+                            : Json::Value(row["color"].as<std::string>());
+    e["label"]         = row["label"].isNull()
+                            ? Json::Value()
+                            : Json::Value(row["label"].as<std::string>());
+    e["description"]   = row["description"].isNull()
+                            ? "" : row["description"].as<std::string>();
+    e["createdBy"]     = row["created_by"].as<int>();
+    e["createdAt"]     = row["created_at"].as<std::string>();
+    e["updatedAt"]     = row["updated_at"].as<std::string>();
+    return e;
+}
+
+const std::string EDGE_COLUMNS =
+    "id, map_id, source_node_id, dest_node_id, directed, color, label, "
+    "description, created_by, created_at, updated_at";
+
+}  // namespace
+
+// ─── GET /api/v1/tenants/{tid}/maps/{mid}/edges ──────────────────────────────
+
+void EdgeController::listEdges(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId) {
+
+    int userId = callerUserId(req);
+
+    // First verify the caller has view access on the map; on success,
+    // fetch the edges. Splitting the read makes 403/empty-array
+    // distinguishable (map missing or hidden → 403; map visible but no
+    // edges → 200 []).
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT m.id FROM maps m "
+        "LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ? "
+        "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
+        "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
+        "WHERE m.id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? "
+        "       OR mp.level IN ('view','comment','edit','moderate','admin') "
+        "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
+        [callback, mapId](const drogon::orm::Result& rAccess) {
+            if (rAccess.empty()) {
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
+                return;
+            }
+            auto db2 = drogon::app().getDbClient();
+            db2->execSqlAsync(
+                "SELECT " + EDGE_COLUMNS +
+                " FROM node_edges WHERE map_id = ? "
+                " ORDER BY created_at ASC, id ASC",
+                [callback](const drogon::orm::Result& r) {
+                    Json::Value arr(Json::arrayValue);
+                    for (const auto& row : r) arr.append(rowToEdge(row));
+                    callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to fetch edges"));
+                },
+                mapId);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error"));
+        },
+        userId, mapId, tenantId, userId);
+}
+
+// ─── POST /api/v1/tenants/{tid}/maps/{mid}/edges ─────────────────────────────
+
+void EdgeController::createEdge(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId) {
+
+    if (!isTenantEditorOrAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Edge management requires editor or admin role"));
+        return;
+    }
+
+    int userId = callerUserId(req);
+    auto body  = req->getJsonObject();
+    if (!body || !(*body).isMember("sourceNodeId") || !(*body).isMember("destNodeId")) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "sourceNodeId and destNodeId are required"));
+        return;
+    }
+    if (!(*body)["sourceNodeId"].isInt() || !(*body)["destNodeId"].isInt()) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "sourceNodeId and destNodeId must be integers"));
+        return;
+    }
+
+    int sourceNodeId = (*body)["sourceNodeId"].asInt();
+    int destNodeId   = (*body)["destNodeId"].asInt();
+    if (sourceNodeId == destNodeId) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "sourceNodeId and destNodeId must differ"));
+        return;
+    }
+
+    bool directed = (*body).get("directed", false).asBool();
+    std::string color       = (*body).get("color", "").asString();
+    std::string label       = (*body).get("label", "").asString();
+    std::string description = (*body).get("description", "").asString();
+
+    if (!checkMaxLen("label", label, MAX_NAME_LEN, callback)) return;
+    if (!checkMaxLen("description", description, MAX_DESCRIPTION_LEN, callback)) return;
+    // Color is short; 9-char column accepts #RRGGBBAA. Reject longer
+    // values up-front for a clearer error than the DB truncation warning.
+    if (color.size() > 9) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "color must be a hex color (e.g. #ff0000)"));
+        return;
+    }
+
+    // Verify caller has edit access on the map AND both endpoints exist
+    // on this map. Single SELECT does both checks: count of nodes whose
+    // id ∈ {source, dest} AND map_id = ? must be 2.
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT m.id, "
+        "       (SELECT COUNT(*) FROM nodes n "
+        "          WHERE n.map_id = m.id AND n.id IN (?, ?)) AS endpoint_count "
+        "FROM maps m "
+        "LEFT JOIN map_permissions mp ON mp.map_id = m.id AND mp.user_id = ? "
+        "WHERE m.id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? OR mp.level IN ('edit','moderate','admin'))",
+        [callback, req, mapId, tenantId, userId,
+         sourceNodeId, destNodeId, directed, color, label, description]
+        (const drogon::orm::Result& rAcc) {
+            if (rAcc.empty()) {
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
+                return;
+            }
+            int endpointCount = rAcc[0]["endpoint_count"].as<int>();
+            if (endpointCount != 2) {
+                // Either one or both endpoints missing, or one is on a
+                // different map. Same error either way — don't leak
+                // which one — to avoid information disclosure.
+                callback(errorResponse(drogon::k400BadRequest,
+                    "bad_request",
+                    "sourceNodeId and destNodeId must both exist on this map"));
+                return;
+            }
+
+            // INSERT, then re-SELECT the canonical row (#152 pattern).
+            auto db2 = drogon::app().getDbClient();
+            db2->execSqlAsync(
+                "INSERT INTO node_edges "
+                "  (map_id, source_node_id, dest_node_id, directed, "
+                "   color, label, description, created_by) "
+                "VALUES (?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''), ?)",
+                [callback, req, mapId, tenantId, userId, sourceNodeId, destNodeId]
+                (const drogon::orm::Result& rIns) {
+                    int newId = static_cast<int>(rIns.insertId());
+                    Json::Value detail;
+                    detail["mapId"]        = mapId;
+                    detail["edgeId"]       = newId;
+                    detail["sourceNodeId"] = sourceNodeId;
+                    detail["destNodeId"]   = destNodeId;
+                    AuditLog::record("edge_create", req,
+                        userId, 0, tenantId, detail);
+
+                    auto db3 = drogon::app().getDbClient();
+                    db3->execSqlAsync(
+                        "SELECT " + EDGE_COLUMNS + " FROM node_edges "
+                        "WHERE id = ? AND map_id = ?",
+                        [callback](const drogon::orm::Result& rGet) {
+                            if (rGet.empty()) {
+                                callback(errorResponse(drogon::k500InternalServerError,
+                                    "internal_error", "Edge vanished after insert"));
+                                return;
+                            }
+                            auto resp = drogon::HttpResponse::newHttpJsonResponse(
+                                rowToEdge(rGet[0]));
+                            resp->setStatusCode(drogon::k201Created);
+                            callback(resp);
+                        },
+                        [callback](const drogon::orm::DrogonDbException&) {
+                            callback(errorResponse(drogon::k500InternalServerError,
+                                "db_error", "Failed to fetch created edge"));
+                        },
+                        newId, mapId);
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to create edge"));
+                },
+                mapId, sourceNodeId, destNodeId, directed,
+                color, label, description, userId);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error"));
+        },
+        sourceNodeId, destNodeId, userId, mapId, tenantId, userId);
+}
+
+// ─── GET /api/v1/tenants/{tid}/maps/{mid}/edges/{id} ─────────────────────────
+
+void EdgeController::getEdge(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int id) {
+
+    int userId = callerUserId(req);
+
+    // Verify view access on the map first; on success, fetch the edge.
+    // Returns 404 (not 403) if the edge doesn't exist on this map — the
+    // caller proved they could see the map, so distinguishing missing
+    // from hidden is fine here.
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT m.id FROM maps m "
+        "LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ? "
+        "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
+        "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
+        "WHERE m.id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? "
+        "       OR mp.level IN ('view','comment','edit','moderate','admin') "
+        "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
+        [callback, mapId, id](const drogon::orm::Result& rAcc) {
+            if (rAcc.empty()) {
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
+                return;
+            }
+            auto db2 = drogon::app().getDbClient();
+            db2->execSqlAsync(
+                "SELECT " + EDGE_COLUMNS +
+                " FROM node_edges WHERE id = ? AND map_id = ?",
+                [callback](const drogon::orm::Result& r) {
+                    if (r.empty()) {
+                        callback(errorResponse(drogon::k404NotFound,
+                            "not_found", "Edge not found"));
+                        return;
+                    }
+                    callback(drogon::HttpResponse::newHttpJsonResponse(rowToEdge(r[0])));
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to fetch edge"));
+                },
+                id, mapId);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error"));
+        },
+        userId, mapId, tenantId, userId);
+}
+
+// ─── PUT /api/v1/tenants/{tid}/maps/{mid}/edges/{id} ─────────────────────────
+//
+// Endpoints (sourceNodeId, destNodeId) are immutable. Body accepts
+// directed, color, label, description (any subset). Body fields that
+// are omitted leave the column unchanged.
+
+void EdgeController::updateEdge(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int id) {
+
+    if (!isTenantEditorOrAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Edge management requires editor or admin role"));
+        return;
+    }
+
+    int userId = callerUserId(req);
+    auto body  = req->getJsonObject();
+    if (!body) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "Request body required"));
+        return;
+    }
+
+    bool hasDirected    = body->isMember("directed");
+    bool hasColor       = body->isMember("color");
+    bool hasLabel       = body->isMember("label");
+    bool hasDescription = body->isMember("description");
+
+    if (!hasDirected && !hasColor && !hasLabel && !hasDescription) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "At least one of directed/color/label/description required"));
+        return;
+    }
+
+    bool directed       = hasDirected ? (*body)["directed"].asBool() : false;
+    std::string color       = hasColor       ? (*body)["color"].asString()       : "";
+    std::string label       = hasLabel       ? (*body)["label"].asString()       : "";
+    std::string description = hasDescription ? (*body)["description"].asString() : "";
+
+    if (hasLabel       && !checkMaxLen("label", label, MAX_NAME_LEN, callback)) return;
+    if (hasDescription && !checkMaxLen("description", description, MAX_DESCRIPTION_LEN, callback)) return;
+    if (hasColor && color.size() > 9) {
+        callback(errorResponse(drogon::k400BadRequest,
+            "bad_request", "color must be a hex color (e.g. #ff0000)"));
+        return;
+    }
+
+    // Verify caller has edit access on the map; on success, run the
+    // partial UPDATE (each column gated by its has-flag). Same pattern
+    // as PlotController::updatePlot — empty string maps to NULL via
+    // NULLIF for nullable columns.
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT m.id FROM maps m "
+        "LEFT JOIN map_permissions mp ON mp.map_id = m.id AND mp.user_id = ? "
+        "WHERE m.id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? OR mp.level IN ('edit','moderate','admin'))",
+        [callback, req, mapId, tenantId, userId, id,
+         hasDirected, directed, hasColor, color, hasLabel, label,
+         hasDescription, description]
+        (const drogon::orm::Result& rAcc) {
+            if (rAcc.empty()) {
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
+                return;
+            }
+
+            // Build UPDATE with only the supplied columns. Pass-through
+            // unchanged columns by reusing the existing value via the
+            // table itself (e.g. `color = IF(?, NULLIF(?, ''), color)`).
+            std::string sql = "UPDATE node_edges SET ";
+            std::vector<std::string> sets;
+            if (hasDirected)    sets.push_back("directed = ?");
+            if (hasColor)       sets.push_back("color = NULLIF(?, '')");
+            if (hasLabel)       sets.push_back("label = NULLIF(?, '')");
+            if (hasDescription) sets.push_back("description = NULLIF(?, '')");
+            for (size_t i = 0; i < sets.size(); ++i) {
+                sql += (i ? ", " : "") + sets[i];
+            }
+            sql += " WHERE id = ? AND map_id = ?";
+
+            auto onUpdated = [callback, req, mapId, tenantId, userId, id]
+                (const drogon::orm::Result& rU) {
+                if (rU.affectedRows() == 0) {
+                    // Either edge doesn't exist on this map, or values
+                    // matched exactly (no-op). Disambiguate.
+                    auto dbEx = drogon::app().getDbClient();
+                    dbEx->execSqlAsync(
+                        "SELECT 1 FROM node_edges WHERE id = ? AND map_id = ?",
+                        [callback, req, mapId, tenantId, userId, id]
+                        (const drogon::orm::Result& rEx) {
+                            if (rEx.empty()) {
+                                callback(errorResponse(drogon::k404NotFound,
+                                    "not_found", "Edge not found"));
+                                return;
+                            }
+                            // No-op success: re-fetch and return.
+                            Json::Value detail;
+                            detail["edgeId"] = id; detail["noop"] = true;
+                            AuditLog::record("edge_update", req,
+                                userId, 0, tenantId, detail);
+                            auto dbR = drogon::app().getDbClient();
+                            dbR->execSqlAsync(
+                                "SELECT " + EDGE_COLUMNS +
+                                " FROM node_edges WHERE id = ? AND map_id = ?",
+                                [callback](const drogon::orm::Result& rGet) {
+                                    if (rGet.empty()) {
+                                        callback(errorResponse(drogon::k404NotFound,
+                                            "not_found", "Edge not found"));
+                                        return;
+                                    }
+                                    callback(drogon::HttpResponse::newHttpJsonResponse(rowToEdge(rGet[0])));
+                                },
+                                [callback](const drogon::orm::DrogonDbException&) {
+                                    callback(errorResponse(drogon::k500InternalServerError,
+                                        "db_error", "Failed to re-fetch edge"));
+                                },
+                                id, mapId);
+                        },
+                        [callback](const drogon::orm::DrogonDbException&) {
+                            callback(errorResponse(drogon::k500InternalServerError,
+                                "db_error", "Database error"));
+                        },
+                        id, mapId);
+                    return;
+                }
+                Json::Value detail;
+                detail["edgeId"] = id;
+                AuditLog::record("edge_update", req,
+                    userId, 0, tenantId, detail);
+                auto dbR = drogon::app().getDbClient();
+                dbR->execSqlAsync(
+                    "SELECT " + EDGE_COLUMNS +
+                    " FROM node_edges WHERE id = ? AND map_id = ?",
+                    [callback](const drogon::orm::Result& rGet) {
+                        if (rGet.empty()) {
+                            callback(errorResponse(drogon::k404NotFound,
+                                "not_found", "Edge not found"));
+                            return;
+                        }
+                        callback(drogon::HttpResponse::newHttpJsonResponse(rowToEdge(rGet[0])));
+                    },
+                    [callback](const drogon::orm::DrogonDbException&) {
+                        callback(errorResponse(drogon::k500InternalServerError,
+                            "db_error", "Failed to re-fetch edge"));
+                    },
+                    id, mapId);
+            };
+            auto onErr = [callback](const drogon::orm::DrogonDbException&) {
+                callback(errorResponse(drogon::k500InternalServerError,
+                    "db_error", "Failed to update edge"));
+            };
+
+            auto db2 = drogon::app().getDbClient();
+            // Bind the column values in the order of `sets`, then id, mapId.
+            // Each present flag adds one bind parameter.
+            // We iterate the 16 combinations explicitly to keep type-correctness:
+            // bool / std::string mixed parameter packs are unsupported in a
+            // single dynamic call, so dispatch on the bitmask of present flags.
+            int mask = (hasDirected    ? 1 : 0) |
+                       (hasColor       ? 2 : 0) |
+                       (hasLabel       ? 4 : 0) |
+                       (hasDescription ? 8 : 0);
+            switch (mask) {
+                case 1: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, id, mapId); break;
+                case 2: db2->execSqlAsync(sql, onUpdated, onErr,
+                    color, id, mapId); break;
+                case 3: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, color, id, mapId); break;
+                case 4: db2->execSqlAsync(sql, onUpdated, onErr,
+                    label, id, mapId); break;
+                case 5: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, label, id, mapId); break;
+                case 6: db2->execSqlAsync(sql, onUpdated, onErr,
+                    color, label, id, mapId); break;
+                case 7: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, color, label, id, mapId); break;
+                case 8: db2->execSqlAsync(sql, onUpdated, onErr,
+                    description, id, mapId); break;
+                case 9: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, description, id, mapId); break;
+                case 10: db2->execSqlAsync(sql, onUpdated, onErr,
+                    color, description, id, mapId); break;
+                case 11: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, color, description, id, mapId); break;
+                case 12: db2->execSqlAsync(sql, onUpdated, onErr,
+                    label, description, id, mapId); break;
+                case 13: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, label, description, id, mapId); break;
+                case 14: db2->execSqlAsync(sql, onUpdated, onErr,
+                    color, label, description, id, mapId); break;
+                case 15: db2->execSqlAsync(sql, onUpdated, onErr,
+                    directed, color, label, description, id, mapId); break;
+                default: break;  // mask = 0 already rejected above
+            }
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error"));
+        },
+        userId, mapId, tenantId, userId);
+}
+
+// ─── DELETE /api/v1/tenants/{tid}/maps/{mid}/edges/{id} ──────────────────────
+
+void EdgeController::deleteEdge(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int id) {
+
+    if (!isTenantEditorOrAdmin(req)) {
+        callback(errorResponse(drogon::k403Forbidden,
+            "forbidden", "Edge management requires editor or admin role"));
+        return;
+    }
+
+    int userId = callerUserId(req);
+
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT m.id FROM maps m "
+        "LEFT JOIN map_permissions mp ON mp.map_id = m.id AND mp.user_id = ? "
+        "WHERE m.id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? OR mp.level IN ('edit','moderate','admin'))",
+        [callback, req, mapId, tenantId, userId, id]
+        (const drogon::orm::Result& rAcc) {
+            if (rAcc.empty()) {
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
+                return;
+            }
+            auto db2 = drogon::app().getDbClient();
+            db2->execSqlAsync(
+                "DELETE FROM node_edges WHERE id = ? AND map_id = ?",
+                [callback, req, mapId, tenantId, userId, id]
+                (const drogon::orm::Result& rD) {
+                    if (rD.affectedRows() == 0) {
+                        callback(errorResponse(drogon::k404NotFound,
+                            "not_found", "Edge not found"));
+                        return;
+                    }
+                    Json::Value detail;
+                    detail["edgeId"] = id; detail["mapId"] = mapId;
+                    AuditLog::record("edge_delete", req,
+                        userId, 0, tenantId, detail);
+                    auto resp = drogon::HttpResponse::newHttpResponse();
+                    resp->setStatusCode(drogon::k204NoContent);
+                    callback(resp);
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Failed to delete edge"));
+                },
+                id, mapId);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error"));
+        },
+        userId, mapId, tenantId, userId);
+}
+
+// ─── GET /api/v1/tenants/{tid}/maps/{mid}/nodes/{nid}/edges ──────────────────
+// All edges where source = nodeId OR dest = nodeId, on this map.
+
+void EdgeController::listEdgesForNode(
+    const drogon::HttpRequestPtr& req,
+    std::function<void(const drogon::HttpResponsePtr&)>&& callback,
+    int tenantId, int mapId, int nodeId) {
+
+    int userId = callerUserId(req);
+
+    // Same map-view check as listEdges. Visibility filter on the *other*
+    // endpoint comes in #197.
+    auto db = drogon::app().getDbClient();
+    db->execSqlAsync(
+        "SELECT m.id FROM maps m "
+        "LEFT JOIN map_permissions mp     ON mp.map_id = m.id     AND mp.user_id = ? "
+        "LEFT JOIN map_permissions mp_pub ON mp_pub.map_id = m.id AND mp_pub.user_id IS NULL "
+        "                                AND mp_pub.level IN ('view','comment','edit','moderate','admin') "
+        "WHERE m.id = ? AND m.tenant_id = ? "
+        "  AND (m.owner_id = ? "
+        "       OR mp.level IN ('view','comment','edit','moderate','admin') "
+        "       OR mp_pub.level IN ('view','comment','edit','moderate','admin'))",
+        [callback, mapId, nodeId](const drogon::orm::Result& rAcc) {
+            if (rAcc.empty()) {
+                callback(errorResponse(drogon::k403Forbidden,
+                    "forbidden", "Map not found or insufficient permissions"));
+                return;
+            }
+            // Verify the node is on this map (cheap; avoids returning
+            // an empty array when the caller passed a bogus nodeId).
+            auto dbN = drogon::app().getDbClient();
+            dbN->execSqlAsync(
+                "SELECT 1 FROM nodes WHERE id = ? AND map_id = ?",
+                [callback, mapId, nodeId](const drogon::orm::Result& rN) {
+                    if (rN.empty()) {
+                        callback(errorResponse(drogon::k404NotFound,
+                            "not_found", "Node not found on this map"));
+                        return;
+                    }
+                    auto db2 = drogon::app().getDbClient();
+                    db2->execSqlAsync(
+                        "SELECT " + EDGE_COLUMNS +
+                        " FROM node_edges "
+                        "WHERE map_id = ? AND (source_node_id = ? OR dest_node_id = ?) "
+                        "ORDER BY created_at ASC, id ASC",
+                        [callback](const drogon::orm::Result& r) {
+                            Json::Value arr(Json::arrayValue);
+                            for (const auto& row : r) arr.append(rowToEdge(row));
+                            callback(drogon::HttpResponse::newHttpJsonResponse(arr));
+                        },
+                        [callback](const drogon::orm::DrogonDbException&) {
+                            callback(errorResponse(drogon::k500InternalServerError,
+                                "db_error", "Failed to fetch edges"));
+                        },
+                        mapId, nodeId, nodeId);
+                },
+                [callback](const drogon::orm::DrogonDbException&) {
+                    callback(errorResponse(drogon::k500InternalServerError,
+                        "db_error", "Database error"));
+                },
+                nodeId, mapId);
+        },
+        [callback](const drogon::orm::DrogonDbException&) {
+            callback(errorResponse(drogon::k500InternalServerError,
+                "db_error", "Database error"));
+        },
+        userId, mapId, tenantId, userId);
+}

--- a/backend/src/controllers/EdgeController.h
+++ b/backend/src/controllers/EdgeController.h
@@ -1,0 +1,86 @@
+#pragma once
+#include <drogon/HttpController.h>
+
+/**
+ * EdgeController — graph layer alongside the existing node tree (#148).
+ *
+ * Edges connect two nodes within the same map for relational use cases
+ * (trade routes, ferry connections, quest dependencies). Tree structure
+ * (parent_id) stays for containment; edges layer in for "A connects to B."
+ *
+ * This sub-ticket lands the schema + unfiltered CRUD. Visibility filtering
+ * (edge is visible iff BOTH endpoints are visible) lands in #197.
+ *
+ * Edge CRUD:
+ *   GET    /api/v1/tenants/{tenantId}/maps/{mapId}/edges
+ *   POST   /api/v1/tenants/{tenantId}/maps/{mapId}/edges
+ *   GET    /api/v1/tenants/{tenantId}/maps/{mapId}/edges/{id}
+ *   PUT    /api/v1/tenants/{tenantId}/maps/{mapId}/edges/{id}
+ *   DELETE /api/v1/tenants/{tenantId}/maps/{mapId}/edges/{id}
+ *
+ * Per-node edge listing (used by NodeDetailPanel in #200):
+ *   GET    /api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{nodeId}/edges
+ *
+ * Authorization:
+ *   - Read: any tenant member with view access on the map.
+ *   - Write: tenant admin/editor with edit access on the map.
+ *
+ * Body shapes:
+ *   POST /edges — { sourceNodeId, destNodeId, directed?, color?,
+ *                   label?, description? }
+ *   PUT  /edges/{id} — { directed?, color?, label?, description? }
+ *                       (endpoints are immutable; create a new edge to
+ *                        re-target — keeps audit semantics simple)
+ *
+ * Constraints:
+ *   - Both sourceNodeId and destNodeId must belong to {mapId}; cross-map
+ *     edges are out of scope for v1 (#148 design decision).
+ *   - sourceNodeId != destNodeId enforced by DB CHECK.
+ *   - Duplicate edges (same source/dest/directed) are intentionally
+ *     allowed — represent distinct trade routes, ferry runs, etc.
+ *
+ * POST/PUT both return the full canonical record (per §4b — frontend
+ * Zod schema parses the response without a follow-up GET).
+ */
+class EdgeController : public drogon::HttpController<EdgeController> {
+public:
+    METHOD_LIST_BEGIN
+        ADD_METHOD_TO(EdgeController::listEdges,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/edges",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+        ADD_METHOD_TO(EdgeController::createEdge,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/edges",
+                      drogon::Post, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(EdgeController::getEdge,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/edges/{id}",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+        ADD_METHOD_TO(EdgeController::updateEdge,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/edges/{id}",
+                      drogon::Put, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(EdgeController::deleteEdge,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/edges/{id}",
+                      drogon::Delete, "JwtFilter", "TenantFilter", "RateLimitFilter");
+        ADD_METHOD_TO(EdgeController::listEdgesForNode,
+                      "/api/v1/tenants/{tenantId}/maps/{mapId}/nodes/{nodeId}/edges",
+                      drogon::Get, "JwtFilter", "TenantFilter");
+    METHOD_LIST_END
+
+    void listEdges(const drogon::HttpRequestPtr&,
+                   std::function<void(const drogon::HttpResponsePtr&)>&&,
+                   int tenantId, int mapId);
+    void createEdge(const drogon::HttpRequestPtr&,
+                    std::function<void(const drogon::HttpResponsePtr&)>&&,
+                    int tenantId, int mapId);
+    void getEdge(const drogon::HttpRequestPtr&,
+                 std::function<void(const drogon::HttpResponsePtr&)>&&,
+                 int tenantId, int mapId, int id);
+    void updateEdge(const drogon::HttpRequestPtr&,
+                    std::function<void(const drogon::HttpResponsePtr&)>&&,
+                    int tenantId, int mapId, int id);
+    void deleteEdge(const drogon::HttpRequestPtr&,
+                    std::function<void(const drogon::HttpResponsePtr&)>&&,
+                    int tenantId, int mapId, int id);
+    void listEdgesForNode(const drogon::HttpRequestPtr&,
+                          std::function<void(const drogon::HttpResponsePtr&)>&&,
+                          int tenantId, int mapId, int nodeId);
+};

--- a/backend/tests/run-tests.py
+++ b/backend/tests/run-tests.py
@@ -55,6 +55,7 @@ FAST_TESTS = [
     "test_26_coordinate_systems.py",
     "test_27_error_shape.py",
     "test_28_permissions.py",
+    "test_29_edges.py",
 ]
 
 # test_14_nodes.py landed in #96 (NodeController CRUD + tree + max-depth).

--- a/backend/tests/test_29_edges.py
+++ b/backend/tests/test_29_edges.py
@@ -259,13 +259,19 @@ status, _ = http_post(EDGES_BASE,
     {"sourceNodeId": NODE_X, "destNodeId": NODE_Y}, TOKEN_C)
 assert_status("auth: cross-tenant create 403", 403, status)
 
-# B is a viewer of TENANT_A with view perm on MAP_ID — can read
+# B is a viewer of TENANT_A with view perm on MAP_ID — read endpoint
+# returns 200 (the visibility filter applies — see Visibility filter
+# section below for the per-edge expectations). EDGE_1 / EDGE_2's
+# endpoints (NODE_X / NODE_Y / NODE_Z) are untagged in this section,
+# which under the existing visibility model means admin-only — so B
+# gets back an empty list and a 404 on direct get.
 status, body = http_get(EDGES_BASE, TOKEN_B)
 assert_status("auth: viewer can list 200", 200, status)
-assert_true("auth: viewer sees both edges", len(body) == 2)
+assert_true("auth: viewer sees no untagged-endpoint edges (vis filter)",
+            isinstance(body, list) and len(body) == 0)
 
-status, body = http_get(f"{EDGES_BASE}/{EDGE_1}", TOKEN_B)
-assert_status("auth: viewer can get 200", 200, status)
+status, _ = http_get(f"{EDGES_BASE}/{EDGE_1}", TOKEN_B)
+assert_status("auth: viewer get untagged-endpoint edge 404 (hidden, not 403)", 404, status)
 
 # Viewer cannot write — tenant role 'viewer' fails the editor/admin gate
 status, _ = http_post(EDGES_BASE,
@@ -314,5 +320,131 @@ assert_true("cascade: edge gone after map delete",  remaining == "0",
             f"got remaining={remaining!r}")
 
 print("  All cascade tests passed.")
+
+# ─── Visibility filter (#197) ───────────────────────────────────────────────
+# An edge is visible iff BOTH endpoints are visible to the caller.
+# Owner-xray and tenant-admin bypass.
+
+print("  --- Visibility filter (#197) ---")
+
+# Fresh map for the visibility tests (the earlier MAP_ID has all edges
+# from the CRUD section + a new node count near the end). Easier reasoning
+# with a clean slate.
+_, body = http_post(f"/tenants/{TENANT_A}/maps", {
+    "title": "Edge Visibility Map",
+    "coordinateSystem": {"type": "wgs84", "center": {"lat": 0, "lng": 0}, "zoom": 3},
+}, TOKEN_A)
+VMAP = json_field(body, ["id"])
+mysql_query(
+    f"INSERT INTO map_permissions (map_id, user_id, level) "
+    f"VALUES ({VMAP}, {USER_B_ID}, 'view');")
+
+VBASE     = f"/tenants/{TENANT_A}/maps/{VMAP}/nodes"
+VEDGES    = f"/tenants/{TENANT_A}/maps/{VMAP}/edges"
+
+# Two visibility groups; B is in Players.
+VGB = f"/tenants/{TENANT_A}/visibility-groups"
+_, body = http_post(VGB, {"name": "EdgePlayers"}, TOKEN_A)
+VG_PLAYERS = json_field(body, ["id"])
+_, body = http_post(VGB, {"name": "EdgeGMs"}, TOKEN_A)
+VG_GMS = json_field(body, ["id"])
+http_post(f"{VGB}/{VG_PLAYERS}/members", {"userId": USER_B_ID}, TOKEN_A)
+
+# Per the existing visibility model (test_20 fixture comment): untagged
+# nodes are admin-only — there is no "publicly visible" default for
+# non-admins. To make a node visible to a non-admin, tag it with a group
+# they belong to. So the fixtures use:
+#   VPNODE_A, VPNODE_B: Players-tagged → visible to B (Players member)
+#   VGNODE:             GMs-tagged     → hidden from B (not in GMs)
+#   VUNTAGGED:          no tags        → admin-only (hidden from B)
+
+VPNODE_A = mknode(VBASE, "PlayersA")
+http_post(f"{VBASE}/{VPNODE_A}/visibility",
+          {"override": True, "groupIds": [VG_PLAYERS]}, TOKEN_A)
+VPNODE_B = mknode(VBASE, "PlayersB")
+http_post(f"{VBASE}/{VPNODE_B}/visibility",
+          {"override": True, "groupIds": [VG_PLAYERS]}, TOKEN_A)
+VGNODE = mknode(VBASE, "GMsOnly")
+http_post(f"{VBASE}/{VGNODE}/visibility",
+          {"override": True, "groupIds": [VG_GMS]}, TOKEN_A)
+VUNTAGGED = mknode(VBASE, "Untagged")  # admin-only
+
+# Edges:
+#   E_PVIS:   PlayersA ↔ PlayersB  → both visible to B → visible
+#   E_MIXED:  PlayersA ↔ GMsOnly   → B sees A but not GMsOnly → hidden
+#   E_GHIDDEN:GMsOnly  ↔ Untagged  → B sees neither → hidden
+#   E_UNTAG:  PlayersA ↔ Untagged  → B sees A but not Untagged → hidden
+def mkedge(s, d):
+    _, b = http_post(VEDGES, {"sourceNodeId": s, "destNodeId": d}, TOKEN_A)
+    return json_field(b, ["id"])
+E_PVIS    = mkedge(VPNODE_A, VPNODE_B)
+E_MIXED   = mkedge(VPNODE_A, VGNODE)
+E_GHIDDEN = mkedge(VGNODE,   VUNTAGGED)
+E_UNTAG   = mkedge(VPNODE_A, VUNTAGGED)
+
+# Admin (A) sees all 4
+status, body = http_get(VEDGES, TOKEN_A)
+assert_status("vis: admin list 200", 200, status)
+ids = {e["id"] for e in body}
+assert_true("vis: admin sees all 4 edges",
+            ids == {E_PVIS, E_MIXED, E_GHIDDEN, E_UNTAG})
+
+# B (Players member, no GMs) sees only edges where BOTH endpoints visible
+status, body = http_get(VEDGES, TOKEN_B)
+assert_status("vis: B list 200", 200, status)
+ids = {e["id"] for e in body}
+assert_true("vis: B sees only E_PVIS",
+            ids == {E_PVIS},
+            f"got {ids}")
+
+# B getting visible edge → 200; getting any hidden → 404 (never 403)
+status, _ = http_get(f"{VEDGES}/{E_PVIS}", TOKEN_B)
+assert_status("vis: B get visible edge 200", 200, status)
+status, _ = http_get(f"{VEDGES}/{E_MIXED}", TOKEN_B)
+assert_status("vis: B get mixed-vis edge 404 (hidden, not 403)", 404, status)
+status, _ = http_get(f"{VEDGES}/{E_GHIDDEN}", TOKEN_B)
+assert_status("vis: B get fully-hidden edge 404", 404, status)
+status, _ = http_get(f"{VEDGES}/{E_UNTAG}", TOKEN_B)
+assert_status("vis: B get untagged-endpoint edge 404", 404, status)
+
+# listEdgesForNode from a visible-to-B node — only edges where the OTHER
+# endpoint is also visible
+status, body = http_get(f"{VBASE}/{VPNODE_A}/edges", TOKEN_B)
+assert_status("vis: listForNode visible-source 200", 200, status)
+ids = {e["id"] for e in body}
+assert_true("vis: listForNode VPNODE_A → only E_PVIS",
+            ids == {E_PVIS},
+            f"got {ids}")
+
+# listEdgesForNode from a HIDDEN node → 404 (hidden node looks missing)
+status, _ = http_get(f"{VBASE}/{VGNODE}/edges", TOKEN_B)
+assert_status("vis: listForNode hidden node 404", 404, status)
+status, _ = http_get(f"{VBASE}/{VUNTAGGED}/edges", TOKEN_B)
+assert_status("vis: listForNode untagged node 404 (admin-only)", 404, status)
+
+# Owner-xray bypass: temporarily hand the map to B with xray=TRUE.
+# B should now see ALL 4 edges regardless of tags.
+mysql_query(f"UPDATE maps SET owner_id={USER_B_ID}, owner_xray=TRUE "
+            f"WHERE id={VMAP};")
+status, body = http_get(VEDGES, TOKEN_B)
+ids = {e["id"] for e in body}
+assert_true("vis: xray=TRUE B sees all 4 edges",
+            ids == {E_PVIS, E_MIXED, E_GHIDDEN, E_UNTAG},
+            f"got {ids}")
+
+# xray=FALSE → back to filtered
+mysql_query(f"UPDATE maps SET owner_xray=FALSE WHERE id={VMAP};")
+status, body = http_get(VEDGES, TOKEN_B)
+ids = {e["id"] for e in body}
+assert_true("vis: xray=FALSE B back to filtered set",
+            ids == {E_PVIS})
+
+# Restore A as owner
+mysql_query(f"UPDATE maps SET owner_id={USER_A_ID} WHERE id={VMAP};")
+
+# Restore A as owner
+mysql_query(f"UPDATE maps SET owner_id={USER_A_ID} WHERE id={VMAP};")
+
+print("  All visibility-filter tests passed.")
 
 sys.exit(0 if report() else 1)

--- a/backend/tests/test_29_edges.py
+++ b/backend/tests/test_29_edges.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""test_29_edges.py — Phase 1 of edges epic (#148): schema + EdgeController CRUD.
+
+Covers:
+  - CRUD round-trip (list / create / get / update / delete)
+  - listEdgesForNode endpoint
+  - Self-loop rejection (DB CHECK + controller pre-check)
+  - Cross-map endpoint rejection (both nodes must belong to {mapId})
+  - Map FK CASCADE on delete (delete map → edges gone)
+  - Node FK CASCADE on delete (delete endpoint node → edge gone)
+  - Cross-tenant 403 (TenantFilter)
+  - Read auth: viewer can read, non-member rejected
+  - Write auth: viewer rejected, editor/admin allowed
+  - POST/PUT return full canonical record (#152 pattern)
+  - Endpoints immutable on update (PUT body can't change source/dest)
+  - Duplicate edges allowed (same source/dest/directed)
+"""
+
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import (
+    reset_counters, report, assert_status, assert_json_field, assert_true,
+    http_post, http_get, http_put, http_delete,
+    register_user, json_field, mysql_query,
+)
+
+reset_counters()
+RUN_ID = os.getpid()
+
+print("=== Edge Tests ===")
+
+# ─── Setup ───────────────────────────────────────────────────────────────────
+
+# A: tenant admin (full access)
+TOKEN_A = register_user(f"t29_a_{RUN_ID}", f"t29_a_{RUN_ID}@test.com", "testpass123")
+_, body_a = http_post("/auth/login",
+    {"email": f"t29_a_{RUN_ID}@test.com", "password": "testpass123"})
+TENANT_A   = json_field(body_a, ["tenantId"])
+USER_A_ID  = json_field(body_a, ["user", "id"])
+
+# B: same-org viewer of TENANT_A (read access only)
+TOKEN_B = register_user(f"t29_b_{RUN_ID}", f"t29_b_{RUN_ID}@test.com", "testpass123")
+_, body_b = http_post("/auth/login",
+    {"email": f"t29_b_{RUN_ID}@test.com", "password": "testpass123"})
+USER_B_ID = json_field(body_b, ["user", "id"])
+
+A_ORG_ID = mysql_query(f"SELECT org_id FROM users WHERE id={USER_A_ID};")
+mysql_query(f"UPDATE users SET org_id={A_ORG_ID} WHERE id={USER_B_ID};")
+mysql_query(
+    f"INSERT INTO tenant_members (tenant_id, user_id, role) "
+    f"VALUES ({TENANT_A}, {USER_B_ID}, 'viewer');")
+
+# C: separate tenant, used for cross-tenant rejection tests
+TOKEN_C = register_user(f"t29_c_{RUN_ID}", f"t29_c_{RUN_ID}@test.com", "testpass123")
+_, body_c = http_post("/auth/login",
+    {"email": f"t29_c_{RUN_ID}@test.com", "password": "testpass123"})
+TENANT_C  = json_field(body_c, ["tenantId"])
+
+# A creates a map and grants B view permission (so B can read but not write)
+_, body = http_post(f"/tenants/{TENANT_A}/maps", {
+    "title": "Edge Test Map",
+    "coordinateSystem": {"type": "wgs84", "center": {"lat": 0, "lng": 0}, "zoom": 3},
+}, TOKEN_A)
+MAP_ID = json_field(body, ["id"])
+mysql_query(
+    f"INSERT INTO map_permissions (map_id, user_id, level) "
+    f"VALUES ({MAP_ID}, {USER_B_ID}, 'view');")
+
+# Second map, used for cross-map endpoint rejection
+_, body = http_post(f"/tenants/{TENANT_A}/maps", {
+    "title": "Edge Other Map",
+    "coordinateSystem": {"type": "wgs84", "center": {"lat": 0, "lng": 0}, "zoom": 3},
+}, TOKEN_A)
+MAP2_ID = json_field(body, ["id"])
+
+NODES_BASE  = f"/tenants/{TENANT_A}/maps/{MAP_ID}/nodes"
+NODES2_BASE = f"/tenants/{TENANT_A}/maps/{MAP2_ID}/nodes"
+EDGES_BASE  = f"/tenants/{TENANT_A}/maps/{MAP_ID}/edges"
+
+def mknode(base, name):
+    _, b = http_post(base, {"name": name}, TOKEN_A)
+    return json_field(b, ["id"])
+
+NODE_X = mknode(NODES_BASE,  "X")
+NODE_Y = mknode(NODES_BASE,  "Y")
+NODE_Z = mknode(NODES_BASE,  "Z")
+NODE_OTHERMAP = mknode(NODES2_BASE, "OtherMapNode")
+
+# ─── CRUD ────────────────────────────────────────────────────────────────────
+
+print("  --- CRUD ---")
+
+# Empty list
+status, body = http_get(EDGES_BASE, TOKEN_A)
+assert_status("list: empty 200", 200, status)
+assert_true("list: array initially empty",
+            isinstance(body, list) and len(body) == 0)
+
+# Create (minimal — required fields only)
+status, body = http_post(EDGES_BASE, {
+    "sourceNodeId": NODE_X,
+    "destNodeId":   NODE_Y,
+}, TOKEN_A)
+assert_status("create: minimal returns 201", 201, status)
+EDGE_1 = json_field(body, ["id"])
+assert_json_field("create: mapId echoed",        body, ["mapId"],         str(MAP_ID))
+assert_json_field("create: source echoed",       body, ["sourceNodeId"],  str(NODE_X))
+assert_json_field("create: dest echoed",         body, ["destNodeId"],    str(NODE_Y))
+assert_json_field("create: directed defaults false", body, ["directed"], "False")
+assert_true("create: createdAt present", body.get("createdAt"))
+assert_true("create: updatedAt present", body.get("updatedAt"))
+
+# Create (full — all optional fields)
+status, body = http_post(EDGES_BASE, {
+    "sourceNodeId": NODE_Y,
+    "destNodeId":   NODE_Z,
+    "directed":     True,
+    "color":        "#ff0000",
+    "label":        "Trade route",
+    "description":  "Weekly caravan",
+}, TOKEN_A)
+assert_status("create: full body returns 201", 201, status)
+EDGE_2 = json_field(body, ["id"])
+assert_json_field("create: directed=true",   body, ["directed"], "True")
+assert_json_field("create: color persisted", body, ["color"],    "#ff0000")
+assert_json_field("create: label persisted", body, ["label"],    "Trade route")
+
+# Duplicate edges (same source/dest/directed) are intentionally allowed
+status, body = http_post(EDGES_BASE, {
+    "sourceNodeId": NODE_X,
+    "destNodeId":   NODE_Y,
+}, TOKEN_A)
+assert_status("create: duplicate edge allowed 201", 201, status)
+EDGE_DUP = json_field(body, ["id"])
+assert_true("create: duplicate edge has new id", EDGE_DUP != EDGE_1)
+
+# List shows all three
+status, body = http_get(EDGES_BASE, TOKEN_A)
+assert_true("list: 3 edges after create", len(body) == 3)
+
+# Get one
+status, body = http_get(f"{EDGES_BASE}/{EDGE_2}", TOKEN_A)
+assert_status("get: 200", 200, status)
+assert_json_field("get: label", body, ["label"], "Trade route")
+
+# Get unknown
+status, _ = http_get(f"{EDGES_BASE}/9999999", TOKEN_A)
+assert_status("get: unknown 404", 404, status)
+
+# Update — partial body (just label)
+status, body = http_put(f"{EDGES_BASE}/{EDGE_2}", {"label": "Updated route"}, TOKEN_A)
+assert_status("update: 200", 200, status)
+assert_json_field("update: label changed",    body, ["label"], "Updated route")
+assert_json_field("update: directed preserved", body, ["directed"], "True")
+assert_json_field("update: color preserved",  body, ["color"], "#ff0000")
+
+# Update — multiple fields at once
+status, body = http_put(f"{EDGES_BASE}/{EDGE_2}",
+                        {"directed": False, "color": "#00ff00"}, TOKEN_A)
+assert_json_field("update: directed flipped", body, ["directed"], "False")
+assert_json_field("update: color changed",    body, ["color"],    "#00ff00")
+assert_json_field("update: label preserved (partial)", body, ["label"], "Updated route")
+
+# Update with empty body returns 400
+status, _ = http_put(f"{EDGES_BASE}/{EDGE_2}", {}, TOKEN_A)
+assert_status("update: empty body 400", 400, status)
+
+# Update unknown
+status, _ = http_put(f"{EDGES_BASE}/9999999", {"label": "x"}, TOKEN_A)
+assert_status("update: unknown 404", 404, status)
+
+# Delete one (the duplicate)
+status, _ = http_delete(f"{EDGES_BASE}/{EDGE_DUP}", TOKEN_A)
+assert_status("delete: 204", 204, status)
+status, _ = http_get(f"{EDGES_BASE}/{EDGE_DUP}", TOKEN_A)
+assert_status("delete: gone after delete (404)", 404, status)
+
+# Delete unknown
+status, _ = http_delete(f"{EDGES_BASE}/9999999", TOKEN_A)
+assert_status("delete: unknown 404", 404, status)
+
+print("  All CRUD tests passed.")
+
+# ─── Validation ──────────────────────────────────────────────────────────────
+
+print("  --- Validation ---")
+
+# Missing required fields
+status, _ = http_post(EDGES_BASE, {"sourceNodeId": NODE_X}, TOKEN_A)
+assert_status("create: missing destNodeId 400", 400, status)
+
+status, _ = http_post(EDGES_BASE, {"destNodeId": NODE_Y}, TOKEN_A)
+assert_status("create: missing sourceNodeId 400", 400, status)
+
+# Self-loop rejection (controller pre-check)
+status, _ = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_X, "destNodeId": NODE_X}, TOKEN_A)
+assert_status("create: self-loop 400", 400, status)
+
+# Cross-map endpoint rejection — NODE_OTHERMAP is on MAP2, not MAP
+status, _ = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_X, "destNodeId": NODE_OTHERMAP}, TOKEN_A)
+assert_status("create: cross-map dest 400", 400, status)
+
+status, _ = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_OTHERMAP, "destNodeId": NODE_X}, TOKEN_A)
+assert_status("create: cross-map source 400", 400, status)
+
+# Missing endpoint id
+status, _ = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_X, "destNodeId": 9999999}, TOKEN_A)
+assert_status("create: missing dest 400", 400, status)
+
+# Color validation (oversized)
+status, _ = http_post(EDGES_BASE, {
+    "sourceNodeId": NODE_X, "destNodeId": NODE_Z,
+    "color": "#" + "f" * 20,
+}, TOKEN_A)
+assert_status("create: oversized color 400", 400, status)
+
+print("  All validation tests passed.")
+
+# ─── listEdgesForNode ───────────────────────────────────────────────────────
+
+print("  --- listEdgesForNode ---")
+
+# Currently: EDGE_1 (X→Y), EDGE_2 (Y→Z, after the updates above)
+# So NODE_Y touches both edges; NODE_X touches only EDGE_1
+status, body = http_get(f"{NODES_BASE}/{NODE_Y}/edges", TOKEN_A)
+assert_status("listForNode: 200", 200, status)
+edge_ids = {e["id"] for e in body}
+assert_true("listForNode: NODE_Y has 2 edges", edge_ids == {EDGE_1, EDGE_2})
+
+status, body = http_get(f"{NODES_BASE}/{NODE_X}/edges", TOKEN_A)
+edge_ids = {e["id"] for e in body}
+assert_true("listForNode: NODE_X has 1 edge", edge_ids == {EDGE_1})
+
+# Non-existent node
+status, _ = http_get(f"{NODES_BASE}/9999999/edges", TOKEN_A)
+assert_status("listForNode: unknown node 404", 404, status)
+
+# Node from a different map
+status, _ = http_get(f"{NODES_BASE}/{NODE_OTHERMAP}/edges", TOKEN_A)
+assert_status("listForNode: node on other map 404", 404, status)
+
+print("  All listEdgesForNode tests passed.")
+
+# ─── Authorization ──────────────────────────────────────────────────────────
+
+print("  --- Authorization ---")
+
+# Cross-tenant: TOKEN_C is in TENANT_C, not TENANT_A
+status, _ = http_get(EDGES_BASE, TOKEN_C)
+assert_status("auth: cross-tenant 403", 403, status)
+
+status, _ = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_X, "destNodeId": NODE_Y}, TOKEN_C)
+assert_status("auth: cross-tenant create 403", 403, status)
+
+# B is a viewer of TENANT_A with view perm on MAP_ID — can read
+status, body = http_get(EDGES_BASE, TOKEN_B)
+assert_status("auth: viewer can list 200", 200, status)
+assert_true("auth: viewer sees both edges", len(body) == 2)
+
+status, body = http_get(f"{EDGES_BASE}/{EDGE_1}", TOKEN_B)
+assert_status("auth: viewer can get 200", 200, status)
+
+# Viewer cannot write — tenant role 'viewer' fails the editor/admin gate
+status, _ = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_X, "destNodeId": NODE_Z}, TOKEN_B)
+assert_status("auth: viewer cannot create 403", 403, status)
+
+status, _ = http_put(f"{EDGES_BASE}/{EDGE_1}", {"label": "hacked"}, TOKEN_B)
+assert_status("auth: viewer cannot update 403", 403, status)
+
+status, _ = http_delete(f"{EDGES_BASE}/{EDGE_1}", TOKEN_B)
+assert_status("auth: viewer cannot delete 403", 403, status)
+
+print("  All authorization tests passed.")
+
+# ─── Cascade behavior ───────────────────────────────────────────────────────
+# FK constraints: deleting an endpoint node, the source/dest map, or the
+# user who created the edge should cascade-delete the edge row.
+
+print("  --- Cascade ---")
+
+# Create a fresh edge to verify node-delete cascade
+status, body = http_post(EDGES_BASE,
+    {"sourceNodeId": NODE_X, "destNodeId": NODE_Z}, TOKEN_A)
+EDGE_CASCADE = json_field(body, ["id"])
+
+# Delete NODE_Z → edge should cascade
+http_delete(f"{NODES_BASE}/{NODE_Z}", TOKEN_A)
+status, _ = http_get(f"{EDGES_BASE}/{EDGE_CASCADE}", TOKEN_A)
+assert_status("cascade: edge gone after endpoint node delete (404)", 404, status)
+
+# Delete the entire MAP2 with NODE_OTHERMAP attached: no edge to verify
+# (we only have edges on MAP_ID), but confirm map deletion still works.
+# Add an edge on MAP2 first to verify the map-delete cascade.
+NODE_M2_A = mknode(NODES2_BASE, "M2A")
+NODE_M2_B = mknode(NODES2_BASE, "M2B")
+status, body = http_post(f"/tenants/{TENANT_A}/maps/{MAP2_ID}/edges", {
+    "sourceNodeId": NODE_M2_A, "destNodeId": NODE_M2_B,
+}, TOKEN_A)
+EDGE_MAP2 = json_field(body, ["id"])
+
+http_delete(f"/tenants/{TENANT_A}/maps/{MAP2_ID}", TOKEN_A)
+# Map deletion cascades to nodes + edges; verify the edge row is gone
+remaining = mysql_query(
+    f"SELECT COUNT(*) FROM node_edges WHERE id={EDGE_MAP2};")
+assert_true("cascade: edge gone after map delete",  remaining == "0",
+            f"got remaining={remaining!r}")
+
+print("  All cascade tests passed.")
+
+sys.exit(0 if report() else 1)

--- a/database/migrations/003_edges.sql
+++ b/database/migrations/003_edges.sql
@@ -1,0 +1,44 @@
+-- Migration 003: Node edges (#148)
+-- Adds a graph layer alongside the existing tree (parent_id) for
+-- relational use cases — trade routes, ferry connections, quest
+-- dependencies, gates between regions. The tree structure stays for
+-- containment ("Region → City"); edges layer in for "A connects to B."
+--
+-- Edges are visible to a user iff BOTH endpoints are visible to them
+-- under the existing per-node visibility rules (see #197). No per-edge
+-- visibility tags — derived purely from endpoint visibility.
+
+CREATE TABLE IF NOT EXISTS node_edges (
+    id              BIGINT UNSIGNED  NOT NULL AUTO_INCREMENT,
+    map_id          BIGINT UNSIGNED  NOT NULL,
+    source_node_id  BIGINT UNSIGNED  NOT NULL,
+    dest_node_id    BIGINT UNSIGNED  NOT NULL,
+    directed        BOOLEAN          NOT NULL DEFAULT FALSE,
+    color           VARCHAR(9)                DEFAULT NULL,
+    label           VARCHAR(255)              DEFAULT NULL,
+    description     TEXT                      DEFAULT NULL,
+    created_by      BIGINT UNSIGNED  NOT NULL,
+    created_at      TIMESTAMP        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP        NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                              ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (id),
+    KEY idx_edge_map_src  (map_id, source_node_id),
+    KEY idx_edge_map_dst  (map_id, dest_node_id),
+    KEY idx_edge_creator  (created_by),
+
+    -- Self-loop prevention. Cross-map edges are out of scope for v1;
+    -- the controller enforces "both nodes belong to map_id" at insert
+    -- time. Duplicate edges (same source/dest/directed) are allowed
+    -- on purpose — distinct trade routes, distinct ferry runs, etc.
+    CONSTRAINT chk_edge_no_self_loop CHECK (source_node_id <> dest_node_id),
+
+    CONSTRAINT fk_edge_map
+        FOREIGN KEY (map_id)         REFERENCES maps  (id) ON DELETE CASCADE,
+    CONSTRAINT fk_edge_src
+        FOREIGN KEY (source_node_id) REFERENCES nodes (id) ON DELETE CASCADE,
+    CONSTRAINT fk_edge_dst
+        FOREIGN KEY (dest_node_id)   REFERENCES nodes (id) ON DELETE CASCADE,
+    CONSTRAINT fk_edge_creator
+        FOREIGN KEY (created_by)     REFERENCES users (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -161,6 +161,30 @@ export type NoteRecord = z.infer<typeof NoteRecordSchema>;
 export const NoteListSchema = z.array(NoteRecordSchema);
 export type NoteList = z.infer<typeof NoteListSchema>;
 
+// ─── Edges (#148, Wave 4) ────────────────────────────────────────────────────
+// Graph layer alongside the per-map node tree. Connects two nodes for
+// relational use cases (trade routes, ferry connections, quest deps).
+// Read-side schema only in #198; write methods + their request schemas
+// land in #199.
+
+export const EdgeRecordSchema = z.object({
+  id: z.number().int(),
+  mapId: z.number().int(),
+  sourceNodeId: z.number().int(),
+  destNodeId: z.number().int(),
+  directed: z.boolean(),
+  color: z.string().nullable(),
+  label: z.string().nullable(),
+  description: z.string(),
+  createdBy: z.number().int(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type EdgeRecord = z.infer<typeof EdgeRecordSchema>;
+
+export const EdgeListSchema = z.array(EdgeRecordSchema);
+export type EdgeList = z.infer<typeof EdgeListSchema>;
+
 // ─── Visibility groups (#85 / #98) ───────────────────────────────────────────
 
 export const VisibilityGroupSchema = z.object({

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -164,8 +164,6 @@ export type NoteList = z.infer<typeof NoteListSchema>;
 // ─── Edges (#148, Wave 4) ────────────────────────────────────────────────────
 // Graph layer alongside the per-map node tree. Connects two nodes for
 // relational use cases (trade routes, ferry connections, quest deps).
-// Read-side schema only in #198; write methods + their request schemas
-// land in #199.
 
 export const EdgeRecordSchema = z.object({
   id: z.number().int(),
@@ -184,6 +182,24 @@ export type EdgeRecord = z.infer<typeof EdgeRecordSchema>;
 
 export const EdgeListSchema = z.array(EdgeRecordSchema);
 export type EdgeList = z.infer<typeof EdgeListSchema>;
+
+// Write request shapes — backend immutability rule (#148): endpoints
+// (sourceNodeId, destNodeId) are immutable on update. Re-targeting an
+// edge means delete + recreate.
+export type CreateEdgeRequest = {
+  sourceNodeId: number;
+  destNodeId: number;
+  directed?: boolean;
+  color?: string;
+  label?: string;
+  description?: string;
+};
+export type UpdateEdgeRequest = {
+  directed?: boolean;
+  color?: string;
+  label?: string;
+  description?: string;
+};
 
 // ─── Visibility groups (#85 / #98) ───────────────────────────────────────────
 

--- a/frontend/src/components/Detail/EdgesSection.tsx
+++ b/frontend/src/components/Detail/EdgesSection.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { edgesService, nodesService } from '@/services/maps';
+import { extractApiError } from '@/utils/errors';
+import type { EdgeRecord, NodeRecord } from '@/types';
+
+// Per-node edges section in the detail panel (#200). Lists every edge
+// touching the selected node, with a quick-remove per row and a
+// "+ Edge from here" affordance that starts MapView's edge-create flow
+// with the current node prefilled as source.
+//
+// The "other endpoint" — the node at the far end of each edge — is
+// fetched in parallel so we can render its name. If a node lookup
+// fails (e.g., visibility), the row falls back to a generic "Hidden
+// location" label rather than disappearing, since the edge itself is
+// still visible to the caller (#197 visibility derives from BOTH
+// endpoints — if either is hidden, the edge wouldn't be in the list
+// at all).
+
+interface EdgesSectionProps {
+  mapId: number;
+  nodeId: number;
+  /** Click on a row's "other endpoint" name selects that node. */
+  onSelectNode: (nodeId: number) => void;
+  /** Click on "+ Edge from here" — MapDetailPage relays to MapView so
+   *  the toolbar state machine jumps into pickingDest with this node
+   *  as source. */
+  onStartEdgeFromNode: (sourceNodeId: number) => void;
+  /** Fired after a successful mutation (currently: delete). Parent uses
+   *  this to refresh sibling components — the map's edge layer in
+   *  particular, which would otherwise be stale. */
+  onChanged?: () => void;
+}
+
+interface RowInfo {
+  edge: EdgeRecord;
+  other: NodeRecord | null;
+  outgoing: boolean;  // edge.sourceNodeId === nodeId
+}
+
+export function EdgesSection({
+  mapId,
+  nodeId,
+  onSelectNode,
+  onStartEdgeFromNode,
+  onChanged,
+}: EdgesSectionProps) {
+  const [rows, setRows] = useState<RowInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const loadAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const edges = await edgesService.listEdgesForNode(mapId, nodeId);
+      // Fetch the "other endpoint" for each row in parallel. Failures
+      // resolve to null and the row renders with a fallback label.
+      const otherIds = edges.map((e) =>
+        e.sourceNodeId === nodeId ? e.destNodeId : e.sourceNodeId,
+      );
+      const fetched = await Promise.all(
+        otherIds.map((oid) => nodesService.getNode(mapId, oid).catch(() => null)),
+      );
+      setRows(edges.map((e, i) => ({
+        edge: e,
+        other: fetched[i],
+        outgoing: e.sourceNodeId === nodeId,
+      })));
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to load edges.'));
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [mapId, nodeId]);
+
+  useEffect(() => { loadAll(); }, [loadAll]);
+
+  const handleRemove = async (edgeId: number) => {
+    if (!window.confirm('Remove this edge?')) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await edgesService.deleteEdge(mapId, edgeId);
+      onChanged?.();  // refresh sibling map render
+      await loadAll();
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to remove edge.'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Display the directed indicator from the perspective of THIS node:
+  //   outgoing + directed → → (this node is the source)
+  //   incoming + directed → ← (this node is the dest)
+  //   not directed        → ↔
+  const indicator = useMemo(() => (row: RowInfo) => {
+    if (!row.edge.directed) return '↔';
+    return row.outgoing ? '→' : '←';
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="edges-section">
+        <h3>Edges</h3>
+        <p className="edges-section-empty">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="edges-section">
+      <div className="edges-section-header">
+        <h3>Edges</h3>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={() => onStartEdgeFromNode(nodeId)}
+        >
+          + Edge from here
+        </button>
+      </div>
+
+      {error && <div className="alert alert-error">{error}</div>}
+
+      {rows.length === 0 ? (
+        <p className="edges-section-empty">No edges touching this location.</p>
+      ) : (
+        <ul className="edges-section-list">
+          {rows.map((row) => (
+            <li key={row.edge.id} className="edges-section-row">
+              {row.edge.color && (
+                <span
+                  className="edges-section-color"
+                  style={{ background: row.edge.color }}
+                  aria-hidden="true"
+                />
+              )}
+              <span className="edges-section-direction" aria-hidden="true">
+                {indicator(row)}
+              </span>
+              {row.other ? (
+                <button
+                  type="button"
+                  className="link-button edges-section-name"
+                  onClick={() => onSelectNode(row.other!.id)}
+                >
+                  {row.other.name}
+                </button>
+              ) : (
+                <span className="edges-section-name edges-section-name-hidden">
+                  Hidden location
+                </span>
+              )}
+              {row.edge.label && (
+                <span className="edges-section-label">{row.edge.label}</span>
+              )}
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                onClick={() => handleRemove(row.edge.id)}
+                disabled={busy}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Detail/NodeDetailPanel.tsx
+++ b/frontend/src/components/Detail/NodeDetailPanel.tsx
@@ -3,6 +3,7 @@ import { nodesService, notesService } from '@/services/maps';
 import { extractApiError } from '@/utils/errors';
 import { VisibilityEditor } from '@/components/Visibility/VisibilityEditor';
 import { PlotsSection } from '@/components/Detail/PlotsSection';
+import { EdgesSection } from '@/components/Detail/EdgesSection';
 import { MediaSection } from '@/components/Detail/MediaSection';
 import type {
   NodeRecord,
@@ -27,12 +28,21 @@ interface NodeDetailPanelProps {
   mapId: number;
   selectedNodeId: number | null;
   onSelectNode: (nodeId: number) => void;
+  /** "+ Edge from here" in the Edges section relays through this callback
+   *  so the map-side toolbar state machine can jump to pickingDest with
+   *  the current node as source (#200). */
+  onStartEdgeFromNode?: (sourceNodeId: number) => void;
+  /** Fired when EdgesSection mutates an edge (currently: delete).
+   *  Parent bumps a counter so MapView can refetch its edge list. */
+  onEdgesChanged?: () => void;
 }
 
 export function NodeDetailPanel({
   mapId,
   selectedNodeId,
   onSelectNode,
+  onStartEdgeFromNode,
+  onEdgesChanged,
 }: NodeDetailPanelProps) {
   const [node, setNode] = useState<NodeRecord | null>(null);
   const [parent, setParent] = useState<NodeRecord | null>(null);
@@ -158,6 +168,18 @@ export function NodeDetailPanel({
       <section className="node-detail-plots">
         <PlotsSection mapId={mapId} kind="node" entityId={node.id} />
       </section>
+
+      {onStartEdgeFromNode && (
+        <section className="node-detail-edges">
+          <EdgesSection
+            mapId={mapId}
+            nodeId={node.id}
+            onSelectNode={onSelectNode}
+            onStartEdgeFromNode={onStartEdgeFromNode}
+            onChanged={onEdgesChanged}
+          />
+        </section>
+      )}
 
       <NotesList
         mapId={mapId}

--- a/frontend/src/components/Map/EdgeFormModal.tsx
+++ b/frontend/src/components/Map/EdgeFormModal.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'react';
+import { edgesService } from '@/services/maps';
+import { extractApiError } from '@/utils/errors';
+import type { EdgeRecord, NodeRecord } from '@/types';
+
+// Modal for creating a new edge or editing an existing one (#199).
+// In create mode the source/dest endpoints are immutable inputs picked
+// in the toolbar's two-step flow; in edit mode the endpoints are read-
+// only too (per #148 design — re-targeting an edge means delete +
+// recreate, keeping audit semantics simple).
+//
+// Form fields (both modes): label, description, color, directed.
+// Edit mode adds a Delete affordance.
+
+interface EdgeFormModalProps {
+  mode: 'create' | 'edit';
+  mapId: number;
+  sourceNode: NodeRecord;
+  destNode: NodeRecord;
+  /** Required in edit mode; null/undefined in create mode. */
+  initial?: EdgeRecord | null;
+  onSaved: (edge: EdgeRecord) => void;
+  /** Only invoked from edit mode. */
+  onDeleted?: () => void;
+  onClose: () => void;
+}
+
+export function EdgeFormModal({
+  mode,
+  mapId,
+  sourceNode,
+  destNode,
+  initial,
+  onSaved,
+  onDeleted,
+  onClose,
+}: EdgeFormModalProps) {
+  const [label, setLabel] = useState(initial?.label ?? '');
+  const [description, setDescription] = useState(initial?.description ?? '');
+  const [color, setColor] = useState(initial?.color ?? '#3388ff');
+  const [directed, setDirected] = useState(initial?.directed ?? false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      let saved: EdgeRecord;
+      if (mode === 'create') {
+        saved = await edgesService.createEdge(mapId, {
+          sourceNodeId: sourceNode.id,
+          destNodeId: destNode.id,
+          directed,
+          color: color || undefined,
+          label: label || undefined,
+          description: description || undefined,
+        });
+      } else if (initial) {
+        saved = await edgesService.updateEdge(mapId, initial.id, {
+          directed,
+          color,
+          label,
+          description,
+        });
+      } else {
+        throw new Error('Edit mode requires an initial edge');
+      }
+      onSaved(saved);
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to save edge.'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!initial || !onDeleted) return;
+    if (!window.confirm('Delete this edge? This cannot be undone.')) return;
+    setError(null);
+    setBusy(true);
+    try {
+      await edgesService.deleteEdge(mapId, initial.id);
+      onDeleted();
+    } catch (e) {
+      setError(extractApiError(e, 'Failed to delete edge.'));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()} role="dialog">
+        <h2>{mode === 'create' ? 'New edge' : 'Edit edge'}</h2>
+
+        {error && <div className="alert alert-error">{error}</div>}
+
+        <div className="form-group">
+          <label>From</label>
+          <div>{sourceNode.name}</div>
+        </div>
+        <div className="form-group">
+          <label>To</label>
+          <div>{destNode.name}</div>
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="edge-label">Label</label>
+          <input
+            id="edge-label"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="optional"
+            maxLength={255}
+          />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="edge-description">Description</label>
+          <textarea
+            id="edge-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+          />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="edge-color">Color</label>
+          <input
+            id="edge-color"
+            type="color"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+          />
+        </div>
+
+        <div className="form-group-checkbox">
+          <label>
+            <input
+              type="checkbox"
+              checked={directed}
+              onChange={(e) => setDirected(e.target.checked)}
+            />
+            Directed (arrow from source to destination)
+          </label>
+        </div>
+
+        <div className="modal-actions">
+          {mode === 'edit' && (
+            <button
+              type="button"
+              className="btn btn-danger"
+              onClick={handleDelete}
+              disabled={busy}
+            >
+              Delete
+            </button>
+          )}
+          <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button type="button" className="btn btn-primary" onClick={handleSave} disabled={busy}>
+            {busy ? 'Saving…' : mode === 'create' ? 'Create' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Map/MapView.tsx
+++ b/frontend/src/components/Map/MapView.tsx
@@ -1,17 +1,18 @@
-import { useEffect, useState } from 'react';
-import { MapContainer, TileLayer, ImageOverlay, Marker, Polyline, Polygon, Popup, useMap as useLeafletMap } from 'react-leaflet';
+import { useEffect, useMemo, useState } from 'react';
+import { MapContainer, TileLayer, ImageOverlay, Marker, Polyline, Polygon, Popup, CircleMarker, useMap as useLeafletMap } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
 import iconUrl from 'leaflet/dist/images/marker-icon.png';
 import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
 import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
-import { nodesService, nodeMediaService } from '@/services/maps';
+import { nodesService, nodeMediaService, edgesService } from '@/services/maps';
 import { useAuthStore } from '@/store/authStore';
 import type {
   MapRecord,
   NodeRecord,
   NodeMediaRecord,
   GeoJsonGeometry,
+  EdgeRecord,
 } from '@/types';
 
 // Fix for leaflet's default icon paths breaking under Vite's bundler.
@@ -147,6 +148,55 @@ function NodeLayer({ node, media, onClick }: NodeLayerProps) {
   return null;
 }
 
+// ─── Per-edge renderer (#198) ────────────────────────────────────────────────
+// Renders an edge as a Leaflet polyline from sourceNode's center to
+// destNode's center. Both endpoints must have a Point geometry (the
+// "center" of a node). Edges where either endpoint lacks a Point are
+// skipped silently — the underlying data still exists, just not
+// rendered (could be enhanced to use centroid for line/polygon nodes
+// in a follow-up).
+//
+// Z-order: rendered BEFORE node markers in the JSX tree so node
+// markers stay clickable on top.
+//
+// "Directed" indicator: a small CircleMarker at the dest endpoint.
+// A real arrowhead would need leaflet-arrowheads or hand-rolled
+// L.polylineDecorator geometry; the CircleMarker is a lightweight
+// stand-in for v1 that conveys direction without a new dependency.
+// (Filed as future polish in #199 / #200 if a real arrow is wanted.)
+
+interface EdgeLayerProps {
+  edge: EdgeRecord;
+  sourceNode: NodeRecord;
+  destNode: NodeRecord;
+}
+
+function EdgeLayer({ edge, sourceNode, destNode }: EdgeLayerProps) {
+  if (!sourceNode.geoJson || sourceNode.geoJson.type !== 'Point') return null;
+  if (!destNode.geoJson   || destNode.geoJson.type   !== 'Point') return null;
+
+  const src = pointLatLng(sourceNode.geoJson);
+  const dst = pointLatLng(destNode.geoJson);
+  if (!src || !dst) return null;
+
+  const color = edge.color ?? '#888';
+  return (
+    <>
+      <Polyline
+        positions={[src, dst]}
+        pathOptions={{ color, weight: 3, opacity: 0.85 }}
+      />
+      {edge.directed && (
+        <CircleMarker
+          center={dst}
+          radius={6}
+          pathOptions={{ color, fillColor: color, fillOpacity: 1 }}
+        />
+      )}
+    </>
+  );
+}
+
 // ─── MapView (dispatches on coordinateSystem.type) ───────────────────────────
 
 interface MapViewProps {
@@ -175,11 +225,20 @@ function PanController({ target }: { target: [number, number] | null | undefined
 
 export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
   const [nodes, setNodes] = useState<NodeRecord[]>([]);
+  const [edges, setEdges] = useState<EdgeRecord[]>([]);
   const [mediaByNode, setMediaByNode] = useState<Record<number, NodeMediaRecord[]>>({});
   const [loadError, setLoadError] = useState<string | null>(null);
   const currentUserId = useAuthStore((s) => s.user?.id);
   const isOwner = currentUserId !== undefined && currentUserId === map.ownerId;
   const xrayActive = isOwner && map.ownerXray;
+
+  // Edge → endpoint nodes lookup. Built once per (nodes, edges) change so
+  // we don't recompute per-render.
+  const nodesById = useMemo(() => {
+    const m = new Map<number, NodeRecord>();
+    for (const n of nodes) m.set(n.id, n);
+    return m;
+  }, [nodes]);
 
   useEffect(() => {
     let cancelled = false;
@@ -207,6 +266,13 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
       .catch(() => {
         if (!cancelled) setLoadError('Failed to load nodes for this map.');
       });
+
+    // Edges are best-effort — failure here doesn't block the map.
+    edgesService
+      .listEdges(map.id)
+      .then((es) => { if (!cancelled) setEdges(es); })
+      .catch(() => { /* render the map without edges; not a fatal */ });
+
     return () => {
       cancelled = true;
     };
@@ -224,6 +290,16 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
   // numbers mean (x, y) but the swap is still correct.
 
   const cs = map.coordinateSystem;
+
+  // Edges render BEFORE node markers so node clicks aren't shadowed.
+  const renderEdgeLayers = () =>
+    edges.map((e) => {
+      const src = nodesById.get(e.sourceNodeId);
+      const dst = nodesById.get(e.destNodeId);
+      if (!src || !dst) return null;  // endpoint not loaded (filtered out by visibility)
+      return <EdgeLayer key={e.id} edge={e} sourceNode={src} destNode={dst} />;
+    });
+
   const renderNodeLayers = () =>
     nodes.map((n) => (
       <NodeLayer
@@ -260,6 +336,7 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
           className="map-view-leaflet"
         >
           <ImageOverlay url={cs.image_url} bounds={bounds} />
+          {renderEdgeLayers()}
           {renderNodeLayers()}
           <PanController target={panTarget} />
         </MapContainer>
@@ -291,6 +368,7 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
           maxBounds={maxBounds}
           className="map-view-leaflet map-view-blank"
         >
+          {renderEdgeLayers()}
           {renderNodeLayers()}
           <PanController target={panTarget} />
         </MapContainer>
@@ -313,6 +391,7 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         />
+        {renderEdgeLayers()}
         {renderNodeLayers()}
         <PanController target={panTarget} />
       </MapContainer>

--- a/frontend/src/components/Map/MapView.tsx
+++ b/frontend/src/components/Map/MapView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { MapContainer, TileLayer, ImageOverlay, Marker, Polyline, Polygon, Popup, CircleMarker, useMap as useLeafletMap } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
@@ -7,6 +7,7 @@ import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
 import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
 import { nodesService, nodeMediaService, edgesService } from '@/services/maps';
 import { useAuthStore } from '@/store/authStore';
+import { EdgeFormModal } from './EdgeFormModal';
 import type {
   MapRecord,
   NodeRecord,
@@ -169,9 +170,10 @@ interface EdgeLayerProps {
   edge: EdgeRecord;
   sourceNode: NodeRecord;
   destNode: NodeRecord;
+  onClick?: (edgeId: number) => void;
 }
 
-function EdgeLayer({ edge, sourceNode, destNode }: EdgeLayerProps) {
+function EdgeLayer({ edge, sourceNode, destNode, onClick }: EdgeLayerProps) {
   if (!sourceNode.geoJson || sourceNode.geoJson.type !== 'Point') return null;
   if (!destNode.geoJson   || destNode.geoJson.type   !== 'Point') return null;
 
@@ -180,17 +182,20 @@ function EdgeLayer({ edge, sourceNode, destNode }: EdgeLayerProps) {
   if (!src || !dst) return null;
 
   const color = edge.color ?? '#888';
+  const handlers = onClick ? { click: () => onClick(edge.id) } : undefined;
   return (
     <>
       <Polyline
         positions={[src, dst]}
         pathOptions={{ color, weight: 3, opacity: 0.85 }}
+        eventHandlers={handlers}
       />
       {edge.directed && (
         <CircleMarker
           center={dst}
           radius={6}
           pathOptions={{ color, fillColor: color, fillOpacity: 1 }}
+          eventHandlers={handlers}
         />
       )}
     </>
@@ -231,6 +236,23 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
   const currentUserId = useAuthStore((s) => s.user?.id);
   const isOwner = currentUserId !== undefined && currentUserId === map.ownerId;
   const xrayActive = isOwner && map.ownerXray;
+  // Edit-permission gate for the edge toolbar (#199). The MapRecord's
+  // `permission` field is the caller's effective access. Owner + edit
+  // both qualify; view-only callers don't see the toolbar.
+  const canEdit = map.permission === 'edit' || map.permission === 'owner';
+
+  // ── Edge create / edit state machine (#199) ──────────────────────────────
+  // edgeMode: idle = no special interaction; pickingSource = waiting for
+  // the user to click the source node; pickingDest = source is captured,
+  // waiting for the dest. The state transitions on each node click and
+  // resets via Esc or after a successful create.
+  type EdgeMode =
+    | { kind: 'idle' }
+    | { kind: 'pickingSource' }
+    | { kind: 'pickingDest'; sourceId: number }
+    | { kind: 'creating'; sourceId: number; destId: number }
+    | { kind: 'editing'; edge: EdgeRecord };
+  const [edgeMode, setEdgeMode] = useState<EdgeMode>({ kind: 'idle' });
 
   // Edge → endpoint nodes lookup. Built once per (nodes, edges) change so
   // we don't recompute per-render.
@@ -278,9 +300,77 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
     };
   }, [map.id]);
 
-  const handleClick = (nodeId: number) => {
+  // react-leaflet captures `eventHandlers` at marker-mount time and
+  // doesn't always re-attach when the prop's identity changes — so a
+  // closure-based handler always runs against the FIRST render's state
+  // (idle), which broke the edge create flow until this ref-based
+  // indirection. Pattern: keep a ref pointed at the latest "real"
+  // handler, expose a stable wrapper that delegates to it. The wrapper's
+  // identity never changes, so react-leaflet keeps the original binding;
+  // each call re-reads the live ref and runs against current state.
+  const handleClickRef = useRef<(nodeId: number) => void>(() => {});
+  handleClickRef.current = (nodeId: number) => {
+    // Edge create flow intercepts node clicks. In picking-source mode,
+    // the click captures the source. In picking-dest mode, it captures
+    // the dest (rejecting same-node-as-source) and opens the create
+    // modal. Outside those modes, fall through to the default
+    // selection callback.
+    if (edgeMode.kind === 'pickingSource') {
+      setEdgeMode({ kind: 'pickingDest', sourceId: nodeId });
+      return;
+    }
+    if (edgeMode.kind === 'pickingDest') {
+      if (nodeId === edgeMode.sourceId) {
+        // Self-loop attempt — backend would 400; refuse early.
+        return;
+      }
+      setEdgeMode({
+        kind: 'creating',
+        sourceId: edgeMode.sourceId,
+        destId: nodeId,
+      });
+      return;
+    }
     onNodeClick?.(nodeId);
   };
+  const handleClick = useRef((nodeId: number) => {
+    handleClickRef.current(nodeId);
+  }).current;
+
+  // Esc cancels mid-creation (any non-idle/non-modal state).
+  useEffect(() => {
+    if (edgeMode.kind !== 'pickingSource' && edgeMode.kind !== 'pickingDest') {
+      return;
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setEdgeMode({ kind: 'idle' });
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [edgeMode.kind]);
+
+  // After create / update / delete, refetch edges so the rendering
+  // layer reflects the latest state. Cheaper than splicing the local
+  // array and avoids drift if the response shape changes.
+  const refetchEdges = () => {
+    edgesService.listEdges(map.id)
+      .then((es) => setEdges(es))
+      .catch(() => { /* keep stale list; same posture as initial load */ });
+  };
+
+  // Same staleness mitigation as handleClick — the EdgeLayer's onClick
+  // is captured at first mount by react-leaflet, so without ref-stable
+  // wrapping the latest `edges` and `edgeMode` would never be visible.
+  const handleEdgeClickRef = useRef<(edgeId: number) => void>(() => {});
+  handleEdgeClickRef.current = (edgeId: number) => {
+    if (edgeMode.kind !== 'idle') return;  // mid-flow; ignore
+    if (!canEdit) return;                  // view-only; no edit modal
+    const e = edges.find((x) => x.id === edgeId);
+    if (e) setEdgeMode({ kind: 'editing', edge: e });
+  };
+  const handleEdgeClick = useRef((edgeId: number) => {
+    handleEdgeClickRef.current(edgeId);
+  }).current;
 
   // All three renderers share the same node-layer rendering; the only
   // difference is the MapContainer's CRS + base layer (or lack thereof).
@@ -292,13 +382,123 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
   const cs = map.coordinateSystem;
 
   // Edges render BEFORE node markers so node clicks aren't shadowed.
+  // Pass onClick only when canEdit AND not mid-creation — mid-creation
+  // node clicks would otherwise compete with edge clicks for the same
+  // gesture.
+  const edgeLayerOnClick = canEdit && edgeMode.kind === 'idle'
+    ? handleEdgeClick
+    : undefined;
   const renderEdgeLayers = () =>
     edges.map((e) => {
       const src = nodesById.get(e.sourceNodeId);
       const dst = nodesById.get(e.destNodeId);
       if (!src || !dst) return null;  // endpoint not loaded (filtered out by visibility)
-      return <EdgeLayer key={e.id} edge={e} sourceNode={src} destNode={dst} />;
+      return (
+        <EdgeLayer
+          key={e.id}
+          edge={e}
+          sourceNode={src}
+          destNode={dst}
+          onClick={edgeLayerOnClick}
+        />
+      );
     });
+
+  // Toolbar + status hint shown above the map. Toolbar visible only
+  // when caller has edit access; hint reflects the current mode so the
+  // user knows what to do next (mirrors MapBox / OSM iD draw flows).
+  const renderToolbar = () => {
+    if (!canEdit) return null;
+    const startEdgeCreate = () => setEdgeMode({ kind: 'pickingSource' });
+    const cancelEdgeCreate = () => setEdgeMode({ kind: 'idle' });
+    if (edgeMode.kind === 'idle') {
+      return (
+        <div className="map-view-toolbar">
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            onClick={startEdgeCreate}
+          >
+            + Edge
+          </button>
+        </div>
+      );
+    }
+    if (edgeMode.kind === 'pickingSource') {
+      return (
+        <div className="map-view-toolbar map-view-toolbar-active">
+          <span>Click the source node (Esc to cancel)</span>
+          <button type="button" className="btn btn-ghost btn-sm" onClick={cancelEdgeCreate}>
+            Cancel
+          </button>
+        </div>
+      );
+    }
+    if (edgeMode.kind === 'pickingDest') {
+      return (
+        <div className="map-view-toolbar map-view-toolbar-active">
+          <span>Click the destination node (Esc to cancel)</span>
+          <button type="button" className="btn btn-ghost btn-sm" onClick={cancelEdgeCreate}>
+            Cancel
+          </button>
+        </div>
+      );
+    }
+    return null;  // creating / editing — modal is the affordance
+  };
+
+  const renderEdgeModal = () => {
+    if (edgeMode.kind === 'creating') {
+      const src = nodesById.get(edgeMode.sourceId);
+      const dst = nodesById.get(edgeMode.destId);
+      if (!src || !dst) {
+        // Race: a node disappeared between picking and modal mount;
+        // bail back to idle.
+        setEdgeMode({ kind: 'idle' });
+        return null;
+      }
+      return (
+        <EdgeFormModal
+          mode="create"
+          mapId={map.id}
+          sourceNode={src}
+          destNode={dst}
+          onSaved={() => {
+            setEdgeMode({ kind: 'idle' });
+            refetchEdges();
+          }}
+          onClose={() => setEdgeMode({ kind: 'idle' })}
+        />
+      );
+    }
+    if (edgeMode.kind === 'editing') {
+      const src = nodesById.get(edgeMode.edge.sourceNodeId);
+      const dst = nodesById.get(edgeMode.edge.destNodeId);
+      if (!src || !dst) {
+        setEdgeMode({ kind: 'idle' });
+        return null;
+      }
+      return (
+        <EdgeFormModal
+          mode="edit"
+          mapId={map.id}
+          sourceNode={src}
+          destNode={dst}
+          initial={edgeMode.edge}
+          onSaved={() => {
+            setEdgeMode({ kind: 'idle' });
+            refetchEdges();
+          }}
+          onDeleted={() => {
+            setEdgeMode({ kind: 'idle' });
+            refetchEdges();
+          }}
+          onClose={() => setEdgeMode({ kind: 'idle' })}
+        />
+      );
+    }
+    return null;
+  };
 
   const renderNodeLayers = () =>
     nodes.map((n) => (
@@ -323,6 +523,8 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
     return (
       <div className="map-view">
         {loadError && <div className="alert alert-error">{loadError}</div>}
+        {renderToolbar()}
+        {renderEdgeModal()}
         {xrayActive && (
           <div className="alert alert-xray" role="status">
             🔍 Owner X-ray active — you can see all nodes regardless of visibility tagging.
@@ -355,6 +557,8 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
     return (
       <div className="map-view">
         {loadError && <div className="alert alert-error">{loadError}</div>}
+        {renderToolbar()}
+        {renderEdgeModal()}
         {xrayActive && (
           <div className="alert alert-xray" role="status">
             🔍 Owner X-ray active — you can see all nodes regardless of visibility tagging.
@@ -381,6 +585,8 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
   return (
     <div className="map-view">
       {loadError && <div className="alert alert-error">{loadError}</div>}
+      {renderToolbar()}
+      {renderEdgeModal()}
       {xrayActive && (
         <div className="alert alert-xray" role="status">
           🔍 Owner X-ray active — you can see all nodes regardless of visibility tagging.

--- a/frontend/src/components/Map/MapView.tsx
+++ b/frontend/src/components/Map/MapView.tsx
@@ -214,6 +214,21 @@ interface MapViewProps {
    * twice in the tree should re-center the map both times.
    */
   panTarget?: [number, number] | null;
+  /**
+   * Command to start the edge-create flow with a source already chosen
+   * (#200's "+ Edge from here" affordance in NodeDetailPanel). Each set
+   * to a new object identity triggers MapView to jump straight to
+   * pickingDest with `sourceNodeId` as source.
+   */
+  edgeStartFrom?: { sourceNodeId: number } | null;
+  /**
+   * Bump counter that signals an external edge mutation (e.g.,
+   * EdgesSection deleted an edge from the detail panel). On change,
+   * MapView refetches its edge list so the map rendering stays in
+   * sync with cross-component changes. Increment from MapDetailPage
+   * whenever a non-MapView code path mutates an edge.
+   */
+  edgesRefreshKey?: number;
 }
 
 // Mounted inside MapContainer so it has access to the leaflet map instance.
@@ -228,7 +243,13 @@ function PanController({ target }: { target: [number, number] | null | undefined
   return null;
 }
 
-export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
+export function MapView({
+  map,
+  onNodeClick,
+  panTarget,
+  edgeStartFrom,
+  edgesRefreshKey,
+}: MapViewProps) {
   const [nodes, setNodes] = useState<NodeRecord[]>([]);
   const [edges, setEdges] = useState<EdgeRecord[]>([]);
   const [mediaByNode, setMediaByNode] = useState<Record<number, NodeMediaRecord[]>>({});
@@ -337,6 +358,20 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
     handleClickRef.current(nodeId);
   }).current;
 
+  // External command: "+ Edge from here" in NodeDetailPanel (#200).
+  // When the prop's object identity changes, jump straight to
+  // pickingDest with the supplied source. Only fires if currently idle
+  // — refuses to override an in-flight pick/edit.
+  useEffect(() => {
+    if (!edgeStartFrom) return;
+    if (!canEdit) return;
+    setEdgeMode((prev) =>
+      prev.kind === 'idle'
+        ? { kind: 'pickingDest', sourceId: edgeStartFrom.sourceNodeId }
+        : prev,
+    );
+  }, [edgeStartFrom, canEdit]);
+
   // Esc cancels mid-creation (any non-idle/non-modal state).
   useEffect(() => {
     if (edgeMode.kind !== 'pickingSource' && edgeMode.kind !== 'pickingDest') {
@@ -357,6 +392,17 @@ export function MapView({ map, onNodeClick, panTarget }: MapViewProps) {
       .then((es) => setEdges(es))
       .catch(() => { /* keep stale list; same posture as initial load */ });
   };
+
+  // External-mutation signal (#200). NodeDetailPanel's EdgesSection can
+  // delete an edge directly, bypassing this component's modal handlers.
+  // MapDetailPage bumps `edgesRefreshKey` on each such mutation; the
+  // effect below refetches so the map render stays in sync. Skip the
+  // initial undefined value (first mount).
+  useEffect(() => {
+    if (edgesRefreshKey === undefined) return;
+    refetchEdges();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [edgesRefreshKey]);
 
   // Same staleness mitigation as handleClick — the EdgeLayer's onClick
   // is captured at first mount by react-leaflet, so without ref-stable

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -397,6 +397,24 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
 }
 .map-view-blank .leaflet-container { background: #f5f5f5; }
 
+/* Edge create/edit toolbar (#199). Sits above the leaflet container; the
+   active state (mid-creation hint) flips background to draw the eye. */
+.map-view-toolbar {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  padding: .5rem .75rem;
+  margin-bottom: .5rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-size: .875rem;
+}
+.map-view-toolbar-active {
+  background: #fff7e6;
+  border-color: #f0c060;
+}
+
 /* ─── Map detail layout (tree panel + map, #93) ────────────────────────────── */
 .map-detail-layout {
   display: flex;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -945,6 +945,55 @@ html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; co
   gap: .35rem;
 }
 .plots-section-add select { flex: 1; min-width: 8rem; }
+
+/* Per-node Edges section in the detail panel (#200). Same visual
+   shape as PlotsSection — row of color swatch + direction glyph +
+   other-endpoint name + optional label + remove. */
+.node-detail-edges {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+}
+.edges-section h3 { font-size: .9rem; margin: 0 0 .5rem; }
+.edges-section-empty {
+  font-size: .8rem;
+  color: #888;
+  margin: .25rem 0;
+}
+.edges-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: .25rem;
+}
+.edges-section-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+}
+.edges-section-row {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  padding: .25rem .5rem;
+  border-radius: var(--radius);
+  background: #fafafa;
+  font-size: .85rem;
+}
+.edges-section-color {
+  width: .9rem;
+  height: .9rem;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, .1);
+}
+.edges-section-direction { font-weight: 600; opacity: .65; }
+.edges-section-name { font-weight: 500; flex: 1; text-align: left; }
+.edges-section-name-hidden { font-style: italic; color: #888; font-weight: normal; }
+.edges-section-label { color: #888; font-size: .8rem; }
+
 .note-card-plots {
   margin-top: .5rem;
   padding-top: .5rem;

--- a/frontend/src/pages/MapDetailPage.tsx
+++ b/frontend/src/pages/MapDetailPage.tsx
@@ -32,6 +32,16 @@ export function MapDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<number | null>(null);
   const [panTarget, setPanTarget] = useState<[number, number] | null>(null);
+  // "+ Edge from here" cross-component command (#200). NodeDetailPanel
+  // fires this; MapView reads it via prop. Object identity changes per
+  // command so MapView's effect re-fires even when the same node is
+  // chosen twice.
+  const [edgeStartFrom, setEdgeStartFrom] =
+    useState<{ sourceNodeId: number } | null>(null);
+  // Bump counter for external edge mutations (e.g., EdgesSection delete
+  // from the detail panel). MapView's effect on this prop refetches so
+  // the map render stays in sync.
+  const [edgesRefreshKey, setEdgesRefreshKey] = useState(0);
   const [xraySaving, setXraySaving] = useState(false);
   const [xrayError, setXrayError] = useState<string | null>(null);
   const [showSharing, setShowSharing] = useState(false);
@@ -149,12 +159,16 @@ export function MapDetailPage() {
           map={activeMap}
           onNodeClick={setSelectedNodeId}
           panTarget={panTarget}
+          edgeStartFrom={edgeStartFrom}
+          edgesRefreshKey={edgesRefreshKey}
         />
       </div>
       <NodeDetailPanel
         mapId={activeMap.id}
         selectedNodeId={selectedNodeId}
         onSelectNode={setSelectedNodeId}
+        onStartEdgeFromNode={(nodeId) => setEdgeStartFrom({ sourceNodeId: nodeId })}
+        onEdgesChanged={() => setEdgesRefreshKey((k) => k + 1)}
       />
       <button className="btn btn-ghost" onClick={() => navigate(`/tenants/${tenantId}/maps`)}>
         Back to maps

--- a/frontend/src/services/maps.ts
+++ b/frontend/src/services/maps.ts
@@ -18,6 +18,8 @@ import {
   PlotRecordSchema,
   PlotListSchema,
   PlotMembersSchema,
+  EdgeRecordSchema,
+  EdgeListSchema,
   type MapRecord,
   type MapList,
   type NodeRecord,
@@ -48,6 +50,8 @@ import {
   type PlotMembers,
   type CreatePlotRequest,
   type UpdatePlotRequest,
+  type EdgeRecord,
+  type EdgeList,
 } from '@/api/schemas';
 import type {
   Tenant,
@@ -568,5 +572,31 @@ export const plotsService = {
       `${tenantBase(tenantId)}/maps/${mapId}/notes/${noteId}/plots`,
     );
     return PlotListSchema.parse(res.data);
+  },
+};
+
+// ─── Edges (#148, Wave 4) ─────────────────────────────────────────────────────
+// Read-only methods for #198 (rendering layer); write methods land in #199.
+
+export const edgesService = {
+  async listEdges(mapId: number, tenantId?: number): Promise<EdgeList> {
+    const res = await apiClient.get(`${tenantBase(tenantId)}/maps/${mapId}/edges`);
+    return EdgeListSchema.parse(res.data);
+  },
+
+  async getEdge(mapId: number, edgeId: number, tenantId?: number): Promise<EdgeRecord> {
+    const res = await apiClient.get(`${tenantBase(tenantId)}/maps/${mapId}/edges/${edgeId}`);
+    return EdgeRecordSchema.parse(res.data);
+  },
+
+  async listEdgesForNode(
+    mapId: number,
+    nodeId: number,
+    tenantId?: number,
+  ): Promise<EdgeList> {
+    const res = await apiClient.get(
+      `${tenantBase(tenantId)}/maps/${mapId}/nodes/${nodeId}/edges`
+    );
+    return EdgeListSchema.parse(res.data);
   },
 };

--- a/frontend/src/services/maps.ts
+++ b/frontend/src/services/maps.ts
@@ -52,6 +52,8 @@ import {
   type UpdatePlotRequest,
   type EdgeRecord,
   type EdgeList,
+  type CreateEdgeRequest,
+  type UpdateEdgeRequest,
 } from '@/api/schemas';
 import type {
   Tenant,
@@ -598,5 +600,42 @@ export const edgesService = {
       `${tenantBase(tenantId)}/maps/${mapId}/nodes/${nodeId}/edges`
     );
     return EdgeListSchema.parse(res.data);
+  },
+
+  // Write methods (#199). POST/PUT return the full canonical record per
+  // §4b — same #152 pattern as plots/nodes.
+  async createEdge(
+    mapId: number,
+    data: CreateEdgeRequest,
+    tenantId?: number,
+  ): Promise<EdgeRecord> {
+    const res = await apiClient.post(
+      `${tenantBase(tenantId)}/maps/${mapId}/edges`,
+      data,
+    );
+    return EdgeRecordSchema.parse(res.data);
+  },
+
+  async updateEdge(
+    mapId: number,
+    edgeId: number,
+    data: UpdateEdgeRequest,
+    tenantId?: number,
+  ): Promise<EdgeRecord> {
+    const res = await apiClient.put(
+      `${tenantBase(tenantId)}/maps/${mapId}/edges/${edgeId}`,
+      data,
+    );
+    return EdgeRecordSchema.parse(res.data);
+  },
+
+  async deleteEdge(
+    mapId: number,
+    edgeId: number,
+    tenantId?: number,
+  ): Promise<void> {
+    await apiClient.delete(
+      `${tenantBase(tenantId)}/maps/${mapId}/edges/${edgeId}`,
+    );
   },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -42,6 +42,8 @@ export type {
   UpdateNodeRequest,
   CreateNoteRequest,
   UpdateNoteRequest,
+  EdgeRecord,
+  EdgeList,
 } from '@/api/schemas';
 
 // ─── Auth ────────────────────────────────────────────────────────────────────

--- a/frontend/tests/e2e/coordinate-systems-crud.spec.ts
+++ b/frontend/tests/e2e/coordinate-systems-crud.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Locator } from '@playwright/test';
 import {
   registerViaApi,
   createMapViaApi,
@@ -153,6 +153,64 @@ for (const { name, cs } of COORD_SYSTEMS) {
       await expect(
         page.getByRole('heading', { name: 'NodeForDetail' }),
       ).toBeVisible();
+    });
+
+    test(`${name}: edge create + delete (Wave 4 #200 lock-in)`, async ({ page, request }) => {
+      // Each coord system uses its own pointable coordinates. wgs84 +
+      // blank both accept [x, y] in the GeoJSON spec; pixel uses image
+      // pixels. The Point geometry shape is the same — the renderer
+      // interprets it per coord-system at view time.
+      const pointA: [number, number] =
+        name === 'pixel' ? [200, 200] :
+        name === 'blank' ? [100, 100] :
+        [0, 0];
+      const pointB: [number, number] =
+        name === 'pixel' ? [600, 400] :
+        name === 'blank' ? [400, 300] :
+        [10, 5];
+
+      const api = await registerViaApi(request, `${name}_edge_lockin`);
+      const map = await createMapViaApi(request, api, `${name} Edge Lockin`, cs);
+      await createNodeViaApi(request, api, map.id, {
+        name: 'NodeA',
+        geoJson: { type: 'Point', coordinates: pointA },
+      });
+      await createNodeViaApi(request, api, map.id, {
+        name: 'NodeB',
+        geoJson: { type: 'Point', coordinates: pointB },
+      });
+
+      await seedAuthInBrowser(page, api);
+      await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+      // Create the edge via the toolbar two-step pick. The same
+      // dispatchEvent trick used elsewhere — Leaflet's L.DomEvent
+      // listens for real native events; Playwright's synthetic
+      // .click() doesn't trigger it.
+      await page.getByRole('button', { name: /\+ edge/i }).click();
+      const dispatchClick = (loc: Locator) =>
+        loc.evaluate((el) =>
+          el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+        );
+      const markers = page.locator('.leaflet-marker-icon');
+      await dispatchClick(markers.nth(0));
+      await dispatchClick(markers.nth(1));
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await page.getByRole('button', { name: /^create$/i }).click();
+      await expect(page.getByRole('dialog')).not.toBeVisible();
+
+      // Polyline renders on this coord system.
+      await expect(
+        page.locator('.leaflet-overlay-pane svg path'),
+      ).toHaveCount(1, { timeout: 10000 });
+
+      // Delete via the polyline click → modal → Delete.
+      page.once('dialog', (d) => d.accept());
+      await dispatchClick(page.locator('.leaflet-overlay-pane svg path').first());
+      await page.getByRole('button', { name: /^delete$/i }).click();
+      await expect(
+        page.locator('.leaflet-overlay-pane svg path'),
+      ).toHaveCount(0);
     });
   });
 }

--- a/frontend/tests/e2e/edges-create-edit.spec.ts
+++ b/frontend/tests/e2e/edges-create-edit.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import {
+  registerViaApi,
+  createMapViaApi,
+  createNodeViaApi,
+  seedAuthInBrowser,
+  API_URL,
+  type ApiUser,
+} from './helpers';
+
+/**
+ * E2E for #199 — edge create + edit UX.
+ *
+ * Read-only rendering is covered by edges.spec.ts (#198). This spec covers
+ * the toolbar-driven create flow, the click-to-edit modal, delete, and
+ * Esc cancellation. NodeDetailPanel-side edge listing is in #200's spec.
+ *
+ * The maps in these tests use a wgs84 coord system because the tests
+ * interact with Leaflet markers as the picking targets — the same DOM
+ * shape applies to pixel/blank, but cross-coord-system lock-in is
+ * #200's coordinate-systems-crud extension.
+ */
+
+const WGS84 = {
+  type: 'wgs84' as const,
+  center: { lat: 0, lng: 0 },
+  zoom: 3,
+};
+
+async function seedMapWithTwoNodes(
+  request: APIRequestContext,
+  api: ApiUser,
+  tag: string,
+): Promise<{ mapId: number; nodeAId: number; nodeBId: number }> {
+  const map = await createMapViaApi(request, api, `Edge UX ${tag}`, WGS84);
+  const a = await createNodeViaApi(request, api, map.id, {
+    name: 'NodeA',
+    geoJson: { type: 'Point', coordinates: [0, 0] },
+  });
+  const b = await createNodeViaApi(request, api, map.id, {
+    name: 'NodeB',
+    geoJson: { type: 'Point', coordinates: [10, 5] },
+  });
+  return { mapId: map.id, nodeAId: a.id, nodeBId: b.id };
+}
+
+async function createEdgeViaApi(
+  request: APIRequestContext,
+  api: ApiUser,
+  mapId: number,
+  body: { sourceNodeId: number; destNodeId: number; label?: string; color?: string; directed?: boolean },
+): Promise<{ id: number }> {
+  const res = await request.post(
+    `${API_URL}/tenants/${api.tenantId}/maps/${mapId}/edges`,
+    { headers: { Authorization: `Bearer ${api.token}` }, data: body },
+  );
+  if (!res.ok()) throw new Error(`createEdge failed: ${res.status()}`);
+  return res.json();
+}
+
+test.describe('Edges — create + edit UX (#199)', () => {
+  test('toolbar two-step pick → modal → create renders the polyline', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_ux_create');
+    const { mapId } = await seedMapWithTwoNodes(request, api, 'create');
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${mapId}`);
+
+    // Toolbar shows when caller has edit perm (owner here).
+    await page.getByRole('button', { name: /\+ edge/i }).click();
+    await expect(page.getByText(/click the source node/i)).toBeVisible();
+
+    // Click the two markers to pick source then dest. Leaflet renders
+    // each Point node as a `.leaflet-marker-icon`; first() / nth(1) by
+    // creation order in our seed. Use dispatchEvent because Leaflet's
+    // L.DomEvent listens for real native events; Playwright's synthetic
+    // click sometimes goes through actionability checks but doesn't
+    // trigger Leaflet's underlying click binding.
+    const clickMarker = (idx: number) =>
+      page.locator('.leaflet-marker-icon').nth(idx).evaluate((el) =>
+        el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      );
+    await clickMarker(0);
+    await expect(page.getByText(/click the destination node/i)).toBeVisible();
+    await clickMarker(1);
+
+    // Modal opens with both endpoints prefilled.
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.getByLabel(/^label/i).fill('Trade route');
+    await page.getByRole('button', { name: /^create$/i }).click();
+
+    // Modal closes, polyline appears in the overlay pane.
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+    const paths = page.locator('.leaflet-overlay-pane svg path');
+    await expect(paths).toHaveCount(1, { timeout: 10000 });
+  });
+
+  test('clicking an existing edge opens the edit modal and saves changes that persist on reload', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_ux_edit');
+    const { mapId, nodeAId, nodeBId } = await seedMapWithTwoNodes(request, api, 'edit');
+    await createEdgeViaApi(request, api, mapId, {
+      sourceNodeId: nodeAId,
+      destNodeId: nodeBId,
+      label: 'Initial',
+      color: '#3388ff',
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${mapId}`);
+
+    // Click the polyline (only path in the overlay pane for this test).
+    // Same dispatchEvent trick as marker clicks — Leaflet's path uses
+    // its own event binding, not the React synthetic event chain.
+    const clickPolyline = () =>
+      page.locator('.leaflet-overlay-pane svg path').first().evaluate((el) =>
+        el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      );
+    await clickPolyline();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    // Label field reflects the existing value, then we change it.
+    const label = page.getByLabel(/^label/i);
+    await expect(label).toHaveValue('Initial');
+    await label.fill('Updated');
+    await page.getByRole('button', { name: /^save$/i }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    // Reload and re-open to confirm the new value round-trips through the API.
+    await page.reload();
+    await clickPolyline();
+    await expect(page.getByLabel(/^label/i)).toHaveValue('Updated');
+  });
+
+  test('delete from the edit modal removes the edge and survives reload', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_ux_delete');
+    const { mapId, nodeAId, nodeBId } = await seedMapWithTwoNodes(request, api, 'delete');
+    await createEdgeViaApi(request, api, mapId, { sourceNodeId: nodeAId, destNodeId: nodeBId });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${mapId}`);
+
+    // Polyline visible pre-delete.
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(1, { timeout: 10000 });
+
+    page.once('dialog', (d) => d.accept());  // confirm() prompt
+    await page.locator('.leaflet-overlay-pane svg path').first().evaluate((el) =>
+      el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    );
+    await page.getByRole('button', { name: /^delete$/i }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    // Polyline gone after refetch.
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(0);
+
+    // Reload — still gone (DELETE was real, not just optimistic).
+    await page.reload();
+    await page.waitForTimeout(500);
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(0);
+  });
+
+  test('Esc cancels edge-create mid-flow without creating an edge', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_ux_cancel');
+    const { mapId } = await seedMapWithTwoNodes(request, api, 'cancel');
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${mapId}`);
+
+    await page.getByRole('button', { name: /\+ edge/i }).click();
+    await expect(page.getByText(/click the source node/i)).toBeVisible();
+
+    await page.locator('.leaflet-marker-icon').nth(0).evaluate((el) =>
+      el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    );
+    await expect(page.getByText(/click the destination node/i)).toBeVisible();
+
+    // Esc — modal should NOT open and toolbar returns to idle.
+    await page.keyboard.press('Escape');
+    await expect(page.getByText(/click the destination node/i)).not.toBeVisible();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    // No polyline created.
+    await page.waitForTimeout(500);
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(0);
+  });
+});

--- a/frontend/tests/e2e/edges-epic.spec.ts
+++ b/frontend/tests/e2e/edges-epic.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect, type Locator } from '@playwright/test';
+import {
+  registerViaApi,
+  createMapViaApi,
+  createNodeViaApi,
+  seedAuthInBrowser,
+} from './helpers';
+
+/**
+ * Epic lock-in E2E for the Edges epic (#148). Full round-trip in one
+ * spec — covers the integration points across all four implementation
+ * tickets (#148 backend CRUD, #197 visibility filter, #198 rendering,
+ * #199 toolbar UX, #200 detail-panel section):
+ *
+ *   - create two nodes via API → navigate to map
+ *   - toolbar "+ Edge" → click source → click dest → modal → save
+ *   - polyline renders
+ *   - click polyline → edit label → save → reload → label persists
+ *   - select a source-side node → NodeDetailPanel shows the edge in the
+ *     Edges section with the correct direction glyph
+ *   - "Remove" in the panel → confirm → edge gone from panel AND map
+ *
+ * The "+ Edge from here" affordance (#200) is exercised in its own test
+ * below: select a node, click the button in the panel, pick a dest by
+ * clicking on the map, save, verify.
+ */
+
+const WGS84 = {
+  type: 'wgs84' as const,
+  center: { lat: 0, lng: 0 },
+  zoom: 3,
+};
+
+// Leaflet's L.DomEvent listens for native events; Playwright's
+// synthetic .click() doesn't trigger it. dispatchEvent is the same
+// trick used in edges-create-edit.spec.ts and is documented in the
+// PR #199 description for future-spec reference.
+async function clickLeafletEl(locator: Locator): Promise<void> {
+  await locator.evaluate((el) =>
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+  );
+}
+
+test.describe('Edges — epic lock-in (#148 / #197 / #198 / #199 / #200)', () => {
+  test('full round-trip: create via toolbar, edit, find in detail panel, remove', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_epic');
+    const map = await createMapViaApi(request, api, 'Epic edges', WGS84);
+
+    await createNodeViaApi(request, api, map.id, {
+      name: 'NodeA',
+      geoJson: { type: 'Point', coordinates: [0, 0] },
+    });
+    await createNodeViaApi(request, api, map.id, {
+      name: 'NodeB',
+      geoJson: { type: 'Point', coordinates: [10, 5] },
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // ── Create via toolbar ───────────────────────────────────────────────
+    await page.getByRole('button', { name: /\+ edge/i }).click();
+    await expect(page.getByText(/click the source node/i)).toBeVisible();
+
+    const markers = page.locator('.leaflet-marker-icon');
+    await clickLeafletEl(markers.nth(0));
+    await expect(page.getByText(/click the destination node/i)).toBeVisible();
+    await clickLeafletEl(markers.nth(1));
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.getByLabel(/^label/i).fill('Trade route');
+    await page.getByRole('button', { name: /^create$/i }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(1, { timeout: 10000 });
+
+    // ── Edit + reload persistence ────────────────────────────────────────
+    await clickLeafletEl(page.locator('.leaflet-overlay-pane svg path').first());
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.getByLabel(/^label/i).fill('Updated route');
+    await page.getByRole('button', { name: /^save$/i }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    await page.reload();
+    await clickLeafletEl(page.locator('.leaflet-overlay-pane svg path').first());
+    await expect(page.getByLabel(/^label/i)).toHaveValue('Updated route');
+    // Close the modal so the rest of the flow can interact freely.
+    await page.getByRole('button', { name: /^cancel$/i }).click();
+
+    // ── Detail panel: select NodeA, see the edge listed ──────────────────
+    // The tree panel has a button per node; clicking selects + scrolls the
+    // detail panel into view.
+    await page.getByRole('button', { name: 'NodeA' }).click();
+
+    // EdgesSection lists the row with NodeB as the other endpoint.
+    const edgesSection = page.locator('.edges-section');
+    await expect(edgesSection.getByRole('heading', { name: /^edges$/i })).toBeVisible();
+    await expect(edgesSection.getByRole('button', { name: 'NodeB' })).toBeVisible();
+
+    // Other-endpoint click should navigate selection. We don't need to
+    // assert on URL here — the heading flipping to NodeB is enough.
+    await edgesSection.getByRole('button', { name: 'NodeB' }).click();
+    await expect(page.getByRole('heading', { name: 'NodeB', level: 2 })).toBeVisible();
+
+    // ── Remove via panel ─────────────────────────────────────────────────
+    page.once('dialog', (d) => d.accept());
+    await page.locator('.edges-section').getByRole('button', { name: /^remove$/i }).click();
+    // Edge gone from panel
+    await expect(page.locator('.edges-section').getByRole('button', { name: 'NodeA' })).toHaveCount(0);
+    // Gone from map (refetch + rerender)
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(0);
+
+    // Reload — still gone (DELETE was real, not just optimistic).
+    await page.reload();
+    await page.waitForTimeout(500);
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(0);
+  });
+
+  test('"+ Edge from here" prefills source and only the dest needs picking', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_epic_fromhere');
+    const map = await createMapViaApi(request, api, 'Epic from-here', WGS84);
+    await createNodeViaApi(request, api, map.id, {
+      name: 'NodeA',
+      geoJson: { type: 'Point', coordinates: [0, 0] },
+    });
+    await createNodeViaApi(request, api, map.id, {
+      name: 'NodeB',
+      geoJson: { type: 'Point', coordinates: [10, 5] },
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // Select NodeA from the tree so its panel section renders.
+    await page.getByRole('button', { name: 'NodeA' }).click();
+    await expect(page.locator('.edges-section')).toBeVisible();
+
+    // "+ Edge from here" button in the section header.
+    await page.locator('.edges-section').getByRole('button', { name: /\+ edge from here/i }).click();
+
+    // Toolbar should jump straight to "Click the destination node"
+    // (source is prefilled — picking-source is skipped).
+    await expect(page.getByText(/click the destination node/i)).toBeVisible();
+    // We should NOT have seen the "Click the source node" hint.
+    await expect(page.getByText(/click the source node/i)).not.toBeVisible();
+
+    // Click NodeB as the dest. The second marker by creation order.
+    await page.locator('.leaflet-marker-icon').nth(1).evaluate((el) =>
+      el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    );
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.getByRole('button', { name: /^create$/i }).click();
+    await expect(page.locator('.leaflet-overlay-pane svg path')).toHaveCount(1, { timeout: 10000 });
+  });
+});

--- a/frontend/tests/e2e/edges.spec.ts
+++ b/frontend/tests/e2e/edges.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import {
+  registerViaApi,
+  createMapViaApi,
+  createNodeViaApi,
+  seedAuthInBrowser,
+  API_URL,
+  type ApiUser,
+} from './helpers';
+
+/**
+ * E2E for #198 — edge rendering layer (read-only).
+ *
+ * Seeds an edge between two existing nodes via the backend API, then
+ * navigates to the map and asserts the polyline is rendered. Covers the
+ * directed-edge marker and the wgs84 coord system — the cross-coord-system
+ * lock-in (pixel + blank) is filed as part of #200's coordinate-systems-crud
+ * extension, not duplicated here.
+ *
+ * Create / edit UX lands in #199; this spec only verifies that an edge
+ * the backend already knows about renders correctly.
+ */
+
+const WGS84 = {
+  type: 'wgs84' as const,
+  center: { lat: 0, lng: 0 },
+  zoom: 3,
+};
+
+async function createEdgeViaApi(
+  request: APIRequestContext,
+  api: ApiUser,
+  mapId: number,
+  body: {
+    sourceNodeId: number;
+    destNodeId: number;
+    directed?: boolean;
+    color?: string;
+    label?: string;
+  },
+): Promise<{ id: number }> {
+  const res = await request.post(
+    `${API_URL}/tenants/${api.tenantId}/maps/${mapId}/edges`,
+    { headers: { Authorization: `Bearer ${api.token}` }, data: body },
+  );
+  if (!res.ok()) {
+    throw new Error(`createEdge failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+test.describe('Edges — rendering (#198)', () => {
+  test('an edge between two Point nodes renders as a polyline on the map', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_render');
+    const map = await createMapViaApi(request, api, 'Edge render', WGS84);
+
+    // Two nodes with Point geometry — endpoints we can connect.
+    const a = await createNodeViaApi(request, api, map.id, {
+      name: 'NodeA',
+      geoJson: { type: 'Point', coordinates: [0, 0] },
+    });
+    const b = await createNodeViaApi(request, api, map.id, {
+      name: 'NodeB',
+      geoJson: { type: 'Point', coordinates: [10, 5] },
+    });
+
+    await createEdgeViaApi(request, api, map.id, {
+      sourceNodeId: a.id,
+      destNodeId: b.id,
+      color: '#ff5500',
+    });
+
+    // Boot authenticated and navigate to the map detail page.
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // The map renders SVG paths for both polyline-like layers (edges) and
+    // any polygon nodes. We have no polygon/line nodes in this test, so
+    // every <path> in the overlay pane is an edge polyline.
+    const paths = page.locator('.leaflet-overlay-pane svg path');
+    await expect(paths).toHaveCount(1, { timeout: 10000 });
+    // Edge color is applied via the path's `stroke` attribute.
+    await expect(paths.first()).toHaveAttribute('stroke', '#ff5500');
+  });
+
+  test('a directed edge renders an extra circle marker at the destination', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_directed');
+    const map = await createMapViaApi(request, api, 'Edge directed', WGS84);
+
+    const a = await createNodeViaApi(request, api, map.id, {
+      name: 'NodeA',
+      geoJson: { type: 'Point', coordinates: [0, 0] },
+    });
+    const b = await createNodeViaApi(request, api, map.id, {
+      name: 'NodeB',
+      geoJson: { type: 'Point', coordinates: [5, 5] },
+    });
+
+    await createEdgeViaApi(request, api, map.id, {
+      sourceNodeId: a.id,
+      destNodeId: b.id,
+      directed: true,
+      color: '#3388ff',
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // Directed edges add a CircleMarker at the dest endpoint. Leaflet
+    // renders CircleMarker as an SVG <path> with a circular `d` attr —
+    // it shows up alongside the polyline path. So we expect 2 paths
+    // (1 polyline + 1 directed-marker) instead of 1.
+    const paths = page.locator('.leaflet-overlay-pane svg path');
+    await expect(paths).toHaveCount(2, { timeout: 10000 });
+  });
+
+  test('edges with non-Point endpoints are skipped (no crash, no render)', async ({ page, request }) => {
+    const api = await registerViaApi(request, 'edges_skip_nonpoint');
+    const map = await createMapViaApi(request, api, 'Edge skip', WGS84);
+
+    const a = await createNodeViaApi(request, api, map.id, {
+      name: 'PointNode',
+      geoJson: { type: 'Point', coordinates: [0, 0] },
+    });
+    // Tree-only node (no geoJson) — edge from this node should be skipped.
+    const b = await createNodeViaApi(request, api, map.id, { name: 'TreeOnly' });
+
+    await createEdgeViaApi(request, api, map.id, {
+      sourceNodeId: a.id,
+      destNodeId: b.id,
+    });
+
+    await seedAuthInBrowser(page, api);
+    await page.goto(`/tenants/${api.tenantId}/maps/${map.id}`);
+
+    // The polyline shouldn't render because TreeOnly lacks Point geometry.
+    // We expect 0 paths in the overlay pane (no edges, no polygon nodes).
+    // Wait briefly to be sure the listEdges call has finished and
+    // nothing rendered as a side effect.
+    await page.waitForTimeout(500);
+    const paths = page.locator('.leaflet-overlay-pane svg path');
+    await expect(paths).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Final merge of `wave-4-edges` → `main`. Lands the Edges epic as an integration-verified unit. Tracking: #255.

## What's in this wave

| Sub-PR | Ticket | Layer | What it does |
|--------|--------|-------|--------------|
| #256 | #148 | Backend | Schema + EdgeController CRUD (foundation) |
| #257 | #197 | Backend | Visibility filter (recursive CTE, both-endpoints-visible) |
| #258 | #198 | Frontend | Edge rendering layer (read-only Leaflet polylines) |
| #259 | #199 | Frontend | Edge create + edit UX (toolbar two-step + modal) |
| #260 | #200 | Frontend | NodeDetailPanel Edges section + epic E2E |

## Files changed

- `backend/src/controllers/EdgeController.cpp` / `.h` — CRUD + visibility filter. POST/PUT return canonical record (#152 pattern). Endpoints immutable on update; cross-map edges rejected; duplicate edges intentionally allowed.
- `backend/tests/run-tests.py` — register `test_29_edges.py` in FAST_TESTS.
- `backend/tests/test_29_edges.py` — 67 assertions across CRUD, listEdgesForNode, self-loop rejection, cross-map endpoint rejection, FK CASCADE (node + map), cross-tenant 403, viewer read-only enforcement, visibility filter (admin/viewer/untagged-as-admin-only/xray bypass).
- `database/migrations/003_edges.sql` — `node_edges` table, FKs CASCADE on delete, CHECK for self-loop prevention.
- `frontend/src/api/schemas.ts` — `EdgeRecordSchema` + `EdgeListSchema` + request type aliases.
- `frontend/src/components/Detail/EdgesSection.tsx` — per-node edge list with directional glyph, color swatch, other-endpoint link, Remove, "+ Edge from here" header button.
- `frontend/src/components/Detail/NodeDetailPanel.tsx` — wires EdgesSection between Plots and Notes sections; new optional `onStartEdgeFromNode` + `onEdgesChanged` props.
- `frontend/src/components/Map/EdgeFormModal.tsx` — dual-mode (create / edit) modal. Endpoints read-only; mutable fields are label / description / color / directed. Edit mode adds Delete.
- `frontend/src/components/Map/MapView.tsx` — `EdgeLayer` rendering (polyline + CircleMarker on directed edges), toolbar state machine (idle / pickingSource / pickingDest / creating / editing), edit-permission gate, Esc cancel, `edgeStartFrom` and `edgesRefreshKey` props for cross-component coordination. **Ref-stable click handlers** to work around react-leaflet's mount-time eventHandlers capture.
- `frontend/src/index.css` — `.map-view-toolbar` + `.edges-section-*` styles.
- `frontend/src/pages/MapDetailPage.tsx` — owns `edgeStartFrom` + `edgesRefreshKey` state, wires the callback chain.
- `frontend/src/services/maps.ts` — `edgesService` with full CRUD + `listEdgesForNode`.
- `frontend/src/types/index.ts` — re-export EdgeRecord / EdgeList.
- `frontend/tests/e2e/edges.spec.ts` — 3 specs covering read-only rendering (polyline, directed marker, non-Point endpoint skip).
- `frontend/tests/e2e/edges-create-edit.spec.ts` — 4 specs covering create / edit / delete / Esc-cancel.
- `frontend/tests/e2e/edges-epic.spec.ts` — 2 specs locking in the full round-trip including detail-panel integration.
- `frontend/tests/e2e/coordinate-systems-crud.spec.ts` — 3 new tests in the parameterized suite (edge create + delete on wgs84 / pixel / blank).

## Work breakdown

- [x] PR1 #148: schema + CRUD (#256) — 67 backend assertions
- [x] PR2 #197: visibility filter (#257)
- [x] PR3 #198: frontend rendering (#258) — 3 E2E
- [x] PR4 #199: create / edit UX (#259) — 4 E2E
- [x] PR5 #200: detail panel + epic E2E (#260) — 5 E2E (2 epic + 3 cross-coord)
- [x] Per-PR CI sweep: all 5 PRs ✅ green on lint / security / compile / integration
- [x] weekend.yml on wave (https://github.com/dcltdw/annotated-maps/actions/runs/25686353900) — passed in ~15 min, extended tier + no-cache rebuild + full E2E
- [x] Cleanup: 5 issues closed, project board moved to Done, local feature branches deleted

## Test plan

- [x] Backend fast tier passed (test_29_edges 67/67 + sibling sweep)
- [x] Frontend E2E passed (12 net-new edge tests + sibling sweep across 10 specs)
- [x] Per-PR CI all green on the wave branch
- [x] **weekend.yml against wave-4-edges: ✅ green** — integration verification on the fully-integrated wave with extended backend tier (5-min soak) and no-cache Docker rebuild
- [x] CI on this final merge PR

## Operational impact

- **Backend rebuild + restart** required on merge (controller + migration).
- **New migration**: `003_edges.sql`. Runs automatically on fresh container init; existing local-dev databases need `docker compose exec -T mysql mysql -uroot -prootpassword annotated_maps < database/migrations/003_edges.sql` once.
- **Frontend reload** (Vite HMR picks up automatically in dev).

## Stats

18 files changed, **+2,783 / -6 lines**.

## Wave context

Tracker: #255. After this merges, Wave 4 is complete. Next up per the saved memory: between Wave 5 (Location/draw polish) and Wave 6 (public-hosting readiness), consider the inter-wave block (#3 + #196 required; #22 + #149 optional).