### PR TITLE
docs: mark repo paused — work moved to annotated-maps-sp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Annotated Maps
 
+> ## Status: paused (2026-05-11)
+>
+> Active development has moved to **[annotated-maps-sp](https://github.com/dcltdw/annotated-maps-sp)**, a greenfield rebuild using the [Superpowers](https://github.com/obra/superpowers) skills framework. This repo is the reference implementation; no new features are planned here. Security fixes may still land. The pause will be re-evaluated after the trial reaches its first checkpoint. See [#264](https://github.com/dcltdw/annotated-maps/issues/264) for the full notice.
+
 A multi-tenant, collaborative map annotation platform. Users create
 maps, mark places as a tree of *nodes*, attach *notes* and media,
 group nodes and notes into narrative *plots* across maps, and control

--- a/docs/AI-COLLABORATION-CONVENTIONS.md
+++ b/docs/AI-COLLABORATION-CONVENTIONS.md
@@ -1,5 +1,7 @@
 # AI-Agent Collaboration Conventions
 
+> **Repo status (2026-05-11): paused.** Active development has moved to [annotated-maps-sp](https://github.com/dcltdw/annotated-maps-sp), a greenfield rebuild on the [Superpowers](https://github.com/obra/superpowers) framework. These conventions are **frozen** here; the `-sp` repo uses Superpowers' skills instead. Agents reading this file in `annotated-maps`: the rules below still describe how this repo was built, but **no new feature work belongs here** — direct the user to `-sp` for new requests. See [#264](https://github.com/dcltdw/annotated-maps/issues/264).
+
 Process conventions for working with an AI coding agent (e.g., Claude Code,
 Cursor, Aider) on a real software project. Distilled from the `nodes-rebuild`
 work on annotated-maps; the rules are written portably so they transfer to


### PR DESCRIPTION
Companion to #264 (the pinned sticky notice).

## Summary

Adds a paused-status banner to the two most-likely entry points for someone landing on this repo: `README.md` (for users / GitHub viewers) and `docs/AI-COLLABORATION-CONVENTIONS.md` (for AI agents reading the conventions doc). Both point at #264, which carries the full notice with re-evaluation criteria. Archiving the repo is **deferred** — the Superpowers trial is explicitly an experiment, and an archive step would add friction if the trial fails and work returns here.

## Files changed

- `README.md` — paused-status banner above the existing project description.
- `docs/AI-COLLABORATION-CONVENTIONS.md` — paused-status banner above the existing intro; explicitly tells agents reading this in `annotated-maps` that no new feature work belongs here and to direct the user to `-sp`.

## Docs / tests / specs verified

- **Docs**: this PR *is* the doc deliverable. No other docs reference the freeze status (yet — that's intentional; the two banners are the canonical notice).
- **Tests**: none — no code changed.
- **Specs**: no `F-NNN` or `NF-NNN` covers a repo-status banner; §4b-3 does not apply.

## Work breakdown

- [x] File sticky notice issue (#264, intentionally not on project board — it's a meta notice, not work)
- [x] Pin #264 via `pinIssue` GraphQL mutation
- [x] Create feature branch
- [x] README.md banner
- [x] AI-COLLABORATION-CONVENTIONS.md banner
- [x] Add memory rule (`project_repo_paused.md`) so future sessions in this repo surface the pause before starting new feature work
- [x] Open this PR

## Operational impact

None. Pure docs PR. No services restart, no migration, no dependency change.

## After merge

No further action needed. #264 stays open and pinned as the sticky notice. When the trial concludes:

- **Trial succeeds**: archive the repo, close #264.
- **Trial fails**: revert the banner edits (or open a follow-up PR), close #264, remove the memory rule.