### PR TITLE
docs: scaffold docs/agent-spec/ structure (#262)

### DIFF
--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -26,8 +26,9 @@ agent instructions:
 3. **Add every new issue to the project's default board** (whichever board
    represents "what we're working on now").
 4. **Every PR body must include the following sections** (each detailed
-   below): `Files changed` (§4a, alphabetical), docs/tests updates verified
-   (§4b, with §4b-1 cross-cutting docs and §4b-2 E2E for new CRUD pages),
+   below): `Files changed` (§4a, alphabetical), docs/tests/specs updates
+   verified (§4b, with §4b-1 cross-cutting docs, §4b-2 E2E for new CRUD
+   pages, §4b-3 agent-spec files in `docs/agent-spec/`),
    `Test expectations` table only when failures are expected (§4c),
    `Work breakdown` mirroring the agent's task-tracker (§4d), and
    `Operational impact` (§4e, restart / rebuild / migration needs, or
@@ -435,6 +436,21 @@ schema (Zod `.parse()` on the modal save response) had no E2E coverage.
 When a PR adds a new page that does CRUD on an entity through the UI,
 ship a Playwright spec covering at minimum: create → list → edit → delete
 through the UI, asserting the response renders without error.
+
+**§4b-3. Agent-spec files alongside code.** When a PR adds, removes, or
+changes behaviour covered by an `F-NNN` or `NF-NNN` spec in
+[docs/agent-spec/](../docs/agent-spec/), the SAME PR must update that
+spec. For new capabilities, the PR also lands the new `F-NNN`/`NF-NNN`
+file (status transitions to `in-progress` when the PR opens, `shipped`
+when it merges, with `pr:` populated and `last_updated` bumped). The
+agent-spec format exists so that an AI agent can reliably grep a fixed
+schema for behaviours; that guarantee dies if specs drift from code,
+which is why the same agent that changes the code is responsible for
+updating the spec in the same diff. See
+[docs/agent-spec/schema.md](../docs/agent-spec/schema.md) for the
+contract. Note: the project board is authoritative for live status; the
+spec's frontmatter `status` is "current as of `last_updated`" and is
+expected to briefly lag mid-PR — both converge when the PR merges.
 
 **Verify lint/typecheck per-file on the touched files**, not just by
 running the project-wide command. ESLint's daemon and watcher caches can

--- a/docs/agent-spec/00-overview.md
+++ b/docs/agent-spec/00-overview.md
@@ -1,0 +1,96 @@
+# System overview
+
+Read at the start of any agent session that touches this repo. The narrative companion at [docs/REQUIREMENTS.md](../REQUIREMENTS.md) goes deeper on capabilities; this doc is the **orientation layer** — what the system is, how the code is laid out, and the mental model an agent needs to make sense of any specific spec.
+
+## What this is
+
+**Annotated Maps** is a multi-tenant collaborative map annotation platform. Users create maps, mark places as a tree of *nodes*, attach *notes* and media to those nodes, draw *edges* between nodes, group nodes into narrative *plots* that can span multiple maps, and tag content with *visibility groups* that gate who can see what.
+
+The platform supports both standalone personal use (each user gets a "personal" tenant) and organizational deployments with departmental SSO.
+
+## Top-level architecture
+
+```
+┌──────────────────┐         ┌──────────────────┐         ┌──────────────────┐
+│  React + Vite    │  HTTPS  │   Drogon C++     │   SQL   │     MySQL        │
+│  + react-leaflet │ ──────► │   (REST API)     │ ──────► │   (with FTS)     │
+│  + Zod + zustand │  + JWT  │   + JwtFilter    │         │                  │
+└──────────────────┘         │   + TenantFilter │         └──────────────────┘
+                             │   + RateLimit    │
+                             └──────────────────┘
+```
+
+- **Backend**: Drogon C++ HTTP framework, JWT-authenticated REST API, MySQL persistence, recursive CTEs for tree + visibility resolution.
+- **Frontend**: React + Vite + react-leaflet for the map UI, Zod at the API boundary for typed parsing, zustand stores for client state.
+- **Tests**: backend integration tests (Python via `backend/tests/run-tests.py`), frontend E2E via Playwright (`frontend/tests/e2e/`), CI matrix at `pr-tests.yml` / `nightly.yml` / `weekend.yml`.
+
+## Repo layout
+
+| Path | What lives here |
+|---|---|
+| `backend/src/controllers/` | Drogon controllers (one per resource: `MapController`, `NodeController`, `EdgeController`, `NoteController`, `PlotController`, `TenantController`, `AuthController`, `VisibilityGroupController`, `MediaController`, …) |
+| `backend/src/filters/` | `JwtFilter`, `TenantFilter`, `RateLimitFilter` — request-time auth/scope/limit checks |
+| `backend/src/models/` | Drogon ORM models matching the schema |
+| `backend/tests/` | Integration tests in Python; `run-tests.py` is the orchestrator; tests numbered `test_NN_<area>.py` |
+| `database/migrations/` | SQL migrations: `001_schema.sql`, `002_<…>.sql`, `003_edges.sql`, … |
+| `frontend/src/components/` | React components grouped by area: `Map/`, `Tree/`, `Detail/`, `Auth/`, `Modal/` |
+| `frontend/src/services/` | API service layer — one file per resource; Zod parsing happens here |
+| `frontend/src/api/schemas.ts` | Zod schemas for API responses (the typed boundary) |
+| `frontend/src/store/` | zustand stores (`authStore`, `mapsStore`, etc.) |
+| `frontend/src/hooks/` | Custom hooks (`useMap`, `useAuth`, etc.) |
+| `frontend/tests/e2e/` | Playwright specs; helpers at `helpers.ts` |
+| `docs/` | Conventions, requirements, security audits, setup guides |
+| `docs/agent-spec/` | This directory — machine-greppable specs (you are here) |
+| `.github/workflows/` | CI definitions: `pr-tests.yml` (every PR), `nightly.yml`, `weekend.yml` (heavier soak) |
+
+## Mental model — the domain primitives
+
+The relationships between core entities, in dependency order:
+
+1. **`users`** — accounts. Auth via password (bcrypt) or SSO.
+2. **`tenants`** — organizations (or "personal" tenants, one per user). Every other entity is scoped to a tenant.
+3. **`tenant_memberships`** — `(user, tenant, role)` where role ∈ `viewer | editor | admin`. Drives write authorization.
+4. **`maps`** — owned by a user, scoped to a tenant. Each has a `coordinate_system` discriminated on `type` ∈ `wgs84 | pixel | blank`.
+5. **`map_permissions`** — per-map sharing, separate from tenant role. `(map, user_or_null, level)` where `user_id IS NULL` means "public" and `level` ∈ `view | comment | edit | moderate | admin`. The owner has implicit admin.
+6. **`nodes`** — places on a map. Tree structure via `parent_id`. Optional GeoJSON geometry interpreted per the map's coord system. Cycles rejected on move; depth capped (16).
+7. **`node_edges`** — connections between two nodes on the same map. Directed flag; visibility derived from endpoint visibility (see NF-permissions-and-visibility once written).
+8. **`notes`** — attached to nodes. Title + rich text + pinned flag + per-note color. Searchable via FTS.
+9. **`note_media`** — uploaded files attached to notes.
+10. **`plots`** — narrative groupings that can span multiple maps. `plot_nodes` is the membership table.
+11. **`visibility_groups`** + **`node_visibility_tags`** — tagging system gating who can see which nodes. Recursive CTE resolves effective visibility through the tree.
+12. **`audit_log`** — append-only log of sensitive writes.
+
+The most complex semantic in the system is **visibility**:
+
+- Nodes can be tagged with one or more visibility groups.
+- A node inherits visibility from its parent unless `visibility_override = TRUE`.
+- A recursive CTE (`VISIBILITY_RESOLVE_CTE`) walks the tree to compute the effective set of visibility groups for each node.
+- A request can see a node iff: the caller is the map owner with owner-xray enabled, OR the caller is in at least one of the node's effective visibility groups, OR the node has no effective visibility tags (untagged is admin-only by current convention).
+- Edges are visible iff **both** endpoints are visible — there are no per-edge tags.
+
+When this is captured as a spec, it will be `NF-permissions-and-visibility` (forthcoming).
+
+## Coordinate systems
+
+The map's `coordinate_system` is a tagged union. Three renderers:
+
+- **`wgs84`** — real-world geo coords. Leaflet tile layer. `center {lat, lng}` + `zoom`.
+- **`pixel`** — an uploaded image as the map plane. `image_url`, `width`, `height`, `viewport {x, y, zoom}`. Node geometry is in pixel coords.
+- **`blank`** — an unbounded blank canvas. `extent {x, y}`. Node geometry is in canvas units.
+
+The coord system is **fixed at map creation**. The renderer is dispatched at view time from `coordinate_system.type`. See `frontend/src/components/Map/` for the per-renderer code.
+
+## Where to look for…
+
+- **The endpoint that handles X** — `backend/src/controllers/<X>Controller.cpp` is exhaustive.
+- **The Zod schema for an API response** — `frontend/src/api/schemas.ts`.
+- **The visibility-resolution SQL** — search for `VISIBILITY_RESOLVE_CTE` (it's a shared constant across controllers).
+- **Test fixtures** — `backend/tests/helpers.py` (registration, map creation, etc.); `frontend/tests/e2e/helpers.ts` (browser-side equivalents).
+- **CI behaviour** — `.github/workflows/pr-tests.yml` is what every PR runs against.
+
+## What's NOT in scope of this overview
+
+- The reasoning behind specific architectural decisions — see `decisions/` for ADRs.
+- Detailed per-feature behaviour — see the relevant `F-NNN` or `NF-NNN` spec.
+- Conventions for how PRs / tickets / branches work — see [docs/AI-COLLABORATION-CONVENTIONS.md](../AI-COLLABORATION-CONVENTIONS.md).
+- The deployment / hosting story — currently local-dev only; Wave 7 (#235-#248) addresses public hosting.

--- a/docs/agent-spec/F-001-click-on-map-location-placement.md
+++ b/docs/agent-spec/F-001-click-on-map-location-placement.md
@@ -1,0 +1,68 @@
+---
+id: F-001
+title: Click-on-map location placement
+type: functional
+status: proposed
+issue: 153
+pr: null
+depends_on: []
+owner: dcltdw
+last_updated: 2026-05-11
+---
+
+## Summary
+
+Add a "place a location here" gesture on the map view so users can create a node by clicking the desired spot, instead of typing coordinates into the existing create-node modal. A toolbar button toggles "placement mode" on `MapView`; while in mode the cursor becomes a crosshair and the next map click captures the spot, opens the existing `CreateNodeModal` (from #150) with the coordinates pre-filled, and lets the user complete the create flow as normal. The same gesture works on all three coordinate systems (wgs84, pixel, blank) — the modal already adapts its coordinate fields per system. This ticket establishes the toolbar overlay + placement-mode state-machine pattern that future geometry gestures (line, polygon) will plug into.
+
+## Inputs
+
+- Click on the map-view "Add location here" toolbar button.
+- Subsequent click on the Leaflet map surface (captured as `event.latlng` for wgs84, or pixel coords computed from `event.containerPoint` for non-wgs84 maps).
+- Escape key, right-click on the map, or a second click on the toolbar button (all three cancel placement mode).
+- The active map's `coordinateSystem.type` (determines whether captured coords go to lat/lng or x/y fields).
+
+## Behaviour
+
+1. The toolbar button "Add location here" is visible on `MapView` at all zoom levels and on all three coordinate-system renderers.
+2. Clicking the toolbar button enters placement mode: the map cursor becomes a crosshair via a CSS class on the map container.
+3. While in placement mode, the next single click on the map captures the click coordinates and opens `CreateNodeModal` with those coordinates pre-filled into the relevant fields.
+4. After the modal opens, placement mode exits automatically — a second click on the map without re-entering mode does nothing special.
+5. Pressing Escape, right-clicking the map, or clicking the toolbar button again while in placement mode exits the mode without opening the modal.
+6. Submitting the modal creates the node at the captured coordinates and renders it on the map at that spot.
+7. Cancelling the modal does not delete a partially-created node (nothing is created until submit).
+8. Placement-mode state is local to `MapView` and does not affect other components; the cross-component command/bump pattern is not used here.
+
+## Outputs
+
+- Visible toolbar button on the map view.
+- A `cursor: crosshair` class on the map container while in placement mode.
+- The existing `CreateNodeModal` opened with pre-filled coordinate fields.
+- On submit: a new row in `nodes` with the captured geometry; a re-rendered marker on the map.
+
+## Edge cases
+
+- **Click on a marker or polyline instead of empty map**: the click still opens the create modal at the marker's coordinates (no special "you clicked a marker" handling); follow-up issue if this proves confusing in practice.
+- **Click outside the map viewport**: Leaflet doesn't fire a map click for clicks outside the container, so no action.
+- **Zoom or pan during placement mode**: zoom/pan continue to work; placement mode stays active until cancel or click.
+- **Network failure on modal submit**: the existing modal error handling applies (error banner inside the modal); placement mode has already exited, so no recovery is needed there.
+- **Coordinate precision on pixel maps**: `event.containerPoint` returns float pixels; the captured coords are passed through to the modal without rounding.
+
+## Out of scope
+
+- **Line and polygon drawing** (click-click-click for polylines, double-click to finish). This ticket lays the toolbar + mode-state foundation that future geometry types will reuse.
+- **Editing existing geometry** (drag a marker to a new location, reshape a polygon). Separate ticket.
+- **Multi-point capture**: this ticket is single-click → single Point geometry.
+- **Touch / mobile gestures**: out of scope for v1; the Leaflet click event fires on touch, but no touch-specific UX (long-press, two-finger gestures) is added.
+
+## Verification
+
+- `frontend/tests/e2e/<new-spec>.spec.ts`:
+  - Open a fresh wgs84 map → click toolbar → click map → verify modal opens with lat/lng pre-filled → fill name → submit → verify the node is created at that spot.
+  - Same flow on a blank map (validates pixel-coord routing on a non-wgs84 system).
+  - Esc-cancel: enter placement mode → press Esc → confirm mode exited (clicking map does NOT open modal).
+- Manual: pixel-map placement (if the pixel-map test plumbing is in good shape; otherwise smoke-test manually and note in the PR).
+- No regression in existing E2E specs (`frontend/tests/e2e/coordinate-systems-crud.spec.ts`, `frontend/tests/e2e/edges-epic.spec.ts`).
+
+## Open questions
+
+_None._

--- a/docs/agent-spec/NF-001-error-shape.md
+++ b/docs/agent-spec/NF-001-error-shape.md
@@ -1,0 +1,62 @@
+---
+id: NF-001
+title: Backend error response shape
+type: non-functional
+status: shipped
+issue: 52
+pr: 191
+depends_on: []
+owner: dcltdw
+last_updated: 2026-05-11
+---
+
+## Summary
+
+Every backend error response uses the same JSON envelope: `{"error": "<code>", "message": "<text>"}`. The `error` field is a short stable machine-readable code (e.g. `bad_request`, `not_found`, `unauthorized`, `forbidden`, `conflict`, `limit_exceeded`, `db_error`); the `message` is a human-readable string. The frontend's `extractApiError(err, fallback)` helper depends on this shape — controllers that drift to a different structure (`{"detail": "…"}`, raw strings, etc.) silently show generic fallbacks. Shared `errorJson(code, msg)` and `errorResponse(status, code, msg)` helpers in `backend/src/ErrorResponse.h` are the only sanctioned way to build error responses; new controllers must include the header and use them. This is a retroactive spec capturing the shape that's been the de-facto standard since the rebuild and was explicitly locked in by #52 / PR #191 (the `assert_error_shape` test helper).
+
+## Inputs
+
+- Any error path in any backend controller.
+- The `ErrorResponse.h` helpers: `errorJson(code, msg)` (returns a `Json::Value`) and `errorResponse(status, code, msg)` (returns a `drogon::HttpResponsePtr` with the status code set).
+
+## Properties
+
+1. Every 4xx and 5xx response body is JSON with exactly two top-level fields: `error` (string) and `message` (string).
+2. The HTTP status code is set independently of the `error` code — both must be correct (e.g., `bad_request` with 400, `not_found` with 404, `unauthorized` with 401).
+3. The `error` code value is short, snake_case, machine-stable, and may be matched on by the frontend (e.g., `email_taken`, `username_taken` drive specific form-field error rendering).
+4. The `message` is human-readable and may change wording without notice; the frontend treats it as fallback display text, not a stable identifier.
+5. Controllers must include `backend/src/ErrorResponse.h` and use `errorJson()` / `errorResponse()`; ad-hoc `Json::Value` construction for error bodies is forbidden by review.
+6. Tests in `backend/tests/test_27_error_shape.py` exercise the shape across all known 4xx paths (`bad_request`, `unauthorized`, `forbidden`, `not_found`, `conflict`) on representative controllers.
+7. The `assert_error_shape(test_name, body, expected_code=None)` helper in `backend/tests/helpers.py` is used by error-path assertions in all backend integration tests touching error responses.
+
+## Outputs
+
+- A JSON body with `error` + `message` on every 4xx/5xx response.
+- A predictable surface the frontend's `extractApiError()` in `frontend/src/utils/errors.ts` can rely on without per-endpoint fallback logic.
+- Test failures (via `assert_error_shape`) when a controller drifts from the shape.
+
+## Edge cases
+
+- **5xx server errors**: same shape applies. `db_error` is the canonical code for unexpected DB failures.
+- **JWT validation failure** (handled by `JwtFilter` before the controller runs): the filter still emits the canonical shape with `error: "unauthorized"`.
+- **Rate-limit rejection** (handled by `RateLimitFilter`): emits the canonical shape with `error: "limit_exceeded"`.
+- **Drogon framework errors before any filter runs** (e.g., malformed JSON body): Drogon's default error rendering may produce a non-canonical body. The current convention is to trap these at the controller layer where possible; truly framework-level errors are accepted as out-of-band (the frontend's fallback path covers them).
+- **CORS preflight / OPTIONS responses**: no body; CORS headers only.
+- **Empty `message`**: forbidden by review; the helper signature requires both arguments.
+
+## Out of scope
+
+- A separate `ERROR-CODES.md` documenting every code: the codes are visible in controller source and the frontend only branches on specific ones (`email_taken`, `username_taken`). Adding a doc creates another source of drift.
+- Internationalisation of `message`: messages are English-only by current design.
+- Trace IDs or structured error metadata beyond `error` + `message`: deferred until a concrete need (e.g., audit/observability follow-up).
+- Replacing Drogon's default framework-level error responses: too invasive for the marginal benefit.
+
+## Verification
+
+- `backend/tests/test_27_error_shape.py` — walks through all known 4xx paths on representative controllers (auth, maps, cross-tenant, missing-map, duplicate-register, bogus-token). Asserts shape + expected code on each.
+- `backend/tests/helpers.py::assert_error_shape` — used inline by other test files (`test_01_auth.py`, `test_03_maps.py`, `test_05_tenants.py`, etc.) at error-path assertion points.
+- Manual: `curl -i -X POST http://localhost:8080/api/v1/maps -H 'Content-Type: application/json' -d '{}'` returns a 4xx with `{"error": "…", "message": "…"}`.
+
+## Open questions
+
+_None._

--- a/docs/agent-spec/README.md
+++ b/docs/agent-spec/README.md
@@ -1,0 +1,56 @@
+# Agent spec
+
+Structured specifications, designed to be consumed by both humans and AI agents working on this repository. Files in this directory follow the contract in [schema.md](schema.md).
+
+## Why this exists
+
+Narrative docs ([REQUIREMENTS.md](../REQUIREMENTS.md)) are great for humans but bad for automation: an agent cannot reliably tell "the relevant section for the click-on-map placement gesture" from a long prose document. The agent-spec format trades narrative flexibility for machine-readable structure:
+
+- Each file is one requirement.
+- Each file has YAML frontmatter declaring its ID, type, scope, status, and linked issue/PR.
+- Each file has the same H2 sections in the same order, so an agent can grep for any of them.
+
+Two use cases drove the format:
+
+1. **Onboarding new agents** — a fresh agent session can grep a fixed schema for the exact requirement it cares about, instead of reading a long narrative doc end-to-end.
+2. **Disaster recovery** — the repo + git mirrors are the real DR. This catalog is a complementary, durable record of behaviours, edge cases, and rationale that an agent + human team could use to rebuild.
+
+## File layout
+
+- `README.md` — this file.
+- `schema.md` — the schema contract every spec follows.
+- `00-overview.md` — system orientation (stack, repo layout, mental model). Not a numbered spec; the only doc here you read end-to-end at session start.
+- `F-NNN-<slug>.md` — functional requirement (user-facing behaviour or system capability).
+- `NF-NNN-<slug>.md` — non-functional requirement (cross-cutting properties — visibility, error shape, audit, rate limits, etc.).
+- `decisions/` — ADR-style decision records. One file per decision. Frozen-in-time history; the "WHY" behind the system.
+
+`NNN` is a three-digit zero-padded sequence number scoped to the type (functional or non-functional). Slug is kebab-case, ≤ 6 words. See [schema.md](schema.md) for the full contract.
+
+## When to read what
+
+| You are… | Start here |
+|---|---|
+| A new agent picking up a task | `00-overview.md`, then grep `F-NNN`/`NF-NNN` for your area |
+| Doing disaster recovery | Read in order: `00-overview.md` → all `NF-NNN` (cross-cutting first) → `F-NNN` by area → `decisions/` for rationale |
+| Filing a new feature ticket | Read `schema.md` and pick the next sequential `F-NNN` |
+| Auditing a decision's rationale | `decisions/` |
+
+The narrative companion at [docs/REQUIREMENTS.md](../REQUIREMENTS.md) remains the human-readable capability list. It cross-references this directory.
+
+## Workflow
+
+1. **New requirement surfaces** — file an issue first; add it to the "Focus on next" project board per [docs/AI-COLLABORATION-CONVENTIONS.md](../AI-COLLABORATION-CONVENTIONS.md) §3.
+2. **Write the spec** — create `F-NNN-<slug>.md` or `NF-NNN-<slug>.md` in this directory with `status: proposed` and the issue number in frontmatter. The spec can land in its own PR (for big features where the spec discussion is itself the work) or in the implementing PR (small features).
+3. **Implementation PR** — when work starts, transition `status: proposed` → `in-progress`. When the PR merges, transition to `shipped` and set `pr:` to the PR number. Update `last_updated`.
+4. **Spec drift** — if code changes after the spec is shipped, the same PR that changes the code must update the spec (per §4b-3, the spec-alongside-code rule).
+
+Status authority: the project board column is the live state. Spec frontmatter `status` is "current as of `last_updated`" and may briefly lag. Don't dual-write transitions atomically; let the board drive and let the spec catch up at `last_updated` time. See [schema.md](schema.md#status-vs-board) for full discussion.
+
+## Current specs
+
+| ID | Title | Status |
+|---|---|---|
+| F-001 | Click-on-map location placement | proposed |
+| NF-001 | Backend error response shape | shipped |
+
+(Updated as specs land; backfill of historical capabilities is tracked separately — see the issue that introduced this directory.)

--- a/docs/agent-spec/decisions/README.md
+++ b/docs/agent-spec/decisions/README.md
@@ -1,0 +1,49 @@
+# Decision records
+
+ADR-style ("Architecture Decision Record") one-paragraph-per-decision files. Captures the **WHY** behind major architectural choices so future agents and humans don't re-litigate settled questions.
+
+These are **frozen-in-time** by intent: a decision record is the snapshot of *why a choice was made at a given moment*. If the decision is later revisited and changed, file a new record (`NNN-revisit-…`) that supersedes the prior one. Don't edit the original except to add a `Superseded by:` line at the top.
+
+## Filename
+
+`NNN-short-slug.md` where `NNN` is zero-padded, three digits, monotonically increasing. Slug is kebab-case, ≤ 6 words.
+
+## Frontmatter
+
+```yaml
+---
+id: 001
+title: Edges have no per-edge visibility tags
+date: 2026-05-08
+status: accepted          # one of: accepted | superseded
+supersedes: null          # NNN of a prior decision this replaces, or null
+superseded_by: null       # NNN of a later decision that replaces this, or null
+---
+```
+
+## Body sections
+
+Every decision record has these H2 sections in this order:
+
+1. `## Context` — what prompted the decision; what was the unsettled question.
+2. `## Decision` — the chosen path, stated affirmatively.
+3. `## Alternatives considered` — bullet list of options rejected, with one-line reasons.
+4. `## Consequences` — what this commits us to; what becomes harder; what becomes easier.
+
+Keep each section short. A decision record is not a design doc — it is a pointer to the design's load-bearing choice, recorded so the choice doesn't have to be made again.
+
+## Cross-linking
+
+- From a spec (`F-NNN` or `NF-NNN`): link to the relevant decision when behaviour depends on it.
+- From a decision: link to the spec it constrains.
+
+## Candidates for early backfill
+
+(Filed as a separate ticket — not part of the scaffold PR. Listed here so an agent can prioritise.)
+
+- The nodes-rebuild (Phase 2, branch `nodes-rebuild`): why we replaced `annotations` + `note_groups` with the `nodes` + `node_visibility_tags` tree.
+- Edges have no per-edge visibility tags (visibility derived from endpoints): see commentary in #148 / #197.
+- Coordinate systems as a fixed-at-creation tagged union (vs. mutable / multi-CRS).
+- Recursive CTE for visibility resolution (vs. denormalized closure table).
+- Zod at the frontend API boundary (vs. trusting backend types).
+- Drogon C++ for the backend (vs. Go / Rust / Node).

--- a/docs/agent-spec/schema.md
+++ b/docs/agent-spec/schema.md
@@ -1,0 +1,152 @@
+# Agent-spec file schema
+
+Every file in `docs/agent-spec/` (other than `README.md`, `00-overview.md`, this file, and the `decisions/` subdirectory) is one requirement and conforms to the contract below. The contract is enforced by **review**, not by tooling — the format exists so an AI agent can grep predictable section headers, not so a validator can fail a CI job.
+
+## Filename
+
+- Functional requirement: `F-NNN-short-slug.md` (e.g. `F-003-edge-create-ux.md`).
+- Non-functional requirement: `NF-NNN-short-slug.md` (e.g. `NF-005-permission-model.md`).
+- `NNN` is zero-padded, three digits, monotonically increasing per type.
+- Slug is kebab-case, ≤ 6 words, no trailing punctuation.
+
+## Frontmatter
+
+YAML at the top of every file:
+
+```yaml
+---
+id: F-003                       # matches filename prefix
+title: Edge create + edit UX
+type: functional                # one of: functional | non-functional
+status: proposed                # one of: proposed | in-progress | shipped | deferred
+issue: 199                      # tracking GitHub issue number
+pr: null                        # the implementing PR number (set when work lands)
+depends_on: [F-001, NF-002]     # other spec IDs; empty list if none
+owner: dcltdw
+last_updated: 2026-05-11
+---
+```
+
+Required keys: `id`, `title`, `type`, `status`, `issue`, `owner`, `last_updated`. Optional: `pr` (null until merged), `depends_on` (empty list if none).
+
+### Status transitions
+
+- `proposed` → `in-progress`: the implementing PR is open.
+- `in-progress` → `shipped`: the implementing PR is merged. Set `pr:` to the merged PR number.
+- `proposed` → `deferred`: rolled to a later issue or dropped. Retain the file for history.
+
+### Status vs. board
+
+The "Focus on next" project board is **authoritative** for live state. Spec frontmatter `status` is a point-in-time snapshot "current as of `last_updated`". The two may briefly disagree:
+
+- A PR opens at 10:00 → board moves Todo → In Progress immediately, per §2. Spec frontmatter still says `proposed` until the PR's diff touches the spec to update both `status` and `last_updated`.
+- A PR merges at 14:00 → board moves In Progress → Done immediately. Spec frontmatter typically transitions in the **same** PR (since the PR itself sets `status: shipped` and `pr: NNN`).
+
+Don't try to keep the two in lockstep on intermediate state. **The board is the source of truth for status; the spec is the source of truth for behaviour.**
+
+## Body sections
+
+Every spec body has the following H2 sections, in this order, with these exact titles:
+
+1. `## Summary` — one-paragraph plain-language description.
+2. `## Inputs` — bullet list of inputs to the system component (data, configs, env vars, upstream feeds, user actions).
+3. `## Behaviour` — numbered list of observable behaviours. Each item is a single sentence.
+4. `## Outputs` — bullet list of outputs (UI surfaces, log lines, API responses, downstream signals).
+5. `## Edge cases` — bullet list of named edge cases, each with a one-line handling rule.
+6. `## Out of scope` — explicit non-goals (helps future readers understand why the spec is small).
+7. `## Verification` — how this is verified: which tests, which manual smoke check. Cross-link to test files.
+8. `## Open questions` — bullet list, or `_None._`.
+
+A **non-functional** spec replaces `## Behaviour` with `## Properties` (the cross-cutting invariants the system must maintain) and otherwise follows the same shape.
+
+## Granularity
+
+**One spec per coherent user-facing capability**, not per controller method, not per source file.
+
+A worked example: the Edges epic (issue #148) shipped as **5 sub-tickets** (#148 backend CRUD, #197 visibility filter, #198 frontend render, #199 create/edit UX, #200 detail-panel section). Each is one coherent capability from the user's perspective and would be one F-NNN spec:
+
+- F-NNN edge-crud-backend (the API)
+- F-NNN edge-visibility-filter (a non-functional property of edge listings — so actually NF-NNN)
+- F-NNN edge-render-layer (the map visualization)
+- F-NNN edge-create-edit-ux (the toolbar gesture + modal)
+- F-NNN edge-detail-panel-section (the per-node Edges list)
+
+**Don't** create one spec per controller method (`F-NNN edge-create`, `F-NNN edge-update`, `F-NNN edge-delete`); CRUD on a single resource is one capability.
+
+**Do** split when the user-facing surface is genuinely different — visibility filtering is a non-functional concern that applies to many endpoints; modal UX is a frontend capability distinct from the backend it talks to.
+
+## Cross-linking
+
+- Cite other specs as `[F-NNN](./F-NNN-short-slug.md)` or `[NF-NNN](./NF-NNN-short-slug.md)`.
+- Cite the implementing issue as `#NNN` (GitHub auto-links).
+- Cite source-of-truth conventions as `§N` against [docs/AI-COLLABORATION-CONVENTIONS.md](../AI-COLLABORATION-CONVENTIONS.md).
+- Cite test files by repo-relative path, e.g. `backend/tests/test_29_edges.py::test_create_edge`.
+
+## Retroactive specs
+
+When backfilling a spec for already-shipped work (NF-001 below is an example), set:
+
+- `status: shipped`
+- `pr:` the merged PR number that delivered the behaviour
+- `last_updated`: the backfill date, not the original ship date
+
+Document in the spec body that this is a retroactive capture — the goal is to lock in current behaviour, not to litigate the original implementation.
+
+## Lifecycle
+
+- A spec for **new** work lands in the implementing PR, or in a preceding PR if the spec discussion is itself the load-bearing review (e.g., for a contentious or cross-cutting design).
+- A spec is updated when the corresponding code changes; if the spec falls out of sync, that is a bug worth filing.
+- The doc-as-master convention (§8 of [AI-COLLABORATION-CONVENTIONS.md](../AI-COLLABORATION-CONVENTIONS.md)) applies: this schema is the master; any memory or other replicas point back here.
+- §4b-3 binds: the PR that changes a behaviour described in a spec must update that spec in the same diff.
+
+## Example skeleton
+
+```markdown
+---
+id: F-NNN
+title: <short title>
+type: functional
+status: proposed
+issue: <issue number>
+pr: null
+depends_on: []
+owner: dcltdw
+last_updated: 2026-05-11
+---
+
+## Summary
+
+<one paragraph>
+
+## Inputs
+
+- <input 1>
+- <input 2>
+
+## Behaviour
+
+1. <behaviour 1>
+2. <behaviour 2>
+
+## Outputs
+
+- <output 1>
+
+## Edge cases
+
+- **<name>**: <handling>
+
+## Out of scope
+
+- <non-goal>
+
+## Verification
+
+- `backend/tests/test_<area>.py::<test_name>` covers <scenario>.
+- `frontend/tests/e2e/<spec>.spec.ts` covers <scenario>.
+- Manual: <observable check>.
+
+## Open questions
+
+_None._
+```


### PR DESCRIPTION
Closes #262.

## Summary

Adopts the [gtfs-style](https://github.com/dcltdw/gtfs-dleung/tree/main/docs/agent-spec) per-requirement spec format: one `F-NNN` (functional) or `NF-NNN` (non-functional) file per coherent capability, fixed H2 schema, YAML frontmatter with status tied to the implementing PR. Scope is **scaffold only** — directory + schema + two example specs that exercise the full lifecycle (one fresh in `proposed`, one retroactive in `shipped`). Backfilling existing capabilities is out of scope and tracked separately.

## Files changed

- `docs/AI-COLLABORATION-CONVENTIONS.md` — added §4b-3 (spec-alongside-code rule); updated the quick-reference rule 4 to mention §4b-3.
- `docs/agent-spec/00-overview.md` — system orientation (stack, repo layout, mental model, where-to-look-for table). Read at agent session start.
- `docs/agent-spec/F-001-click-on-map-location-placement.md` — `proposed` example for Wave 5 #153. Exercises the full lifecycle when #153's implementing PR transitions it to `in-progress` → `shipped`.
- `docs/agent-spec/NF-001-error-shape.md` — `shipped` retroactive example for #52 (PR #191). Validates the non-functional `## Properties` section.
- `docs/agent-spec/README.md` — purpose, file layout, when-to-read-what, workflow, spec index.
- `docs/agent-spec/decisions/README.md` — ADR-style format for future decision records. Includes a candidates-for-backfill list.
- `docs/agent-spec/schema.md` — full contract (filename, frontmatter, H2 sections, status transitions, board-vs-spec authority, granularity rule with the edges-epic-as-5-specs worked example, retroactive case, lifecycle, example skeleton).

## Docs / tests / specs verified

- **Docs**: `docs/AI-COLLABORATION-CONVENTIONS.md` extended with §4b-3 + quick-reference update. The agent-spec scaffold *is* the doc deliverable for this PR.
- **Tests**: No code changed; no tests to update. The two example specs themselves cite existing tests (F-001 references the Playwright spec that #153's implementation will add; NF-001 references the shipped `backend/tests/test_27_error_shape.py`).
- **Specs**: This PR establishes the spec format. No prior spec to update.

## Work breakdown

- [x] Resolve open questions on #262 (fresh F-NNN, board-authoritative, granularity rule)
- [x] Read §4b context in `AI-COLLABORATION-CONVENTIONS.md`
- [x] Create feature branch
- [x] Write `README.md` (index + workflow)
- [x] Write `schema.md` (port from gtfs with annotated-maps adjustments)
- [x] Write `00-overview.md` (system orientation)
- [x] Write `decisions/README.md` (ADR format + backfill candidates)
- [x] Write `F-001` (proposed; for #153)
- [x] Write `NF-001` (shipped; retroactive for #52/PR#191)
- [x] Add §4b-3 to `AI-COLLABORATION-CONVENTIONS.md`
- [x] Add memory replica per §8 (doc-as-master)
- [x] Open this PR

## Operational impact

None. Pure docs/conventions PR. No services restart, no migration, no dependency change.

## Resolved decisions (mirrored from #262)

- **Example F-NNN**: Fresh — `F-001-click-on-map-location-placement.md` for Wave 5's #153, `status: proposed`. The #153 implementing PR will transition it to `in-progress` → `shipped`.
- **Authority**: Board is authoritative for live state. Spec frontmatter `status` is "current as of `last_updated`".
- **Granularity**: One F-NNN per coherent user-facing capability, not per controller method. Documented in `schema.md` with the edges-epic-as-5-specs example.

## Follow-up tickets (not opened in this PR)

- Backfill ADR for the nodes-rebuild + the edges-no-tags decision.
- Backfill the highest-value `NF-NNN` first: permissions + visibility, coordinate systems.
- Backfill `F-NNN` for the edges epic (5 files) — most recent, easiest to write fresh.
- Backfill `F-NNN` for the remaining core CRUD epics (nodes, notes, plots, visibility groups, auth) — opportunistically.

Wave 5's three tickets (#153 / #164 / #195) will be the first consumers of the new format with native `proposed` specs filed alongside their implementation PRs.